### PR TITLE
[Fix] Issue Format Check Misreads Fix-Tagged Work Requests

### DIFF
--- a/.github/workflows/issue-format.yml
+++ b/.github/workflows/issue-format.yml
@@ -17,13 +17,24 @@ jobs:
       - uses: actions/github-script@v7
         with:
           script: |
-            const { title, body = '', number } = context.payload.issue
-            const isBug = /^\[Fix\]/i.test(title)
-            const required = isBug
-              ? ['버그 개요', '발생 환경', '재현 절차', '실제 결과', '예상 결과']
-              : ['작업 개요', '작업 유형', '작업 내용', '변경 대상', '완료 조건']
+            const { body = '', number } = context.payload.issue
+
+            const BUG = ['버그 개요', '발생 환경', '재현 절차', '실제 결과', '예상 결과']
+            const TASK = ['작업 개요', '작업 유형', '작업 내용', '변경 대상', '완료 조건']
 
             const heads = [...body.matchAll(/^##\s+(.+?)\s*$/gm)].map(m => m[1])
+            const hits = list => list.filter(s => heads.some(h => h.startsWith(s))).length
+
+            // 어느 템플릿을 채웠는지로 판정한다. 제목 태그(`[Fix]`)로 보면 안 된다 —
+            // 작업 유형에 fix가 생기면서 [Fix]가 "버그를 신고한다"와 "버그를 고치는
+            // 작업이다" 둘 다 뜻하게 됐다. 제목 태그는 앞으로도 늘어나지만
+            // (Build·Ci·Test·Perf가 그렇게 생겼다) 템플릿의 절 이름은 그대로다.
+            //
+            // 절이 하나쯤 지워져도 판정이 뒤집히지 않도록 개수로 비교한다.
+            // 동수면 작업 요청으로 본다 — 본문이 통째로 비었을 때 더 흔한 쪽이다.
+            const isBug = hits(BUG) > hits(TASK)
+            const required = isBug ? BUG : TASK
+
             const missing = required.filter(s => !heads.some(h => h.startsWith(s)))
 
             // 작업 유형은 있어도 아무것도 체크 안 했으면 빠진 것과 같다


### PR DESCRIPTION
## 작업 내용

이슈 형식 검사가 `[Fix]` 제목을 무조건 버그 리포트로 판정해서, **정상적으로 작성한
작업 요청에 잘못된 지적 댓글**이 달렸습니다. 판정 기준을 제목 태그에서 **본문의 절**로 바꿨습니다.

## 리뷰 포인트

**① 어쩌다 깨졌나** — 같은 이슈(#11) 안에서 순서 때문에 생긴 결함입니다.

| 커밋 | 무엇 |
|---|---|
| `4a86d59` | 워크플로 추가 — 버그 템플릿이 `title: '[Fix] '` 라서 `[Fix]` = 버그로 가정 |
| `d31c6e3` | 작업 유형에 `fix` 추가 — **이때 가정이 깨짐** |

어휘를 통일하면서 그 어휘에 딸린 검사를 같이 고치지 않았습니다.
`#19`에서 실제로 오탐이 났습니다.

**② 왜 제목이 아니라 본문인가** — 제목 태그는 앞으로도 늘어납니다. 오늘만 `[Build]`
`[Ci]` `[Test]` `[Perf]` 넷이 생겼습니다. 태그를 기준으로 두면 태그가 바뀔 때마다 이
워크플로도 같이 고쳐야 하고, 이번처럼 잊습니다. **어떤 템플릿을 채웠는가**는 안 바뀝니다.

**③ 절이 하나 지워져도 안 뒤집히게 했습니다.** 단일 절(`## 버그 개요`)로 판정하면 그
절을 지운 버그 리포트가 작업 요청으로 오인됩니다. 양쪽 절의 **개수를 비교**하고, 동수면
작업 요청으로 봅니다(본문이 통째로 빈 경우 더 흔한 쪽).

**④ 검증** — 판정 로직만 떼어 실제 이슈 본문으로 돌렸습니다.

```
#19 [Fix] 작업요청      판정=작업  누락=없음   ← 오탐이던 것
#15 [Feat] 작업요청     판정=작업  누락=없음
버그 리포트 템플릿       판정=버그  누락=없음   ← 기존 동작 유지
```

머지되면 `#19`의 잘못된 댓글은 이슈를 한 번 수정할 때 자동으로 사라집니다
(`edited` 이벤트에 재검사가 걸려 있고, 통과하면 기존 댓글을 지웁니다).

## 확인

- [x] 로컬에서 동작 확인
- [x] 하나의 PR = 하나의 기능

closes #21