### PR TITLE
feat(infra): add Dockerfile and k8s manifests for EKS deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.git
+.gitignore
+*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:24-alpine AS build
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM nginx:1.27-alpine
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  namespace: iz
+  labels:
+    app: frontend
+spec:
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: frontend
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+        - name: frontend
+          # placeholder — CodePipeline buildspec가 첫 빌드 시 실제 ECR URI/태그로 자동 교체
+          image: "<ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/iz-frontend:latest"
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 80
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  namespace: iz
+spec:
+  type: ClusterIP
+  selector:
+    app: frontend
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,15 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location /healthz {
+        default_type text/plain;
+        return 200 "ok\n";
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Summary
- EKS 배포를 위한 Dockerfile 추가 (multi-stage: `node:24-alpine` build → `nginx:1.27-alpine` serve)
- `nginx.conf`: SPA fallback 라우팅 + `/healthz` 헬스체크 엔드포인트
- `k8s/deployment.yaml`, `k8s/service.yaml` 추가 — mini-project-6에서 검증된 컨벤션(probe, resource limits, RollingUpdate) 그대로 따름

## 참고 (팀원 확인 필요)
- `namespace: iz`, 이미지 URI(`<ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/...`)는 **placeholder** — EKS 파이프라인 부트스트랩 시점에 실제 값으로 확정/치환됨
- Backend/AI repo는 아직 코드가 없어서 이번 PR 범위에서 제외

## Test plan
- [x] `npm ci` + `npm run build` 로컬 실행 → `dist/` 정상 생성 확인
- [x] k8s YAML 파싱 검증
- [ ] 실제 `docker build` (이 작업 환경에 Docker 데몬 없어서 미검증 — 리뷰 시 확인 부탁)
- [ ] 클러스터에 실제 배포해서 `/healthz` 응답 확인 (EKS 부트스트랩 이후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
