### PR TITLE
[Ci] Component Doc Generator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,12 @@ jobs:
       - name: Design tokens
         run: npm run check:design
 
-      # 토큰을 고치고 문서를 다시 만들지 않으면 팀이 낡은 문서를 본다
+      # 토큰·컴포넌트를 고치고 문서를 다시 만들지 않으면 팀이 낡은 문서를 본다
       - name: Design doc up to date
         run: node scripts/design-doc.mjs --check
+
+      - name: Component doc up to date
+        run: node scripts/component-doc.mjs --check
 
       - name: Lint
         run: npm run lint

--- a/.prettierignore
+++ b/.prettierignore
@@ -14,3 +14,4 @@ docs/plan/screen/wireframe
 
 # 생성물 — 포맷하면 생성기 출력과 달라져 드리프트 검사가 깨진다
 docs/dev/design-system.html
+docs/dev/components.html

--- a/docs/dev/components.html
+++ b/docs/dev/components.html
@@ -1,0 +1,320 @@
+<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>IZ-Get · 셸 · 컴포넌트</title>
+<!--
+  이 파일은 생성물이다. 직접 고치지 말고 생성기를 고친 뒤 다시 만든다.
+  값은 src/index.css, 명령은 package.json의 doc:* 스크립트를 본다.
+-->
+<style>
+  :root {
+    --color-canvas: #f4f5f7;
+    --color-surface: #ffffff;
+    --color-surface-2: #fafbfc;
+    --color-border: #e2e5ea;
+    --color-border-strong: #cfd4dc;
+    --color-fg: #181b20;
+    --color-fg-muted: #5a616b;
+    --color-fg-subtle: #686f7d;
+    --color-primary: #3a4db8;
+    --color-primary-hover: #31429e;
+    --color-primary-soft: #eef0fb;
+    --color-primary-border: #cdd4f2;
+    --color-brand-1: #31429e;
+    --color-brand-2: #232a4d;
+    --color-danger: #c0392b;
+    --color-danger-soft: #fbeceb;
+    --color-danger-border: #f0cdc9;
+    --color-warning: #96631a;
+    --color-warning-soft: #fbf3e6;
+    --color-warning-border: #e6d3a8;
+    --color-success: #1a7d52;
+    --color-success-soft: #e8f5ee;
+    --color-success-border: #b7dfc9;
+    --color-info: #2f6bb0;
+    --color-info-soft: #eaf2fa;
+    --color-info-border: #c5daf0;
+    --color-neutral-soft: #e0e3ea;
+    --color-nav: #1e2436;
+    --color-nav-active: #2a3147;
+    --color-nav-fg: #aeb4c6;
+    --color-nav-accent: #d9a441;
+    --radius-sm: 6px;
+    --radius-md: 10px;
+    --radius-lg: 14px;
+    --radius-xl: 18px;
+    --text-2xs: 11px;
+    --text-xs: 12px;
+    --text-sm: 13px;
+    --text-base: 14px;
+    --text-lg: 16px;
+    --text-xl: 20px;
+    --text-2xl: 26px;
+    --text-3xl: 32px;
+    --font-sans: -apple-system, 'Apple SD Gothic Neo', system-ui, 'Segoe UI', sans-serif;
+    --font-mono: ui-monospace, Menlo, monospace;
+    --shadow-card: 0 1px 2px rgba(20, 24, 31, 0.04), 0 4px 16px rgba(20, 24, 31, 0.09);
+    --container-page: 1320px;
+    --font: -apple-system, 'Apple SD Gothic Neo', system-ui, 'Segoe UI', sans-serif;
+    --mono: ui-monospace, Menlo, monospace;
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0 }
+  body {
+    font-family: var(--font); font-size: 14px; line-height: 1.5;
+    color: var(--color-fg); background: var(--color-canvas);
+    -webkit-font-smoothing: antialiased;
+  }
+  .wrap { max-width: 1100px; margin: 0 auto; padding: 40px 24px }
+  code { font-family: var(--mono) }
+
+  header { margin-bottom: 32px }
+  .kicker { font-size: 12px; font-weight: 600; letter-spacing: .04em; text-transform: uppercase; color: var(--color-fg-subtle) }
+  h1 { font-size: 26px; letter-spacing: -.01em; margin: 8px 0 8px }
+  header > p { color: var(--color-fg-muted); max-width: 640px }
+  .howto {
+    margin-top: 16px; padding: 12px 16px; border-radius: var(--radius-md);
+    border: 1px solid var(--color-info-border); background: var(--color-info-soft); color: var(--color-info);
+  }
+  .doc-nav { display: flex; gap: 8px; margin-top: 16px }
+  .doc-nav a {
+    font-size: 13px; font-weight: 600; text-decoration: none; padding: 6px 12px;
+    border-radius: var(--radius-md); border: 1px solid var(--color-border-strong); color: var(--color-fg-muted);
+  }
+  .doc-nav a.on { background: var(--color-primary); border-color: var(--color-primary); color: #fff }
+  .doc-nav a:not(.on):hover { border-color: var(--color-fg-subtle) }
+
+  section { margin-bottom: 48px }
+  h2 { font-size: 18px; display: flex; align-items: baseline; gap: 8px }
+  h2 .cnt { font-size: 14px; font-weight: 400; color: var(--color-fg-subtle) }
+  .cap { font-size: 12px; color: var(--color-fg-subtle); margin-top: 4px }
+  .grp { margin-bottom: 32px }
+  h3 { font-size: 14px; margin-bottom: 2px }
+
+  details { border: 1px solid var(--color-border); border-radius: var(--radius-md); background: var(--color-surface-2); margin-top: 8px }
+  summary { cursor: pointer; padding: 8px 12px; font-size: 12px; font-weight: 600; color: var(--color-fg-muted) }
+  summary .cnt { font-weight: 400; color: var(--color-fg-subtle) }
+  .qa { padding: 12px; border-top: 1px solid var(--color-border); display: grid; gap: 12px }
+  .qa .q { font-size: 14px; font-weight: 600 }
+  .qa .a { font-size: 14px; color: var(--color-fg-muted); margin-top: 4px; line-height: 1.65 }
+
+  footer { border-top: 1px solid var(--color-border); padding-top: 16px; font-size: 12px; color: var(--color-fg-subtle) }
+  :focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px }
+
+
+  .cards { display: grid; gap: 12px; grid-template-columns: 1fr 1fr }
+  @media (max-width: 640px) { .cards { grid-template-columns: 1fr } }
+  .card { display: block; padding: 16px; border: 1px solid var(--color-border); border-radius: var(--radius-lg); background: var(--color-surface); text-decoration: none; color: inherit }
+  .card:hover { border-color: var(--color-border-strong) }
+  .card .top { display: flex; align-items: baseline; justify-content: space-between; margin-top: 12px }
+  .card .nm { font-family: var(--mono); font-size: 14px; font-weight: 600 }
+  .card .uses { font-size: 12px; color: var(--color-fg-subtle) }
+  .card .desc { font-size: 14px; color: var(--color-fg-muted); margin-top: 8px }
+  .card .go { display: inline-block; margin-top: 12px; font-size: 14px; color: var(--color-primary) }
+
+  /* 셸 구조 미리보기 — 뼈대만. 실제 셸 색·타이포는 여기 값과 같지만
+     레이아웃 세부(패딩 등)까지 1:1은 아니다. "구조 미리보기"라고 캡션에 명시한다. */
+  .shell-mini { border: 1px solid var(--color-border); border-radius: var(--radius-md); overflow: hidden; background: var(--color-canvas); pointer-events: none }
+  .shell-mini-auth { display: flex; height: 120px }
+  .sm-brand { flex: 0 0 42%; background: linear-gradient(150deg, var(--color-brand-1), var(--color-brand-2)); padding: 14px; display: flex; flex-direction: column; justify-content: space-between }
+  .sm-dot { width: 14px; height: 14px; border-radius: 4px; background: rgba(255,255,255,.25); display: block }
+  .sm-form { flex: 1; background: var(--color-surface); padding: 16px; display: flex; flex-direction: column; gap: 8px }
+  .sm-line { display: block; height: 6px; border-radius: 3px; background: var(--color-border-strong) }
+  .sm-box { display: block; height: 16px; border-radius: 4px; border: 1px solid var(--color-border-strong); background: var(--color-surface) }
+  .sm-cta { display: block; height: 16px; border-radius: 4px; background: var(--color-primary); margin-top: 4px }
+
+  .shell-mini-manager { height: 120px; display: flex; flex-direction: column }
+  .sm-topbar { height: 22px; flex: 0 0 22px; background: var(--color-surface); border-bottom: 1px solid var(--color-border); display: flex; align-items: center; gap: 8px; padding: 0 10px }
+  .sm-pill { height: 10px; width: 40px; border-radius: 999px; background: var(--color-surface-2); border: 1px solid var(--color-border-strong) }
+  .sm-body { flex: 1; display: flex }
+  .sm-nav { width: 34%; background: var(--color-nav); padding: 8px; display: flex; flex-direction: column; gap: 5px }
+  .sm-navitem { display: block; height: 10px; border-radius: 3px; background: var(--color-nav-fg); opacity: .35 }
+  .sm-navitem-on { background: var(--color-nav-active); opacity: 1 }
+  .sm-content { flex: 1; background: var(--color-canvas); padding: 10px; display: flex; flex-direction: column; gap: 8px }
+  .sm-block { display: block; flex: 1; border-radius: 4px; background: var(--color-surface); border: 1px solid var(--color-border) }
+
+  /* 컴포넌트 데모 — 실제 컴포넌트와 같은 토큰만 쓴다. 값을 새로 만들면 문서가 거짓이 된다 */
+  .comp { margin-bottom: 28px }
+  .comp h3 { display: flex; align-items: baseline; gap: 8px }
+  .comp h3 .cnt { font-size: 12px; font-weight: 400; color: var(--color-fg-subtle) }
+  .row-demo { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-top: 12px }
+  .btn { display: inline-flex; align-items: center; justify-content: center; gap: 6px; border: 0; border-radius: var(--radius-md); font-weight: 600; cursor: pointer; font-family: inherit }
+  .btn-primary { background: var(--color-primary); color: #fff }
+  .btn-ghost { background: var(--color-surface); color: var(--color-fg-muted); border: 1px solid var(--color-border-strong) }
+  .btn-danger { background: var(--color-danger); color: #fff }
+  .btn-sm { padding: 6px 12px; font-size: var(--text-xs) }
+  .btn-md { padding: 8px 14px; font-size: var(--text-xs) }
+  .btn-lg { height: 44px; width: 100%; font-size: var(--text-sm) }
+  .btn:disabled { cursor: not-allowed; opacity: .6 }
+  .bdg { display: inline-flex; align-items: center; gap: 4px; border-radius: 999px; padding: 2px 8px; font-size: var(--text-2xs); font-weight: 600 }
+  .bdg-success { background: var(--color-success-soft); color: var(--color-success) }
+  .bdg-warning { background: var(--color-warning-soft); color: var(--color-warning) }
+  .bdg-danger { background: var(--color-danger-soft); color: var(--color-danger) }
+  .bdg-info { background: var(--color-info-soft); color: var(--color-info) }
+  .bdg-neutral { background: var(--color-neutral-soft); color: var(--color-fg-subtle) }
+  .cardbox { background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--radius-md); overflow: hidden; flex: 1; min-width: 200px }
+  .demo-frame { background: var(--color-canvas); border: 1px solid var(--color-border); border-radius: var(--radius-md); padding: 16px; margin-top: 12px }
+  .ph { display: flex; flex-wrap: wrap; align-items: flex-end; justify-content: space-between; gap: 12px; margin-bottom: 16px }
+  .ph-crumb { font-size: var(--text-xs); color: var(--color-fg-subtle); margin-bottom: 2px }
+  .ph-title { font-size: var(--text-xl); font-weight: 700; letter-spacing: -.01em }
+  .ph-title span { font-size: var(--text-sm); font-weight: 400; color: var(--color-fg-subtle); margin-left: 8px }
+  .tbar { display: flex; flex-wrap: wrap; gap: 8px; padding: 12px; border-bottom: 1px solid var(--color-border) }
+  .fakectl { border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); padding: 4px 10px; font-size: var(--text-xs); color: var(--color-fg-muted); background: var(--color-surface) }
+  .tbody { padding: 28px 12px; text-align: center; color: var(--color-fg-subtle); font-size: var(--text-xs) }
+  .tfoot { display: grid; grid-template-columns: repeat(3, 1fr); align-items: center; padding: 12px; border-top: 1px solid var(--color-border) }
+  .tfoot p { font-size: var(--text-xs); color: var(--color-fg-subtle) }
+  .tfoot-mid { display: flex; justify-content: center }
+
+  .empty-note { font-size: 13px; color: var(--color-fg-subtle) }
+
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <p class="kicker">생성된 문서 · 직접 고치지 않는다</p>
+    <h1>IZ-Get · 셸 · 컴포넌트</h1>
+    <p>실제 화면을 짤 때 참고하는 문서다. 값(색·크기)은 <a href="./design-system.html">토큰 문서</a>와 같은 곳(<code>src/index.css</code>)에서 온다.</p>
+    
+    <div class="doc-nav"><a href="./design-system.html">토큰</a><a class="on" href="./components.html">셸 · 컴포넌트</a></div>
+  </header>
+
+  
+  <section>
+    <h2>셸 <span class="cnt">2</span></h2>
+    <p class="cap">아래 미리보기는 구조·비율·토큰 값만 옮긴 것이다. 실제 셸 코드가 아니다 — 카드를 누르면 그 셸이 뽑힌 원본 와이어프레임이 열린다</p>
+    <div class="cards">
+    <a class="card" href="../plan/screen/wireframe/shared/login.html">
+      <div class="shell-mini shell-mini-auth">
+        <div class="sm-brand">
+          <span class="sm-dot"></span>
+          <span class="sm-line" style="width:60%"></span>
+        </div>
+        <div class="sm-form">
+          <span class="sm-line" style="width:40%;height:8px"></span>
+          <span class="sm-box"></span>
+          <span class="sm-box"></span>
+          <span class="sm-cta"></span>
+        </div>
+      </div>
+      <div class="top"><span class="nm">AuthShell</span><span class="uses">4~7 / 17 화면</span></div>
+      <p class="desc">좌 브랜드 패널 + 우 폼. 구조는 고정이고 헤드라인·설명·각주만 받는다.</p>
+      <span class="go">와이어프레임 열기 →</span>
+    </a>
+    <a class="card" href="../plan/screen/wireframe/manager/dashboard.html">
+      <div class="shell-mini shell-mini-manager">
+        <div class="sm-topbar">
+          <span class="sm-dot" style="background:var(--color-primary);width:10px;height:10px;border-radius:3px"></span>
+          <span class="sm-pill"></span>
+        </div>
+        <div class="sm-body">
+          <div class="sm-nav">
+            <span class="sm-navitem sm-navitem-on"></span>
+            <span class="sm-navitem"></span>
+            <span class="sm-navitem"></span>
+            <span class="sm-navitem"></span>
+          </div>
+          <div class="sm-content">
+            <span class="sm-line" style="width:35%"></span>
+            <span class="sm-block"></span>
+          </div>
+        </div>
+      </div>
+      <div class="top"><span class="nm">ManagerShell</span><span class="uses">7~9 / 17 화면</span></div>
+      <p class="desc">상단바(브랜드·기수 선택기·사용자) + 좌측 네비 184px + 콘텐츠. 총괄 전용 항목을 가린다.</p>
+      <span class="go">와이어프레임 열기 →</span>
+    </a>
+  </div>
+  <details>
+    <summary>왜 이렇게 정했나 <span class="cnt">(3)</span></summary>
+    <div class="qa">
+      <div><p class="q">왜 셸을 먼저 만들었나</p><p class="a">확정 화면 17개에서 무엇이 가장 많이 반복되는지 세어봤더니 개별 컴포넌트가 아니라 셸이었다(레이아웃 골격 9회, 네비·콘텐츠 9회, 상단바 8회). 둘이 나눠 개발하면 각자 셸을 만들게 되고, 그러면 가장 크고 가장 많이 쓰이는 것을 두 벌 갖게 된다.</p></div>
+<div><p class="q">페이지 제목·주액션은 왜 셸이 안 받나</p><p class="a">화면마다 탭이 끼거나 제목 옆에 총개수가 붙는 등 조합이 달라서, 셸이 다 받으면 props가 계속 늘어난다. 별도 컴포넌트로 둔다.</p></div>
+<div><p class="q">위 미리보기는 실제 셸 코드인가</p><p class="a">아니다. 구조·비율·토큰 값만 옮긴 것이다. 실제 마크업을 그대로 박으면 셸이 바뀔 때마다 이 문서를 다시 만들어야 하는데, 그 동기화를 사람이 기억해야 한다면 결국 낡는다. 그래서 카드를 원본 와이어프레임으로 가는 링크로 두었다 — 진짜 화면은 거기서 실행 중인 앱으로 본다.</p></div>
+    </div>
+  </details>
+  </section>
+  <section>
+    <h2>컴포넌트 <span class="cnt">5</span></h2>
+    <p class="cap">확정 화면 17개에서 5회 이상 반복되는 것만 만들었다. 아래는 실제로 렌더된 모습이다</p>
+    <div class="comp">
+    <h3>Button <span class="cnt">10 / 17 화면</span></h3>
+    <p class="cap">주 액션은 한 화면에 하나가 원칙이다. 비활성은 <code>disabled</code> 속성으로 준다 — 회색으로 보이게만 하면 보조기술에는 누를 수 있는 버튼으로 읽힌다</p>
+    <div class="row-demo">
+      <button class="btn btn-primary btn-md">저장</button>
+      <button class="btn btn-ghost btn-md">취소</button>
+      <button class="btn btn-danger btn-md">삭제</button>
+      <button class="btn btn-primary btn-sm">작게</button>
+      <button class="btn btn-primary btn-md" disabled>비활성</button>
+    </div>
+    <div class="row-demo"><button class="btn btn-primary btn-lg">전체 폭 — 폼 제출</button></div>
+  </div>
+
+  <div class="comp">
+    <h3>Badge <span class="cnt">8 / 17 화면</span></h3>
+    <p class="cap"><b>색만으로 상태를 말하지 않는다.</b> 배지 안의 글자가 상태를 그대로 말해야 한다 — 색을 구분하기 어려운 사용자에게는 색이 아무 정보도 주지 않는다</p>
+    <div class="row-demo">
+      <span class="bdg bdg-success">활성</span>
+      <span class="bdg bdg-warning">미검증</span>
+      <span class="bdg bdg-danger">차단됨</span>
+      <span class="bdg bdg-info">안내</span>
+      <span class="bdg bdg-neutral">보류</span>
+    </div>
+  </div>
+
+  <div class="comp">
+    <h3>Card <span class="cnt">6 / 17 화면</span></h3>
+    <p class="cap">안쪽 여백을 기본값으로 두지 않는다 — 표를 담는 카드는 여백이 0이어야 하고 폼을 담는 카드는 필요하다. 기본값을 정하면 절반은 그걸 지우는 데 쓴다</p>
+    <div class="row-demo">
+      <div class="cardbox" style="padding:16px">폼을 담을 때 — 여백을 준다</div>
+      <div class="cardbox">표를 담을 때 — 여백 없음</div>
+    </div>
+  </div>
+
+  <div class="comp">
+    <h3>PageHeader · 표 배치 <span class="cnt">6 · 5 / 17 화면</span></h3>
+    <p class="cap">배치만 만들었다. <b>컬럼 정의와 데이터 연결은 없다</b> — 화면마다 컬럼이 다르고, 한 화면만 보고 그 형태를 정하면 두 번째 화면에서 틀린다</p>
+    <div class="demo-frame">
+      <div class="ph">
+        <div>
+          <p class="ph-crumb">교육생 › 7기</p>
+          <h4 class="ph-title">교육생 <span>48명</span></h4>
+        </div>
+        <button class="btn btn-primary btn-md">+ 추가</button>
+      </div>
+      <div class="cardbox">
+        <div class="tbar">
+          <span class="fakectl">🔍 검색</span>
+          <span class="fakectl">반 ▾</span>
+          <span class="fakectl">계정 ▾</span>
+          <span class="fakectl">정렬 ▾</span>
+        </div>
+        <div class="tbody">표 자리 — 각 화면이 직접 그린다</div>
+        <div class="tfoot">
+          <p>1–20 / 48명</p>
+          <div class="tfoot-mid"><span class="fakectl">‹ 1 2 3 ›</span></div>
+          <div></div>
+        </div>
+      </div>
+    </div>
+    <p class="cap">툴바는 <b>전부 왼쪽</b>, 오른쪽은 비운다. 주 액션은 제목 줄에 있으므로 툴바 오른쪽에도 버튼을 두면 주 액션이 둘로 보인다. 푸터는 범위 개수(왼쪽) · 페이지 이동(가운데) · 오른쪽 비움.</p>
+  </div>
+  <details>
+    <summary>왜 이렇게 정했나 <span class="cnt">(2)</span></summary>
+    <div class="qa">
+      <div><p class="q">왜 미리 다 만들어두지 않나</p><p class="a">화면 하나만 보고 뽑은 컴포넌트는 두 번째 화면에서 대개 틀린다. 같은 조각이 세 번 반복되는 것을 확인한 뒤에 뽑는다. 지금 만드는 것들은 확정 화면 17개에서 5회 이상 반복되는 것만 고른 것이다.</p></div>
+<div><p class="q">필요한 컴포넌트가 없으면</p><p class="a">내 도메인 폴더 안에 만든다(features/{도메인}/components). 다른 도메인에서도 같은 것이 필요해지면 그때 공용으로 올린다. 처음부터 공용으로 만들면 한 곳의 사정에 맞춘 것이 공용이 된다.</p></div>
+    </div>
+  </details>
+  </section>
+  <div class="empty-note">
+    <p>Modal · Tabs · Search · Select는 아직 이름과 위치만 합의된 상태다 — 필요한 사람이 만들고 여기 추가한다.</p>
+  </div>
+  
+
+  <footer>생성 명령 <code>npm run doc:components</code> · 컴포넌트 소스 <code>src/components/</code>, <code>src/shells/</code></footer>
+</div>
+</body>
+</html>

--- a/docs/dev/design-system.html
+++ b/docs/dev/design-system.html
@@ -5,10 +5,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>IZ-Get · 디자인 시스템</title>
 <!--
-  이 파일은 생성물이다. 직접 고치지 말고 아래를 고친 뒤 다시 만든다.
-    값     src/index.css
-    설명   scripts/design-doc-content.mjs
-    생성   npm run doc:design
+  이 파일은 생성물이다. 직접 고치지 말고 생성기를 고친 뒤 다시 만든다.
+  값은 src/index.css, 명령은 package.json의 doc:* 스크립트를 본다.
 -->
 <style>
   :root {
@@ -47,6 +45,7 @@
     --radius-md: 10px;
     --radius-lg: 14px;
     --radius-xl: 18px;
+    --text-2xs: 11px;
     --text-xs: 12px;
     --text-sm: 13px;
     --text-base: 14px;
@@ -61,6 +60,7 @@
     --font: -apple-system, 'Apple SD Gothic Neo', system-ui, 'Segoe UI', sans-serif;
     --mono: ui-monospace, Menlo, monospace;
   }
+
   * { box-sizing: border-box; margin: 0; padding: 0 }
   body {
     font-family: var(--font); font-size: 14px; line-height: 1.5;
@@ -78,6 +78,13 @@
     margin-top: 16px; padding: 12px 16px; border-radius: var(--radius-md);
     border: 1px solid var(--color-info-border); background: var(--color-info-soft); color: var(--color-info);
   }
+  .doc-nav { display: flex; gap: 8px; margin-top: 16px }
+  .doc-nav a {
+    font-size: 13px; font-weight: 600; text-decoration: none; padding: 6px 12px;
+    border-radius: var(--radius-md); border: 1px solid var(--color-border-strong); color: var(--color-fg-muted);
+  }
+  .doc-nav a.on { background: var(--color-primary); border-color: var(--color-primary); color: #fff }
+  .doc-nav a:not(.on):hover { border-color: var(--color-fg-subtle) }
 
   section { margin-bottom: 48px }
   h2 { font-size: 18px; display: flex; align-items: baseline; gap: 8px }
@@ -86,7 +93,17 @@
   .grp { margin-bottom: 32px }
   h3 { font-size: 14px; margin-bottom: 2px }
 
-  /* 사용법 */
+  details { border: 1px solid var(--color-border); border-radius: var(--radius-md); background: var(--color-surface-2); margin-top: 8px }
+  summary { cursor: pointer; padding: 8px 12px; font-size: 12px; font-weight: 600; color: var(--color-fg-muted) }
+  summary .cnt { font-weight: 400; color: var(--color-fg-subtle) }
+  .qa { padding: 12px; border-top: 1px solid var(--color-border); display: grid; gap: 12px }
+  .qa .q { font-size: 14px; font-weight: 600 }
+  .qa .a { font-size: 14px; color: var(--color-fg-muted); margin-top: 4px; line-height: 1.65 }
+
+  footer { border-top: 1px solid var(--color-border); padding-top: 16px; font-size: 12px; color: var(--color-fg-subtle) }
+  :focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px }
+
+
   .rules { border: 1px solid var(--color-border); background: var(--color-surface); border-radius: var(--radius-lg); padding: 20px; margin-bottom: 40px }
   .rules h2 { font-size: 14px }
   .cols { display: grid; gap: 12px; grid-template-columns: 1fr 1fr; margin-top: 12px }
@@ -96,7 +113,6 @@
   pre { margin-top: 4px; padding: 12px; border-radius: var(--radius-md); border: 1px solid var(--color-border); background: var(--color-canvas); font-family: var(--mono); font-size: 12px; overflow-x: auto }
   .rules p { color: var(--color-fg-muted); margin-top: 12px }
 
-  /* 색 카드 — 2층은 호버·포커스로 연다 */
   .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 8px; margin: 12px 0 }
   .sw { position: relative; outline: none }
   .swbox { display: flex; align-items: center; gap: 12px; padding: 8px; border: 1px solid var(--color-border); border-radius: var(--radius-md); background: var(--color-surface) }
@@ -119,15 +135,6 @@
   .pop .ex span { color: var(--color-fg-muted) }
   .pop .note { font-size: 12px; color: var(--color-fg-muted); margin-top: 8px; padding-top: 8px; border-top: 1px solid var(--color-border) }
 
-  /* 3층 — 클릭해서 연다. 접혀 있어도 내용은 문서에 있어 검색·인쇄된다 */
-  details { border: 1px solid var(--color-border); border-radius: var(--radius-md); background: var(--color-surface-2); margin-top: 8px }
-  summary { cursor: pointer; padding: 8px 12px; font-size: 12px; font-weight: 600; color: var(--color-fg-muted) }
-  summary .cnt { font-weight: 400; color: var(--color-fg-subtle) }
-  .qa { padding: 12px; border-top: 1px solid var(--color-border); display: grid; gap: 12px }
-  .qa .q { font-size: 14px; font-weight: 600 }
-  .qa .a { font-size: 14px; color: var(--color-fg-muted); margin-top: 4px; line-height: 1.65 }
-
-  /* 타이포 */
   .rows { border: 1px solid var(--color-border); border-radius: var(--radius-lg); background: var(--color-surface); overflow: hidden }
   .row { display: flex; align-items: baseline; gap: 16px; padding: 12px 16px; border-bottom: 1px solid var(--color-border) }
   .row:last-child { border-bottom: 0 }
@@ -136,41 +143,25 @@
   .row .val { width: 48px; flex: 0 0 48px }
   .fonts { display: flex; flex-wrap: wrap; gap: 24px; margin-top: 16px }
 
-  /* 모서리·그림자 */
   .boxes { display: flex; flex-wrap: wrap; gap: 16px; align-items: flex-end }
   .boxes > div { text-align: center }
   .boxes b { display: block; width: 64px; height: 64px; border: 1px solid var(--color-border-strong); background: var(--color-surface) }
   .boxes code { display: block; margin-top: 4px; font-size: 12px; color: var(--color-fg-subtle) }
 
-  /* 셸 */
-  .cards { display: grid; gap: 12px; grid-template-columns: 1fr 1fr }
-  @media (max-width: 640px) { .cards { grid-template-columns: 1fr } }
-  .card { display: block; padding: 16px; border: 1px solid var(--color-border); border-radius: var(--radius-lg); background: var(--color-surface); text-decoration: none; color: inherit }
-  .card:hover { border-color: var(--color-border-strong) }
-  .card .top { display: flex; align-items: baseline; justify-content: space-between }
-  .card .nm { font-family: var(--mono); font-size: 14px; font-weight: 600 }
-  .card .uses { font-size: 12px; color: var(--color-fg-subtle) }
-  .card .desc { font-size: 14px; color: var(--color-fg-muted); margin-top: 8px }
-  .card .go { display: inline-block; margin-top: 12px; font-size: 14px; color: var(--color-primary) }
-
-  .empty { border: 1px solid var(--color-border); border-radius: var(--radius-lg); background: var(--color-surface); padding: 24px }
-  .empty p + p { color: var(--color-fg-muted); margin-top: 8px }
-  footer { border-top: 1px solid var(--color-border); padding-top: 16px; font-size: 12px; color: var(--color-fg-subtle) }
-  :focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px }
 </style>
 </head>
 <body>
 <div class="wrap">
   <header>
     <p class="kicker">생성된 문서 · 직접 고치지 않는다</p>
-    <h1>디자인 시스템</h1>
-    <p>화면을 만들기 전에 여기서 쓸 토큰을 고른다. 값은 <code>src/index.css</code>에서 읽어 만든다.</p>
-    <div class="howto">
-      <b>카드에 커서를 올리면</b> 언제 쓰는 색인지 나온다. <b>「왜 이렇게 정했나」를 누르면</b> 설계 근거가 열린다.
-      키보드로는 Tab으로 카드에 이동하면 같은 내용이 보인다.
-    </div>
+    <h1>IZ-Get · 디자인 시스템</h1>
+    <p>값은 <code>src/index.css</code>에서 읽어 만든다. 셸·컴포넌트는 <a href="./components.html">구현 문서</a>에 있다.</p>
+    <div class="howto"><b>카드에 커서를 올리면</b> 언제 쓰는 색인지 나온다. <b>「왜 이렇게 정했나」를 누르면</b> 설계 근거가 열린다.
+      키보드로는 Tab으로 카드에 이동하면 같은 내용이 보인다.</div>
+    <div class="doc-nav"><a class="on" href="./design-system.html">토큰</a><a href="./components.html">셸 · 컴포넌트</a></div>
   </header>
 
+  
   <div class="rules">
     <h2>쓰는 법</h2>
     <div class="cols">
@@ -624,16 +615,16 @@
   </section>
 
   <section>
-    <h2>글자 크기 <span class="cnt">7</span></h2>
+    <h2>글자 크기 <span class="cnt">8</span></h2>
     <p class="cap">데이터 밀도가 높은 운영 도구라 기준이 14px다(웹 기본 16px 아님)</p>
     <div class="rows">
-      <div class="row"><code class="k">text-xs</code><code class="val">12px</code><span style="font-size:12px">다람쥐 헌 쳇바퀴에 타고파</span></div><div class="row"><code class="k">text-sm</code><code class="val">13px</code><span style="font-size:13px">다람쥐 헌 쳇바퀴에 타고파</span></div><div class="row"><code class="k">text-base</code><code class="val">14px</code><span style="font-size:14px">다람쥐 헌 쳇바퀴에 타고파</span></div><div class="row"><code class="k">text-lg</code><code class="val">16px</code><span style="font-size:16px">다람쥐 헌 쳇바퀴에 타고파</span></div><div class="row"><code class="k">text-xl</code><code class="val">20px</code><span style="font-size:20px">다람쥐 헌 쳇바퀴에 타고파</span></div><div class="row"><code class="k">text-2xl</code><code class="val">26px</code><span style="font-size:26px">다람쥐 헌 쳇바퀴에 타고파</span></div><div class="row"><code class="k">text-3xl</code><code class="val">32px</code><span style="font-size:32px">다람쥐 헌 쳇바퀴에 타고파</span></div>
+      <div class="row"><code class="k">text-2xs</code><code class="val">11px</code><span style="font-size:11px">다람쥐 헌 쳇바퀴에 타고파</span></div><div class="row"><code class="k">text-xs</code><code class="val">12px</code><span style="font-size:12px">다람쥐 헌 쳇바퀴에 타고파</span></div><div class="row"><code class="k">text-sm</code><code class="val">13px</code><span style="font-size:13px">다람쥐 헌 쳇바퀴에 타고파</span></div><div class="row"><code class="k">text-base</code><code class="val">14px</code><span style="font-size:14px">다람쥐 헌 쳇바퀴에 타고파</span></div><div class="row"><code class="k">text-lg</code><code class="val">16px</code><span style="font-size:16px">다람쥐 헌 쳇바퀴에 타고파</span></div><div class="row"><code class="k">text-xl</code><code class="val">20px</code><span style="font-size:20px">다람쥐 헌 쳇바퀴에 타고파</span></div><div class="row"><code class="k">text-2xl</code><code class="val">26px</code><span style="font-size:26px">다람쥐 헌 쳇바퀴에 타고파</span></div><div class="row"><code class="k">text-3xl</code><code class="val">32px</code><span style="font-size:32px">다람쥐 헌 쳇바퀴에 타고파</span></div>
     </div>
     <details>
     <summary>왜 이렇게 정했나 <span class="cnt">(2)</span></summary>
     <div class="qa">
       <div><p class="q">왜 기본이 16px이 아닌가</p><p class="a">한 화면에 표·지표·목록이 함께 놓이는 운영 도구다. 16px 기준으로 잡으면 표가 한 화면에 안 들어와 스크롤이 늘고, 그러면 비교가 어려워진다. 대신 대비를 AA로 유지해 작아도 읽히게 했다.</p></div>
-<div><p class="q">3xl은 어디 쓰나</p><p class="a">인증 화면의 마케팅 헤드라인 전용이다. 앱 내부 화면에는 그만한 글자가 없다.</p></div>
+<div><p class="q">2xs·3xl은 어디 쓰나</p><p class="a">2xs(11px)는 확정 화면 실측에서 가장 많이 쓰인 크기(148회)라 뒤늦게 승격했다 — 배지·메타·표의 보조 정보. 3xl은 인증 화면의 마케팅 헤드라인 전용이다.</p></div>
     </div>
   </details>
     <div class="fonts">
@@ -662,49 +653,7 @@
   </details>
   </section>
 
-  <section>
-    <h2>셸 <span class="cnt">2</span></h2>
-    <p class="cap">아래는 설계 원본인 와이어프레임으로 연결된다</p>
-    <div class="cards">
-      <a class="card" href="../plan/screen/wireframe/shared/login.html">
-        <div class="top"><span class="nm">AuthShell</span><span class="uses">4~7 / 17 화면</span></div>
-        <p class="desc">좌 브랜드 패널 + 우 폼. 구조는 고정이고 헤드라인·설명·각주만 받는다.</p>
-        <span class="go">와이어프레임 열기 →</span>
-      </a>
-      <a class="card" href="../plan/screen/wireframe/manager/dashboard.html">
-        <div class="top"><span class="nm">ManagerShell</span><span class="uses">7~9 / 17 화면</span></div>
-        <p class="desc">상단바(브랜드·기수 선택기·사용자) + 좌측 네비 184px + 콘텐츠. 총괄 전용 항목을 가린다.</p>
-        <span class="go">와이어프레임 열기 →</span>
-      </a>
-    </div>
-    <details>
-    <summary>왜 이렇게 정했나 <span class="cnt">(2)</span></summary>
-    <div class="qa">
-      <div><p class="q">왜 셸을 먼저 만들었나</p><p class="a">확정 화면 17개에서 무엇이 가장 많이 반복되는지 세어봤더니 개별 컴포넌트가 아니라 셸이었다(레이아웃 골격 9회, 네비·콘텐츠 9회, 상단바 8회). 둘이 나눠 개발하면 각자 셸을 만들게 되고, 그러면 가장 크고 가장 많이 쓰이는 것을 두 벌 갖게 된다.</p></div>
-<div><p class="q">페이지 제목·주액션은 왜 셸이 안 받나</p><p class="a">화면마다 탭이 끼거나 제목 옆에 총개수가 붙는 등 조합이 달라서, 셸이 다 받으면 props가 계속 늘어난다. 별도 컴포넌트로 둔다.</p></div>
-    </div>
-  </details>
-  </section>
-
-  <section>
-    <h2>컴포넌트 <span class="cnt">0</span></h2>
-    
-    <div class="empty">
-      <p><b>아직 없다.</b></p>
-      <p>Button · Badge · Card · 표 배치 · PageHeader가 다음 순서다. 만들어지는 대로 여기에 쌓인다.</p>
-    </div>
-    <details>
-    <summary>왜 이렇게 정했나 <span class="cnt">(2)</span></summary>
-    <div class="qa">
-      <div><p class="q">왜 미리 다 만들어두지 않나</p><p class="a">화면 하나만 보고 뽑은 컴포넌트는 두 번째 화면에서 대개 틀린다. 같은 조각이 세 번 반복되는 것을 확인한 뒤에 뽑는다. 지금 만드는 것들은 확정 화면 17개에서 5회 이상 반복되는 것만 고른 것이다.</p></div>
-<div><p class="q">필요한 컴포넌트가 없으면</p><p class="a">내 도메인 폴더 안에 만든다(features/{도메인}/components). 다른 도메인에서도 같은 것이 필요해지면 그때 공용으로 올린다. 처음부터 공용으로 만들면 한 곳의 사정에 맞춘 것이 공용이 된다.</p></div>
-    </div>
-  </details>
-  </section>
-
-  <footer>
-    생성 명령 <code>npm run doc:design</code> · 값 <code>src/index.css</code> · 설명 <code>scripts/design-doc-content.mjs</code>
-  </footer>
+  <footer>생성 명령 <code>npm run doc:design</code> · 값 <code>src/index.css</code> · 설명 <code>scripts/design-doc-content.mjs</code></footer>
 </div>
 </body>
 </html>

--- a/scripts/component-doc.mjs
+++ b/scripts/component-doc.mjs
@@ -1,0 +1,260 @@
+#!/usr/bin/env node
+/**
+ * 셸·컴포넌트 문서 생성 — `npm run doc:components`
+ *
+ * 토큰 문서(design-system.html)와 분리했다. 값을 고르러 오는 것과 구현을
+ * 참고하러 오는 것은 읽는 목적이 다르다 — 전자는 훑고 고르는 문서, 후자는
+ * "이 화면과 비슷한 걸 어떻게 짰나"를 보러 오는 문서다.
+ *
+ * 셸 미리보기는 **실제 셸 코드가 아니라 구조·비율·토큰 값만 옮긴 것**이다.
+ * 실제 마크업을 그대로 박으면 셸이 바뀔 때 이 문서도 다시 만들어야 하는데,
+ * 그 동기화를 잊으면 정확히 D10·D11이 경계한 "조용히 낡는 문서"가 된다.
+ * 그래서 카드 자체를 원본 와이어프레임으로 가는 링크로 두었다 — 진짜 화면은
+ * 거기서 본다.
+ *
+ * `--check`를 주면 생성 결과가 커밋된 파일과 다를 때 실패한다(CI용).
+ */
+import { writeFileSync, mkdirSync, existsSync, readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { ROOT, readTokens, tokenCssBlock, rationale, section, pageShell } from './doc-shared.mjs'
+
+const OUT = join(ROOT, 'docs/dev/components.html')
+
+const PAGE_CSS = `
+  .cards { display: grid; gap: 12px; grid-template-columns: 1fr 1fr }
+  @media (max-width: 640px) { .cards { grid-template-columns: 1fr } }
+  .card { display: block; padding: 16px; border: 1px solid var(--color-border); border-radius: var(--radius-lg); background: var(--color-surface); text-decoration: none; color: inherit }
+  .card:hover { border-color: var(--color-border-strong) }
+  .card .top { display: flex; align-items: baseline; justify-content: space-between; margin-top: 12px }
+  .card .nm { font-family: var(--mono); font-size: 14px; font-weight: 600 }
+  .card .uses { font-size: 12px; color: var(--color-fg-subtle) }
+  .card .desc { font-size: 14px; color: var(--color-fg-muted); margin-top: 8px }
+  .card .go { display: inline-block; margin-top: 12px; font-size: 14px; color: var(--color-primary) }
+
+  /* 셸 구조 미리보기 — 뼈대만. 실제 셸 색·타이포는 여기 값과 같지만
+     레이아웃 세부(패딩 등)까지 1:1은 아니다. "구조 미리보기"라고 캡션에 명시한다. */
+  .shell-mini { border: 1px solid var(--color-border); border-radius: var(--radius-md); overflow: hidden; background: var(--color-canvas); pointer-events: none }
+  .shell-mini-auth { display: flex; height: 120px }
+  .sm-brand { flex: 0 0 42%; background: linear-gradient(150deg, var(--color-brand-1), var(--color-brand-2)); padding: 14px; display: flex; flex-direction: column; justify-content: space-between }
+  .sm-dot { width: 14px; height: 14px; border-radius: 4px; background: rgba(255,255,255,.25); display: block }
+  .sm-form { flex: 1; background: var(--color-surface); padding: 16px; display: flex; flex-direction: column; gap: 8px }
+  .sm-line { display: block; height: 6px; border-radius: 3px; background: var(--color-border-strong) }
+  .sm-box { display: block; height: 16px; border-radius: 4px; border: 1px solid var(--color-border-strong); background: var(--color-surface) }
+  .sm-cta { display: block; height: 16px; border-radius: 4px; background: var(--color-primary); margin-top: 4px }
+
+  .shell-mini-manager { height: 120px; display: flex; flex-direction: column }
+  .sm-topbar { height: 22px; flex: 0 0 22px; background: var(--color-surface); border-bottom: 1px solid var(--color-border); display: flex; align-items: center; gap: 8px; padding: 0 10px }
+  .sm-pill { height: 10px; width: 40px; border-radius: 999px; background: var(--color-surface-2); border: 1px solid var(--color-border-strong) }
+  .sm-body { flex: 1; display: flex }
+  .sm-nav { width: 34%; background: var(--color-nav); padding: 8px; display: flex; flex-direction: column; gap: 5px }
+  .sm-navitem { display: block; height: 10px; border-radius: 3px; background: var(--color-nav-fg); opacity: .35 }
+  .sm-navitem-on { background: var(--color-nav-active); opacity: 1 }
+  .sm-content { flex: 1; background: var(--color-canvas); padding: 10px; display: flex; flex-direction: column; gap: 8px }
+  .sm-block { display: block; flex: 1; border-radius: 4px; background: var(--color-surface); border: 1px solid var(--color-border) }
+
+  /* 컴포넌트 데모 — 실제 컴포넌트와 같은 토큰만 쓴다. 값을 새로 만들면 문서가 거짓이 된다 */
+  .comp { margin-bottom: 28px }
+  .comp h3 { display: flex; align-items: baseline; gap: 8px }
+  .comp h3 .cnt { font-size: 12px; font-weight: 400; color: var(--color-fg-subtle) }
+  .row-demo { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-top: 12px }
+  .btn { display: inline-flex; align-items: center; justify-content: center; gap: 6px; border: 0; border-radius: var(--radius-md); font-weight: 600; cursor: pointer; font-family: inherit }
+  .btn-primary { background: var(--color-primary); color: #fff }
+  .btn-ghost { background: var(--color-surface); color: var(--color-fg-muted); border: 1px solid var(--color-border-strong) }
+  .btn-danger { background: var(--color-danger); color: #fff }
+  .btn-sm { padding: 6px 12px; font-size: var(--text-xs) }
+  .btn-md { padding: 8px 14px; font-size: var(--text-xs) }
+  .btn-lg { height: 44px; width: 100%; font-size: var(--text-sm) }
+  .btn:disabled { cursor: not-allowed; opacity: .6 }
+  .bdg { display: inline-flex; align-items: center; gap: 4px; border-radius: 999px; padding: 2px 8px; font-size: var(--text-2xs); font-weight: 600 }
+  .bdg-success { background: var(--color-success-soft); color: var(--color-success) }
+  .bdg-warning { background: var(--color-warning-soft); color: var(--color-warning) }
+  .bdg-danger { background: var(--color-danger-soft); color: var(--color-danger) }
+  .bdg-info { background: var(--color-info-soft); color: var(--color-info) }
+  .bdg-neutral { background: var(--color-neutral-soft); color: var(--color-fg-subtle) }
+  .cardbox { background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--radius-md); overflow: hidden; flex: 1; min-width: 200px }
+  .demo-frame { background: var(--color-canvas); border: 1px solid var(--color-border); border-radius: var(--radius-md); padding: 16px; margin-top: 12px }
+  .ph { display: flex; flex-wrap: wrap; align-items: flex-end; justify-content: space-between; gap: 12px; margin-bottom: 16px }
+  .ph-crumb { font-size: var(--text-xs); color: var(--color-fg-subtle); margin-bottom: 2px }
+  .ph-title { font-size: var(--text-xl); font-weight: 700; letter-spacing: -.01em }
+  .ph-title span { font-size: var(--text-sm); font-weight: 400; color: var(--color-fg-subtle); margin-left: 8px }
+  .tbar { display: flex; flex-wrap: wrap; gap: 8px; padding: 12px; border-bottom: 1px solid var(--color-border) }
+  .fakectl { border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); padding: 4px 10px; font-size: var(--text-xs); color: var(--color-fg-muted); background: var(--color-surface) }
+  .tbody { padding: 28px 12px; text-align: center; color: var(--color-fg-subtle); font-size: var(--text-xs) }
+  .tfoot { display: grid; grid-template-columns: repeat(3, 1fr); align-items: center; padding: 12px; border-top: 1px solid var(--color-border) }
+  .tfoot p { font-size: var(--text-xs); color: var(--color-fg-subtle) }
+  .tfoot-mid { display: flex; justify-content: center }
+
+  .empty-note { font-size: 13px; color: var(--color-fg-subtle) }
+`
+
+function build() {
+  const tokens = readTokens()
+
+  const shellsHtml = `<div class="cards">
+    <a class="card" href="../plan/screen/wireframe/shared/login.html">
+      <div class="shell-mini shell-mini-auth">
+        <div class="sm-brand">
+          <span class="sm-dot"></span>
+          <span class="sm-line" style="width:60%"></span>
+        </div>
+        <div class="sm-form">
+          <span class="sm-line" style="width:40%;height:8px"></span>
+          <span class="sm-box"></span>
+          <span class="sm-box"></span>
+          <span class="sm-cta"></span>
+        </div>
+      </div>
+      <div class="top"><span class="nm">AuthShell</span><span class="uses">4~7 / 17 화면</span></div>
+      <p class="desc">좌 브랜드 패널 + 우 폼. 구조는 고정이고 헤드라인·설명·각주만 받는다.</p>
+      <span class="go">와이어프레임 열기 →</span>
+    </a>
+    <a class="card" href="../plan/screen/wireframe/manager/dashboard.html">
+      <div class="shell-mini shell-mini-manager">
+        <div class="sm-topbar">
+          <span class="sm-dot" style="background:var(--color-primary);width:10px;height:10px;border-radius:3px"></span>
+          <span class="sm-pill"></span>
+        </div>
+        <div class="sm-body">
+          <div class="sm-nav">
+            <span class="sm-navitem sm-navitem-on"></span>
+            <span class="sm-navitem"></span>
+            <span class="sm-navitem"></span>
+            <span class="sm-navitem"></span>
+          </div>
+          <div class="sm-content">
+            <span class="sm-line" style="width:35%"></span>
+            <span class="sm-block"></span>
+          </div>
+        </div>
+      </div>
+      <div class="top"><span class="nm">ManagerShell</span><span class="uses">7~9 / 17 화면</span></div>
+      <p class="desc">상단바(브랜드·기수 선택기·사용자) + 좌측 네비 184px + 콘텐츠. 총괄 전용 항목을 가린다.</p>
+      <span class="go">와이어프레임 열기 →</span>
+    </a>
+  </div>
+  ${rationale([
+    {
+      q: '왜 셸을 먼저 만들었나',
+      a: '확정 화면 17개에서 무엇이 가장 많이 반복되는지 세어봤더니 개별 컴포넌트가 아니라 셸이었다(레이아웃 골격 9회, 네비·콘텐츠 9회, 상단바 8회). 둘이 나눠 개발하면 각자 셸을 만들게 되고, 그러면 가장 크고 가장 많이 쓰이는 것을 두 벌 갖게 된다.',
+    },
+    {
+      q: '페이지 제목·주액션은 왜 셸이 안 받나',
+      a: '화면마다 탭이 끼거나 제목 옆에 총개수가 붙는 등 조합이 달라서, 셸이 다 받으면 props가 계속 늘어난다. 별도 컴포넌트로 둔다.',
+    },
+    {
+      q: '위 미리보기는 실제 셸 코드인가',
+      a: '아니다. 구조·비율·토큰 값만 옮긴 것이다. 실제 마크업을 그대로 박으면 셸이 바뀔 때마다 이 문서를 다시 만들어야 하는데, 그 동기화를 사람이 기억해야 한다면 결국 낡는다. 그래서 카드를 원본 와이어프레임으로 가는 링크로 두었다 — 진짜 화면은 거기서 실행 중인 앱으로 본다.',
+    },
+  ])}`
+
+  const componentsHtml = `<div class="comp">
+    <h3>Button <span class="cnt">10 / 17 화면</span></h3>
+    <p class="cap">주 액션은 한 화면에 하나가 원칙이다. 비활성은 <code>disabled</code> 속성으로 준다 — 회색으로 보이게만 하면 보조기술에는 누를 수 있는 버튼으로 읽힌다</p>
+    <div class="row-demo">
+      <button class="btn btn-primary btn-md">저장</button>
+      <button class="btn btn-ghost btn-md">취소</button>
+      <button class="btn btn-danger btn-md">삭제</button>
+      <button class="btn btn-primary btn-sm">작게</button>
+      <button class="btn btn-primary btn-md" disabled>비활성</button>
+    </div>
+    <div class="row-demo"><button class="btn btn-primary btn-lg">전체 폭 — 폼 제출</button></div>
+  </div>
+
+  <div class="comp">
+    <h3>Badge <span class="cnt">8 / 17 화면</span></h3>
+    <p class="cap"><b>색만으로 상태를 말하지 않는다.</b> 배지 안의 글자가 상태를 그대로 말해야 한다 — 색을 구분하기 어려운 사용자에게는 색이 아무 정보도 주지 않는다</p>
+    <div class="row-demo">
+      <span class="bdg bdg-success">활성</span>
+      <span class="bdg bdg-warning">미검증</span>
+      <span class="bdg bdg-danger">차단됨</span>
+      <span class="bdg bdg-info">안내</span>
+      <span class="bdg bdg-neutral">보류</span>
+    </div>
+  </div>
+
+  <div class="comp">
+    <h3>Card <span class="cnt">6 / 17 화면</span></h3>
+    <p class="cap">안쪽 여백을 기본값으로 두지 않는다 — 표를 담는 카드는 여백이 0이어야 하고 폼을 담는 카드는 필요하다. 기본값을 정하면 절반은 그걸 지우는 데 쓴다</p>
+    <div class="row-demo">
+      <div class="cardbox" style="padding:16px">폼을 담을 때 — 여백을 준다</div>
+      <div class="cardbox">표를 담을 때 — 여백 없음</div>
+    </div>
+  </div>
+
+  <div class="comp">
+    <h3>PageHeader · 표 배치 <span class="cnt">6 · 5 / 17 화면</span></h3>
+    <p class="cap">배치만 만들었다. <b>컬럼 정의와 데이터 연결은 없다</b> — 화면마다 컬럼이 다르고, 한 화면만 보고 그 형태를 정하면 두 번째 화면에서 틀린다</p>
+    <div class="demo-frame">
+      <div class="ph">
+        <div>
+          <p class="ph-crumb">교육생 › 7기</p>
+          <h4 class="ph-title">교육생 <span>48명</span></h4>
+        </div>
+        <button class="btn btn-primary btn-md">+ 추가</button>
+      </div>
+      <div class="cardbox">
+        <div class="tbar">
+          <span class="fakectl">🔍 검색</span>
+          <span class="fakectl">반 ▾</span>
+          <span class="fakectl">계정 ▾</span>
+          <span class="fakectl">정렬 ▾</span>
+        </div>
+        <div class="tbody">표 자리 — 각 화면이 직접 그린다</div>
+        <div class="tfoot">
+          <p>1–20 / 48명</p>
+          <div class="tfoot-mid"><span class="fakectl">‹ 1 2 3 ›</span></div>
+          <div></div>
+        </div>
+      </div>
+    </div>
+    <p class="cap">툴바는 <b>전부 왼쪽</b>, 오른쪽은 비운다. 주 액션은 제목 줄에 있으므로 툴바 오른쪽에도 버튼을 두면 주 액션이 둘로 보인다. 푸터는 범위 개수(왼쪽) · 페이지 이동(가운데) · 오른쪽 비움.</p>
+  </div>
+  ${rationale([
+    {
+      q: '왜 미리 다 만들어두지 않나',
+      a: '화면 하나만 보고 뽑은 컴포넌트는 두 번째 화면에서 대개 틀린다. 같은 조각이 세 번 반복되는 것을 확인한 뒤에 뽑는다. 지금 만드는 것들은 확정 화면 17개에서 5회 이상 반복되는 것만 고른 것이다.',
+    },
+    {
+      q: '필요한 컴포넌트가 없으면',
+      a: '내 도메인 폴더 안에 만든다(features/{도메인}/components). 다른 도메인에서도 같은 것이 필요해지면 그때 공용으로 올린다. 처음부터 공용으로 만들면 한 곳의 사정에 맞춘 것이 공용이 된다.',
+    },
+  ])}`
+
+  const bodyHtml = `
+  ${section('셸', 2, '아래 미리보기는 구조·비율·토큰 값만 옮긴 것이다. 실제 셸 코드가 아니다 — 카드를 누르면 그 셸이 뽑힌 원본 와이어프레임이 열린다', shellsHtml)}
+  ${section('컴포넌트', 5, '확정 화면 17개에서 5회 이상 반복되는 것만 만들었다. 아래는 실제로 렌더된 모습이다', componentsHtml)}
+  <div class="empty-note">
+    <p>Modal · Tabs · Search · Select는 아직 이름과 위치만 합의된 상태다 — 필요한 사람이 만들고 여기 추가한다.</p>
+  </div>
+  `
+
+  return pageShell({
+    title: 'IZ-Get · 셸 · 컴포넌트',
+    kicker: '생성된 문서 · 직접 고치지 않는다',
+    lede: `실제 화면을 짤 때 참고하는 문서다. 값(색·크기)은 <a href="./design-system.html">토큰 문서</a>와 같은 곳(<code>src/index.css</code>)에서 온다.`,
+    howto: null,
+    nav: `<a href="./design-system.html">토큰</a><a class="on" href="./components.html">셸 · 컴포넌트</a>`,
+    tokenCss: tokenCssBlock(tokens),
+    pageCss: PAGE_CSS,
+    bodyHtml,
+    footerNote: `생성 명령 <code>npm run doc:components</code> · 컴포넌트 소스 <code>src/components/</code>, <code>src/shells/</code>`,
+  })
+}
+
+/* ── 실행 ────────────────────────────────────────────── */
+
+const html = build()
+
+if (process.argv.includes('--check')) {
+  const current = existsSync(OUT) ? readFileSync(OUT, 'utf8') : ''
+  if (current !== html) {
+    console.error('\n✗ 셸·컴포넌트 문서가 최신이 아니다.')
+    console.error('    npm run doc:components 를 실행하고 결과를 커밋할 것.\n')
+    process.exit(1)
+  }
+  console.log('✓ 셸·컴포넌트 문서가 최신이다')
+} else {
+  mkdirSync(dirname(OUT), { recursive: true })
+  writeFileSync(OUT, html)
+  console.log(`✓ ${OUT.slice(ROOT.length)} 생성됨`)
+}

--- a/scripts/design-doc.mjs
+++ b/scripts/design-doc.mjs
@@ -1,48 +1,32 @@
 #!/usr/bin/env node
 /**
- * 디자인 시스템 문서 생성 — `npm run doc:design`
+ * 디자인 토큰 문서 생성 — `npm run doc:design`
  *
  * src/index.css의 @theme을 읽어 docs/dev/design-system.html을 만든다.
  * 값을 HTML에 손으로 적으면 토큰이 바뀔 때 문서가 조용히 거짓말을 한다.
  * 설명은 design-doc-content.mjs에서만 온다 — 값과 설명 모두 출처가 하나다.
  *
- * `--check`를 주면 생성 결과가 커밋된 파일과 다를 때 실패한다(CI용).
- * 토큰을 고치고 문서를 안 만들면 팀이 낡은 문서를 보게 되므로 기계가 잡는다.
+ * 이 문서는 **토큰(값)만** 다룬다. 셸·컴포넌트는 component-doc.mjs가 만드는
+ * docs/dev/components.html로 분리했다 — 읽는 목적이 다르다. 값을 고르러 오는
+ * 것과 구현을 참고하러 오는 것은 같은 문서에 있을 필요가 없다.
  *
- * 결과물은 빌드 없이 브라우저로 바로 열 수 있어야 한다(팀 공유용).
- * 따라서 CSS·JS를 전부 인라인하고 외부 자원을 참조하지 않는다.
+ * `--check`를 주면 생성 결과가 커밋된 파일과 다를 때 실패한다(CI용).
  */
-import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs'
+import { writeFileSync, mkdirSync, existsSync, readFileSync } from 'node:fs'
 import { join, dirname } from 'node:path'
+import {
+  ROOT,
+  readTokens,
+  byPrefix,
+  tokenCssBlock,
+  esc,
+  rationale,
+  section,
+  pageShell,
+} from './doc-shared.mjs'
 import { TOKEN_DOCS, GROUP_RATIONALE } from './design-doc-content.mjs'
 
-const ROOT = new URL('..', import.meta.url).pathname
-const SOURCE = join(ROOT, 'src/index.css')
 const OUT = join(ROOT, 'docs/dev/design-system.html')
-
-/* ── 토큰 읽기 ───────────────────────────────────────── */
-
-/** @theme 블록에서 `--name: value` 를 뽑는다. 주석은 값에 섞이지 않게 먼저 지운다. */
-function readTokens() {
-  const css = readFileSync(SOURCE, 'utf8')
-  const theme = css.match(/@theme[^{]*\{([\s\S]*?)\n\}/)
-  if (!theme) throw new Error('src/index.css에서 @theme 블록을 찾지 못했다')
-
-  const body = theme[1].replace(/\/\*[\s\S]*?\*\//g, '')
-  const tokens = []
-  for (const m of body.matchAll(/--([a-z0-9-]+):\s*([^;]+);/g)) {
-    const name = m[1]
-    // Tailwind가 자동으로 붙이는 짝 변수는 목록에서 뺀다
-    if (name.includes('--line-height')) continue
-    tokens.push({ name, value: m[2].trim().replace(/\s+/g, ' ') })
-  }
-  return tokens
-}
-
-const byPrefix = (tokens, p) =>
-  tokens.filter((t) => t.name.startsWith(p)).map((t) => ({ ...t, short: t.name.slice(p.length) }))
-
-/* ── 색 분류 ─────────────────────────────────────────── */
 
 const COLOR_GROUPS = [
   { title: '표면', note: '무엇이 무엇 위에 얹히는지를 정한다', re: /^(canvas|surface|border)/ },
@@ -59,14 +43,6 @@ const COLOR_GROUPS = [
     re: /^nav/,
   },
 ]
-
-/* ── HTML 조각 ───────────────────────────────────────── */
-
-const esc = (s) =>
-  String(s).replace(
-    /[&<>"]/g,
-    (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' })[c],
-  )
 
 function swatch(t) {
   const doc = TOKEN_DOCS[t.short]
@@ -91,25 +67,51 @@ function swatch(t) {
   </div>`
 }
 
-function rationale(items) {
-  if (!items?.length) return ''
-  return `<details>
-    <summary>왜 이렇게 정했나 <span class="cnt">(${items.length})</span></summary>
-    <div class="qa">
-      ${items.map((it) => `<div><p class="q">${esc(it.q)}</p><p class="a">${esc(it.a)}</p></div>`).join('\n')}
-    </div>
-  </details>`
-}
+const PAGE_CSS = `
+  .rules { border: 1px solid var(--color-border); background: var(--color-surface); border-radius: var(--radius-lg); padding: 20px; margin-bottom: 40px }
+  .rules h2 { font-size: 14px }
+  .cols { display: grid; gap: 12px; grid-template-columns: 1fr 1fr; margin-top: 12px }
+  @media (max-width: 640px) { .cols { grid-template-columns: 1fr } }
+  .cols .ok { font-size: 12px; font-weight: 600; color: var(--color-success) }
+  .cols .no { font-size: 12px; font-weight: 600; color: var(--color-danger) }
+  pre { margin-top: 4px; padding: 12px; border-radius: var(--radius-md); border: 1px solid var(--color-border); background: var(--color-canvas); font-family: var(--mono); font-size: 12px; overflow-x: auto }
+  .rules p { color: var(--color-fg-muted); margin-top: 12px }
 
-function section(title, count, caption, inner) {
-  return `<section>
-    <h2>${esc(title)} <span class="cnt">${count}</span></h2>
-    ${caption ? `<p class="cap">${esc(caption)}</p>` : ''}
-    ${inner}
-  </section>`
-}
+  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 8px; margin: 12px 0 }
+  .sw { position: relative; outline: none }
+  .swbox { display: flex; align-items: center; gap: 12px; padding: 8px; border: 1px solid var(--color-border); border-radius: var(--radius-md); background: var(--color-surface) }
+  .sw:hover .swbox { border-color: var(--color-border-strong) }
+  .sw:focus .swbox { border-color: var(--color-primary); box-shadow: 0 0 0 2px var(--color-primary-soft) }
+  .swbox i { width: 40px; height: 40px; flex: 0 0 40px; border-radius: 6px; border: 1px solid var(--color-border); display: block }
+  .swtxt { min-width: 0 }
+  .swtxt .n { display: block; font-size: 12px; font-weight: 600 }
+  .swtxt .v { display: block; font-size: 12px; color: var(--color-fg-subtle) }
+  .mark { color: var(--color-warning); margin-left: 4px }
 
-/* ── 문서 조립 ───────────────────────────────────────── */
+  .pop {
+    position: absolute; top: 100%; left: 0; z-index: 10; width: 280px; margin-top: 4px;
+    padding: 12px; border: 1px solid var(--color-border-strong); border-radius: var(--radius-md);
+    background: var(--color-surface); box-shadow: var(--shadow-card);
+    visibility: hidden; opacity: 0;
+  }
+  .sw:hover .pop, .sw:focus .pop, .sw:focus-within .pop { visibility: visible; opacity: 1 }
+  .pop .ex { font-size: 12px; color: var(--color-fg-subtle); margin-top: 8px }
+  .pop .ex span { color: var(--color-fg-muted) }
+  .pop .note { font-size: 12px; color: var(--color-fg-muted); margin-top: 8px; padding-top: 8px; border-top: 1px solid var(--color-border) }
+
+  .rows { border: 1px solid var(--color-border); border-radius: var(--radius-lg); background: var(--color-surface); overflow: hidden }
+  .row { display: flex; align-items: baseline; gap: 16px; padding: 12px 16px; border-bottom: 1px solid var(--color-border) }
+  .row:last-child { border-bottom: 0 }
+  .row code { font-size: 12px; color: var(--color-fg-subtle) }
+  .row .k { width: 120px; flex: 0 0 120px }
+  .row .val { width: 48px; flex: 0 0 48px }
+  .fonts { display: flex; flex-wrap: wrap; gap: 24px; margin-top: 16px }
+
+  .boxes { display: flex; flex-wrap: wrap; gap: 16px; align-items: flex-end }
+  .boxes > div { text-align: center }
+  .boxes b { display: block; width: 64px; height: 64px; border: 1px solid var(--color-border-strong); background: var(--color-surface) }
+  .boxes code { display: block; margin-top: 4px; font-size: 12px; color: var(--color-fg-subtle) }
+`
 
 function build() {
   const tokens = readTokens()
@@ -118,6 +120,7 @@ function build() {
   const texts = byPrefix(tokens, 'text-')
   const fonts = byPrefix(tokens, 'font-')
   const adjusted = colors.filter((c) => TOKEN_DOCS[c.short]?.adjusted).length
+  const hasShadow = tokens.some((t) => t.name.startsWith('shadow-'))
 
   const used = new Set()
   const colorSections = COLOR_GROUPS.map((g) => {
@@ -142,147 +145,7 @@ function build() {
       </div>`
     : ''
 
-  return page({
-    colorCount: colors.length,
-    adjusted,
-    colorSections: colorSections + restSection,
-    texts,
-    fonts,
-    radii,
-    hasShadow: tokens.some((t) => t.name.startsWith('shadow-')),
-    tokenCss: tokens.map((t) => `    --${t.name}: ${t.value};`).join('\n'),
-  })
-}
-
-function page(d) {
-  return `<!doctype html>
-<html lang="ko">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title>IZ-Get · 디자인 시스템</title>
-<!--
-  이 파일은 생성물이다. 직접 고치지 말고 아래를 고친 뒤 다시 만든다.
-    값     src/index.css
-    설명   scripts/design-doc-content.mjs
-    생성   npm run doc:design
--->
-<style>
-  :root {
-${d.tokenCss}
-    --font: -apple-system, 'Apple SD Gothic Neo', system-ui, 'Segoe UI', sans-serif;
-    --mono: ui-monospace, Menlo, monospace;
-  }
-  * { box-sizing: border-box; margin: 0; padding: 0 }
-  body {
-    font-family: var(--font); font-size: 14px; line-height: 1.5;
-    color: var(--color-fg); background: var(--color-canvas);
-    -webkit-font-smoothing: antialiased;
-  }
-  .wrap { max-width: 1100px; margin: 0 auto; padding: 40px 24px }
-  code { font-family: var(--mono) }
-
-  header { margin-bottom: 32px }
-  .kicker { font-size: 12px; font-weight: 600; letter-spacing: .04em; text-transform: uppercase; color: var(--color-fg-subtle) }
-  h1 { font-size: 26px; letter-spacing: -.01em; margin: 8px 0 8px }
-  header > p { color: var(--color-fg-muted); max-width: 640px }
-  .howto {
-    margin-top: 16px; padding: 12px 16px; border-radius: var(--radius-md);
-    border: 1px solid var(--color-info-border); background: var(--color-info-soft); color: var(--color-info);
-  }
-
-  section { margin-bottom: 48px }
-  h2 { font-size: 18px; display: flex; align-items: baseline; gap: 8px }
-  h2 .cnt { font-size: 14px; font-weight: 400; color: var(--color-fg-subtle) }
-  .cap { font-size: 12px; color: var(--color-fg-subtle); margin-top: 4px }
-  .grp { margin-bottom: 32px }
-  h3 { font-size: 14px; margin-bottom: 2px }
-
-  /* 사용법 */
-  .rules { border: 1px solid var(--color-border); background: var(--color-surface); border-radius: var(--radius-lg); padding: 20px; margin-bottom: 40px }
-  .rules h2 { font-size: 14px }
-  .cols { display: grid; gap: 12px; grid-template-columns: 1fr 1fr; margin-top: 12px }
-  @media (max-width: 640px) { .cols { grid-template-columns: 1fr } }
-  .cols .ok { font-size: 12px; font-weight: 600; color: var(--color-success) }
-  .cols .no { font-size: 12px; font-weight: 600; color: var(--color-danger) }
-  pre { margin-top: 4px; padding: 12px; border-radius: var(--radius-md); border: 1px solid var(--color-border); background: var(--color-canvas); font-family: var(--mono); font-size: 12px; overflow-x: auto }
-  .rules p { color: var(--color-fg-muted); margin-top: 12px }
-
-  /* 색 카드 — 2층은 호버·포커스로 연다 */
-  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 8px; margin: 12px 0 }
-  .sw { position: relative; outline: none }
-  .swbox { display: flex; align-items: center; gap: 12px; padding: 8px; border: 1px solid var(--color-border); border-radius: var(--radius-md); background: var(--color-surface) }
-  .sw:hover .swbox { border-color: var(--color-border-strong) }
-  .sw:focus .swbox { border-color: var(--color-primary); box-shadow: 0 0 0 2px var(--color-primary-soft) }
-  .swbox i { width: 40px; height: 40px; flex: 0 0 40px; border-radius: 6px; border: 1px solid var(--color-border); display: block }
-  .swtxt { min-width: 0 }
-  .swtxt .n { display: block; font-size: 12px; font-weight: 600 }
-  .swtxt .v { display: block; font-size: 12px; color: var(--color-fg-subtle) }
-  .mark { color: var(--color-warning); margin-left: 4px }
-
-  .pop {
-    position: absolute; top: 100%; left: 0; z-index: 10; width: 280px; margin-top: 4px;
-    padding: 12px; border: 1px solid var(--color-border-strong); border-radius: var(--radius-md);
-    background: var(--color-surface); box-shadow: var(--shadow-card);
-    visibility: hidden; opacity: 0;
-  }
-  .sw:hover .pop, .sw:focus .pop, .sw:focus-within .pop { visibility: visible; opacity: 1 }
-  .pop .ex { font-size: 12px; color: var(--color-fg-subtle); margin-top: 8px }
-  .pop .ex span { color: var(--color-fg-muted) }
-  .pop .note { font-size: 12px; color: var(--color-fg-muted); margin-top: 8px; padding-top: 8px; border-top: 1px solid var(--color-border) }
-
-  /* 3층 — 클릭해서 연다. 접혀 있어도 내용은 문서에 있어 검색·인쇄된다 */
-  details { border: 1px solid var(--color-border); border-radius: var(--radius-md); background: var(--color-surface-2); margin-top: 8px }
-  summary { cursor: pointer; padding: 8px 12px; font-size: 12px; font-weight: 600; color: var(--color-fg-muted) }
-  summary .cnt { font-weight: 400; color: var(--color-fg-subtle) }
-  .qa { padding: 12px; border-top: 1px solid var(--color-border); display: grid; gap: 12px }
-  .qa .q { font-size: 14px; font-weight: 600 }
-  .qa .a { font-size: 14px; color: var(--color-fg-muted); margin-top: 4px; line-height: 1.65 }
-
-  /* 타이포 */
-  .rows { border: 1px solid var(--color-border); border-radius: var(--radius-lg); background: var(--color-surface); overflow: hidden }
-  .row { display: flex; align-items: baseline; gap: 16px; padding: 12px 16px; border-bottom: 1px solid var(--color-border) }
-  .row:last-child { border-bottom: 0 }
-  .row code { font-size: 12px; color: var(--color-fg-subtle) }
-  .row .k { width: 120px; flex: 0 0 120px }
-  .row .val { width: 48px; flex: 0 0 48px }
-  .fonts { display: flex; flex-wrap: wrap; gap: 24px; margin-top: 16px }
-
-  /* 모서리·그림자 */
-  .boxes { display: flex; flex-wrap: wrap; gap: 16px; align-items: flex-end }
-  .boxes > div { text-align: center }
-  .boxes b { display: block; width: 64px; height: 64px; border: 1px solid var(--color-border-strong); background: var(--color-surface) }
-  .boxes code { display: block; margin-top: 4px; font-size: 12px; color: var(--color-fg-subtle) }
-
-  /* 셸 */
-  .cards { display: grid; gap: 12px; grid-template-columns: 1fr 1fr }
-  @media (max-width: 640px) { .cards { grid-template-columns: 1fr } }
-  .card { display: block; padding: 16px; border: 1px solid var(--color-border); border-radius: var(--radius-lg); background: var(--color-surface); text-decoration: none; color: inherit }
-  .card:hover { border-color: var(--color-border-strong) }
-  .card .top { display: flex; align-items: baseline; justify-content: space-between }
-  .card .nm { font-family: var(--mono); font-size: 14px; font-weight: 600 }
-  .card .uses { font-size: 12px; color: var(--color-fg-subtle) }
-  .card .desc { font-size: 14px; color: var(--color-fg-muted); margin-top: 8px }
-  .card .go { display: inline-block; margin-top: 12px; font-size: 14px; color: var(--color-primary) }
-
-  .empty { border: 1px solid var(--color-border); border-radius: var(--radius-lg); background: var(--color-surface); padding: 24px }
-  .empty p + p { color: var(--color-fg-muted); margin-top: 8px }
-  footer { border-top: 1px solid var(--color-border); padding-top: 16px; font-size: 12px; color: var(--color-fg-subtle) }
-  :focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px }
-</style>
-</head>
-<body>
-<div class="wrap">
-  <header>
-    <p class="kicker">생성된 문서 · 직접 고치지 않는다</p>
-    <h1>디자인 시스템</h1>
-    <p>화면을 만들기 전에 여기서 쓸 토큰을 고른다. 값은 <code>src/index.css</code>에서 읽어 만든다.</p>
-    <div class="howto">
-      <b>카드에 커서를 올리면</b> 언제 쓰는 색인지 나온다. <b>「왜 이렇게 정했나」를 누르면</b> 설계 근거가 열린다.
-      키보드로는 Tab으로 카드에 이동하면 같은 내용이 보인다.
-    </div>
-  </header>
-
+  const bodyHtml = `
   <div class="rules">
     <h2>쓰는 법</h2>
     <div class="cols">
@@ -301,14 +164,14 @@ ${d.tokenCss}
     <p>쓸 토큰이 없으면 임의 색을 만들지 말고 먼저 묻는다 — 대개 이미 있는 의미에 이름을 잘못 찾고 있는 경우다.</p>
   </div>
 
-  ${section('색', d.colorCount, `값이 조정된 토큰 ${d.adjusted}개는 카드에 ✎ 표시가 있다`, d.colorSections)}
+  ${section('색', colors.length, `값이 조정된 토큰 ${adjusted}개는 카드에 ✎ 표시가 있다`, colorSections + restSection)}
 
   ${section(
     '글자 크기',
-    d.texts.length,
+    texts.length,
     '데이터 밀도가 높은 운영 도구라 기준이 14px다(웹 기본 16px 아님)',
     `<div class="rows">
-      ${d.texts
+      ${texts
         .map(
           (t) =>
             `<div class="row"><code class="k">text-${esc(t.short)}</code><code class="val">${esc(t.value)}</code><span style="font-size:${esc(t.value)}">다람쥐 헌 쳇바퀴에 타고파</span></div>`,
@@ -321,12 +184,12 @@ ${d.tokenCss}
         a: '한 화면에 표·지표·목록이 함께 놓이는 운영 도구다. 16px 기준으로 잡으면 표가 한 화면에 안 들어와 스크롤이 늘고, 그러면 비교가 어려워진다. 대신 대비를 AA로 유지해 작아도 읽히게 했다.',
       },
       {
-        q: '3xl은 어디 쓰나',
-        a: '인증 화면의 마케팅 헤드라인 전용이다. 앱 내부 화면에는 그만한 글자가 없다.',
+        q: '2xs·3xl은 어디 쓰나',
+        a: '2xs(11px)는 확정 화면 실측에서 가장 많이 쓰인 크기(148회)라 뒤늦게 승격했다 — 배지·메타·표의 보조 정보. 3xl은 인증 화면의 마케팅 헤드라인 전용이다.',
       },
     ])}
     <div class="fonts">
-      ${d.fonts
+      ${fonts
         .map(
           (f) =>
             `<div><code class="v">font-${esc(f.short)}</code><p style="font-family:${esc(f.value)};font-size:16px">다람쥐 Sphinx 0123</p></div>`,
@@ -343,11 +206,11 @@ ${d.tokenCss}
 
   ${section(
     '모서리 · 그림자',
-    d.radii.length + (d.hasShadow ? 1 : 0),
+    radii.length + (hasShadow ? 1 : 0),
     null,
     `<div class="boxes">
-      ${d.radii.map((r) => `<div><b style="border-radius:${esc(r.value)}"></b><code>rounded-${esc(r.short)} · ${esc(r.value)}</code></div>`).join('')}
-      ${d.hasShadow ? `<div><b style="border-radius:var(--radius-lg);border-color:transparent;box-shadow:var(--shadow-card)"></b><code>shadow-card</code></div>` : ''}
+      ${radii.map((r) => `<div><b style="border-radius:${esc(r.value)}"></b><code>rounded-${esc(r.short)} · ${esc(r.value)}</code></div>`).join('')}
+      ${hasShadow ? `<div><b style="border-radius:var(--radius-lg);border-color:transparent;box-shadow:var(--shadow-card)"></b><code>shadow-card</code></div>` : ''}
     </div>
     ${rationale([
       {
@@ -355,63 +218,20 @@ ${d.tokenCss}
         a: '이 제품에서 떠 있어야 하는 것은 카드뿐이다. 모달은 배경을 덮어 구분되고, 나머지는 테두리로 나뉜다. 그림자 단계를 여럿 두면 "얼마나 떠 있나"를 매번 고민하게 된다.',
       },
     ])}`,
-  )}
+  )}`
 
-  ${section(
-    '셸',
-    2,
-    '아래는 설계 원본인 와이어프레임으로 연결된다',
-    `<div class="cards">
-      <a class="card" href="../plan/screen/wireframe/shared/login.html">
-        <div class="top"><span class="nm">AuthShell</span><span class="uses">4~7 / 17 화면</span></div>
-        <p class="desc">좌 브랜드 패널 + 우 폼. 구조는 고정이고 헤드라인·설명·각주만 받는다.</p>
-        <span class="go">와이어프레임 열기 →</span>
-      </a>
-      <a class="card" href="../plan/screen/wireframe/manager/dashboard.html">
-        <div class="top"><span class="nm">ManagerShell</span><span class="uses">7~9 / 17 화면</span></div>
-        <p class="desc">상단바(브랜드·기수 선택기·사용자) + 좌측 네비 184px + 콘텐츠. 총괄 전용 항목을 가린다.</p>
-        <span class="go">와이어프레임 열기 →</span>
-      </a>
-    </div>
-    ${rationale([
-      {
-        q: '왜 셸을 먼저 만들었나',
-        a: '확정 화면 17개에서 무엇이 가장 많이 반복되는지 세어봤더니 개별 컴포넌트가 아니라 셸이었다(레이아웃 골격 9회, 네비·콘텐츠 9회, 상단바 8회). 둘이 나눠 개발하면 각자 셸을 만들게 되고, 그러면 가장 크고 가장 많이 쓰이는 것을 두 벌 갖게 된다.',
-      },
-      {
-        q: '페이지 제목·주액션은 왜 셸이 안 받나',
-        a: '화면마다 탭이 끼거나 제목 옆에 총개수가 붙는 등 조합이 달라서, 셸이 다 받으면 props가 계속 늘어난다. 별도 컴포넌트로 둔다.',
-      },
-    ])}`,
-  )}
-
-  ${section(
-    '컴포넌트',
-    0,
-    null,
-    `<div class="empty">
-      <p><b>아직 없다.</b></p>
-      <p>Button · Badge · Card · 표 배치 · PageHeader가 다음 순서다. 만들어지는 대로 여기에 쌓인다.</p>
-    </div>
-    ${rationale([
-      {
-        q: '왜 미리 다 만들어두지 않나',
-        a: '화면 하나만 보고 뽑은 컴포넌트는 두 번째 화면에서 대개 틀린다. 같은 조각이 세 번 반복되는 것을 확인한 뒤에 뽑는다. 지금 만드는 것들은 확정 화면 17개에서 5회 이상 반복되는 것만 고른 것이다.',
-      },
-      {
-        q: '필요한 컴포넌트가 없으면',
-        a: '내 도메인 폴더 안에 만든다(features/{도메인}/components). 다른 도메인에서도 같은 것이 필요해지면 그때 공용으로 올린다. 처음부터 공용으로 만들면 한 곳의 사정에 맞춘 것이 공용이 된다.',
-      },
-    ])}`,
-  )}
-
-  <footer>
-    생성 명령 <code>npm run doc:design</code> · 값 <code>src/index.css</code> · 설명 <code>scripts/design-doc-content.mjs</code>
-  </footer>
-</div>
-</body>
-</html>
-`
+  return pageShell({
+    title: 'IZ-Get · 디자인 시스템',
+    kicker: '생성된 문서 · 직접 고치지 않는다',
+    lede: `값은 <code>src/index.css</code>에서 읽어 만든다. 셸·컴포넌트는 <a href="./components.html">구현 문서</a>에 있다.`,
+    howto: `<b>카드에 커서를 올리면</b> 언제 쓰는 색인지 나온다. <b>「왜 이렇게 정했나」를 누르면</b> 설계 근거가 열린다.
+      키보드로는 Tab으로 카드에 이동하면 같은 내용이 보인다.`,
+    nav: `<a class="on" href="./design-system.html">토큰</a><a href="./components.html">셸 · 컴포넌트</a>`,
+    tokenCss: tokenCssBlock(tokens),
+    pageCss: PAGE_CSS,
+    bodyHtml,
+    footerNote: `생성 명령 <code>npm run doc:design</code> · 값 <code>src/index.css</code> · 설명 <code>scripts/design-doc-content.mjs</code>`,
+  })
 }
 
 /* ── 실행 ────────────────────────────────────────────── */
@@ -421,11 +241,11 @@ const html = build()
 if (process.argv.includes('--check')) {
   const current = existsSync(OUT) ? readFileSync(OUT, 'utf8') : ''
   if (current !== html) {
-    console.error('\n✗ 디자인 시스템 문서가 토큰과 어긋난다.')
+    console.error('\n✗ 디자인 토큰 문서가 토큰과 어긋난다.')
     console.error('    npm run doc:design 을 실행하고 결과를 커밋할 것.\n')
     process.exit(1)
   }
-  console.log('✓ 디자인 시스템 문서가 최신이다')
+  console.log('✓ 디자인 토큰 문서가 최신이다')
 } else {
   mkdirSync(dirname(OUT), { recursive: true })
   writeFileSync(OUT, html)

--- a/scripts/doc-shared.mjs
+++ b/scripts/doc-shared.mjs
@@ -1,0 +1,163 @@
+/**
+ * 문서 생성기 두 개(design-doc.mjs · component-doc.mjs)가 공유하는 것.
+ *
+ * 토큰 읽기와 문서 뼈대(헤더·섹션·접기 요소)를 한곳에 둔다. 두 문서가 각자
+ * 베끼면 스타일이 갈라지고, 그러면 "같은 시스템의 두 문서"처럼 안 보인다.
+ */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+export const ROOT = new URL('..', import.meta.url).pathname
+export const SOURCE = join(ROOT, 'src/index.css')
+
+/* ── 토큰 읽기 ───────────────────────────────────────── */
+
+/** @theme 블록에서 `--name: value` 를 뽑는다. 주석은 값에 섞이지 않게 먼저 지운다. */
+export function readTokens() {
+  const css = readFileSync(SOURCE, 'utf8')
+  const theme = css.match(/@theme[^{]*\{([\s\S]*?)\n\}/)
+  if (!theme) throw new Error('src/index.css에서 @theme 블록을 찾지 못했다')
+
+  const body = theme[1].replace(/\/\*[\s\S]*?\*\//g, '')
+  const tokens = []
+  for (const m of body.matchAll(/--([a-z0-9-]+):\s*([^;]+);/g)) {
+    const name = m[1]
+    // Tailwind가 자동으로 붙이는 짝 변수는 목록에서 뺀다
+    if (name.includes('--line-height')) continue
+    tokens.push({ name, value: m[2].trim().replace(/\s+/g, ' ') })
+  }
+  return tokens
+}
+
+export const byPrefix = (tokens, p) =>
+  tokens.filter((t) => t.name.startsWith(p)).map((t) => ({ ...t, short: t.name.slice(p.length) }))
+
+export const tokenCssBlock = (tokens) =>
+  tokens.map((t) => `    --${t.name}: ${t.value};`).join('\n')
+
+/* ── HTML 조각 ───────────────────────────────────────── */
+
+export const esc = (s) =>
+  String(s).replace(
+    /[&<>"]/g,
+    (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' })[c],
+  )
+
+export function rationale(items) {
+  if (!items?.length) return ''
+  return `<details>
+    <summary>왜 이렇게 정했나 <span class="cnt">(${items.length})</span></summary>
+    <div class="qa">
+      ${items.map((it) => `<div><p class="q">${esc(it.q)}</p><p class="a">${esc(it.a)}</p></div>`).join('\n')}
+    </div>
+  </details>`
+}
+
+export function section(title, count, caption, inner) {
+  return `<section>
+    <h2>${esc(title)} <span class="cnt">${count}</span></h2>
+    ${caption ? `<p class="cap">${esc(caption)}</p>` : ''}
+    ${inner}
+  </section>`
+}
+
+/* ── 문서 뼈대 ───────────────────────────────────────── */
+
+/** 두 문서가 공통으로 쓰는 기본 스타일. 페이지별 스타일은 각 생성기가 이어붙인다. */
+export const BASE_CSS = `
+  * { box-sizing: border-box; margin: 0; padding: 0 }
+  body {
+    font-family: var(--font); font-size: 14px; line-height: 1.5;
+    color: var(--color-fg); background: var(--color-canvas);
+    -webkit-font-smoothing: antialiased;
+  }
+  .wrap { max-width: 1100px; margin: 0 auto; padding: 40px 24px }
+  code { font-family: var(--mono) }
+
+  header { margin-bottom: 32px }
+  .kicker { font-size: 12px; font-weight: 600; letter-spacing: .04em; text-transform: uppercase; color: var(--color-fg-subtle) }
+  h1 { font-size: 26px; letter-spacing: -.01em; margin: 8px 0 8px }
+  header > p { color: var(--color-fg-muted); max-width: 640px }
+  .howto {
+    margin-top: 16px; padding: 12px 16px; border-radius: var(--radius-md);
+    border: 1px solid var(--color-info-border); background: var(--color-info-soft); color: var(--color-info);
+  }
+  .doc-nav { display: flex; gap: 8px; margin-top: 16px }
+  .doc-nav a {
+    font-size: 13px; font-weight: 600; text-decoration: none; padding: 6px 12px;
+    border-radius: var(--radius-md); border: 1px solid var(--color-border-strong); color: var(--color-fg-muted);
+  }
+  .doc-nav a.on { background: var(--color-primary); border-color: var(--color-primary); color: #fff }
+  .doc-nav a:not(.on):hover { border-color: var(--color-fg-subtle) }
+
+  section { margin-bottom: 48px }
+  h2 { font-size: 18px; display: flex; align-items: baseline; gap: 8px }
+  h2 .cnt { font-size: 14px; font-weight: 400; color: var(--color-fg-subtle) }
+  .cap { font-size: 12px; color: var(--color-fg-subtle); margin-top: 4px }
+  .grp { margin-bottom: 32px }
+  h3 { font-size: 14px; margin-bottom: 2px }
+
+  details { border: 1px solid var(--color-border); border-radius: var(--radius-md); background: var(--color-surface-2); margin-top: 8px }
+  summary { cursor: pointer; padding: 8px 12px; font-size: 12px; font-weight: 600; color: var(--color-fg-muted) }
+  summary .cnt { font-weight: 400; color: var(--color-fg-subtle) }
+  .qa { padding: 12px; border-top: 1px solid var(--color-border); display: grid; gap: 12px }
+  .qa .q { font-size: 14px; font-weight: 600 }
+  .qa .a { font-size: 14px; color: var(--color-fg-muted); margin-top: 4px; line-height: 1.65 }
+
+  footer { border-top: 1px solid var(--color-border); padding-top: 16px; font-size: 12px; color: var(--color-fg-subtle) }
+  :focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px }
+`
+
+/**
+ * 문서 한 장을 완성한다. 생성기 스크립트가 `--check` 모드로 자기 출력과
+ * 저장된 파일을 비교하므로, 여기서 만드는 문자열이 곧 진실이다.
+ */
+export function pageShell({
+  title,
+  kicker,
+  lede,
+  howto,
+  nav,
+  tokenCss,
+  pageCss,
+  bodyHtml,
+  footerNote,
+}) {
+  return `<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${esc(title)}</title>
+<!--
+  이 파일은 생성물이다. 직접 고치지 말고 생성기를 고친 뒤 다시 만든다.
+  값은 src/index.css, 명령은 package.json의 doc:* 스크립트를 본다.
+-->
+<style>
+  :root {
+${tokenCss}
+    --font: -apple-system, 'Apple SD Gothic Neo', system-ui, 'Segoe UI', sans-serif;
+    --mono: ui-monospace, Menlo, monospace;
+  }
+${BASE_CSS}
+${pageCss}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <p class="kicker">${esc(kicker)}</p>
+    <h1>${esc(title)}</h1>
+    <p>${lede}</p>
+    ${howto ? `<div class="howto">${howto}</div>` : ''}
+    ${nav ? `<div class="doc-nav">${nav}</div>` : ''}
+  </header>
+
+  ${bodyHtml}
+
+  <footer>${footerNote}</footer>
+</div>
+</body>
+</html>
+`
+}


### PR DESCRIPTION
> **base가 `develop`이 아니라 `feature/ui-primitives`입니다.** #17이 먼저 머지되어야
> 이 PR의 diff가 제 몫만 남습니다. 순서는 #13 → #17 → 이 PR입니다.

## 작업 내용

- 문서를 둘로 나눔 — `design-system.html`(토큰 값) · `components.html`(셸·컴포넌트 렌더)
- 공통 코드를 `scripts/doc-shared.mjs`로 분리
- `component-doc.mjs --check`를 CI에 추가

## 리뷰 포인트

**① 왜 나눴나** — 읽는 목적이 다릅니다. 토큰 문서는 "쓸 값을 고르러" 오고, 컴포넌트
문서는 "이 화면과 비슷한 걸 어떻게 짰나"를 보러 옵니다. 한 파일에 있으면 둘 다 찾기 어렵습니다.

**② 셸 미리보기는 실제 셸 코드가 아닙니다.** 구조·비율·토큰만 옮긴 것이고, 카드를 누르면
원본 와이어프레임으로 갑니다. 실제 마크업을 박으면 셸이 바뀔 때마다 문서를 다시 만들어야
하는데 그 동기화를 사람이 기억해야 하면 결국 낡습니다.

**③ 드리프트 검사가 실제로 잡는 것을 확인했습니다.** 문서에 한 줄 넣고 `--check`를 돌려
실패하는 것까지 봤습니다. `design-doc.mjs`에서 이미 "사람이 기억해야 하는 절차는 지켜지지
않는다"를 겪어서 같은 방식으로 기계에 맡겼습니다.

**④ `components.html`은 프리티어 대상에서 뺐습니다** — 생성물이라 포맷이 손대면 검사가
스스로 깨집니다.

## 확인

- [x] 로컬에서 동작 확인
- [x] 하나의 PR = 하나의 기능

closes #16