### PR TITLE
[Fix] Fullscreen Auth Layout

### DIFF
--- a/src/features/auth/InviteSignupScreen.tsx
+++ b/src/features/auth/InviteSignupScreen.tsx
@@ -128,8 +128,8 @@ export default function InviteSignup() {
   const copy = invite ? COPY[invite.inviteType] : COPY.MANAGER
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-canvas p-4">
-      <div className="flex w-full max-w-4xl overflow-hidden rounded-lg border border-border bg-white shadow-sm">
+    <div className="flex min-h-screen w-full bg-canvas">
+      <div className="flex w-full bg-surface">
         <BrandPanel title={copy.brandTitle} description={copy.brandDesc} />
 
         <AuthForm title={copy.title} subtitle={copy.subtitle}>

--- a/src/features/auth/LoginScreen.tsx
+++ b/src/features/auth/LoginScreen.tsx
@@ -74,8 +74,8 @@ export default function Login() {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-canvas p-4">
-      <div className="flex w-full max-w-4xl overflow-hidden rounded-lg border border-border bg-white shadow-sm">
+    <div className="flex min-h-screen w-full bg-canvas">
+      <div className="flex w-full bg-surface">
         <BrandPanel />
 
         <AuthForm title="로그인" subtitle="계정 정보를 입력하세요.">


### PR DESCRIPTION
로그인·가입 화면이 가운데 카드로 떠서 넓은 화면에서 여백이 과도했음.
InviteSignup·Login 모두 카드 래퍼를 제거하고 브랜드 패널+폼이
화면 전체를 채우도록 통일함. 폼 로직은 변경 없음.

<!-- 제목 형식: [Feat] Add Login Page UI  (규약 docs/handbook/git-convention.md §3) -->

## 작업 내용
로그인·가입 화면을 가운데 카드에서 전체화면 2단 레이아웃으로 변경.

## 리뷰 포인트
- 레이아웃(바깥 컨테이너 className)만 변경, 폼·검증·상태 로직은 그대로
- Login·InviteSignup 두 화면을 동일한 전체화면 방식으로 통일

## 확인

- [ ] 로컬에서 동작 확인
- [ ] 하나의 PR = 하나의 기능
