### PR TITLE
[Feat] Curriculum List Screen

### DIFF
--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -1,6 +1,7 @@
 import { createBrowserRouter, Navigate, Link, useLocation } from 'react-router'
 import { authRoutes } from '@/features/auth/routes'
 import { dashboardRoutes } from '@/features/dashboard/routes'
+import { curriculumRoutes } from '@/features/curriculum/routes'
 
 /*
   각 도메인이 자기 라우트를 내보내고, 여기서는 합치기만 한다.
@@ -13,6 +14,7 @@ import { dashboardRoutes } from '@/features/dashboard/routes'
 export const router = createBrowserRouter([
   ...authRoutes,
   ...dashboardRoutes,
+  ...curriculumRoutes,
 
   // 진입점. 로그인 후 역할별 초기 화면은 서버가 판정하므로(명세 AUTH-03),
   // 클라이언트는 역할→화면 매핑을 갖지 않는다.

--- a/src/features/curriculum/CurriculumListScreen.tsx
+++ b/src/features/curriculum/CurriculumListScreen.tsx
@@ -84,7 +84,7 @@ export default function CurriculumListScreen() {
       return true
     })
     return filtered.sort((a, b) =>
-      sort === 'NAME' ? a.name.localeCompare(b.name) : b.updatedAt.localeCompare(a.updatedAt),
+      sort === 'NAME' ? a.name.localeCompare(b.name, 'en') : b.updatedAt.localeCompare(a.updatedAt),
     )
   }, [search, statusFilter, topicFilter, projectFilter, sort])
 

--- a/src/features/curriculum/CurriculumListScreen.tsx
+++ b/src/features/curriculum/CurriculumListScreen.tsx
@@ -1,0 +1,240 @@
+import { useMemo, useState } from 'react'
+import ManagerShell from '@/shells/ManagerShell'
+import PageHeader from '@/components/common/PageHeader'
+import { TableFrame, TableToolbar, TableFooter } from '@/components/common/TableFrame'
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from '@/components/ui/Table'
+import { Badge } from '@/components/ui/Badge'
+import { Button } from '@/components/ui/Button'
+import { CURRICULA, type ExtractionStatus } from './mockData'
+import { ExtractionStatusBadge, TopicAssignmentBadge, topicBucket, type TopicBucket } from './components/StatusBadges'
+
+/*
+  SC-M12 · CUR-03 교안 목록. 목업 — API 연동 없이 고정 배열(mockData)을 화면에서
+  직접 검색·필터·정렬한다. 실 연동 시 이 필터 로직은 쿼리 파라미터로 옮겨간다.
+
+  열람=총괄·담당 둘 다 / 저작(등록·재처리·삭제)=총괄만(D91) — isLead가 저작 액션만
+  가린다. 인증이 붙기 전까지 사용자·기수·역할은 대시보드와 같은 방식으로 화면에서 고정한다.
+*/
+
+const SEARCH_PLACEHOLDER = '교안명 · 주제 검색'
+const PILL =
+  'border-border-strong bg-surface-2 text-fg-muted rounded-full border px-3 py-[7px] text-xs'
+
+const STATUS_OPTIONS: { value: 'ALL' | ExtractionStatus; label: string }[] = [
+  { value: 'ALL', label: '전체' },
+  { value: 'EXTRACTED', label: '추출 완료' },
+  { value: 'EXTRACTING', label: '추출 중' },
+  { value: 'EXTRACTION_FAILED', label: '추출 실패' },
+  { value: 'UPLOADED', label: '업로드됨' },
+]
+
+const TOPIC_OPTIONS: { value: 'ALL' | TopicBucket; label: string }[] = [
+  { value: 'ALL', label: '전체' },
+  { value: 'FULL', label: '지정 완료' },
+  { value: 'PARTIAL', label: '부분 지정' },
+  { value: 'NONE', label: '미지정' },
+  { value: 'NA', label: '추출 전' },
+]
+
+const SORT_OPTIONS = [
+  { value: 'RECENT', label: '최근 수정순' },
+  { value: 'NAME', label: '이름순' },
+] as const
+
+export default function CurriculumListScreen() {
+  const isLead = true
+
+  const [search, setSearch] = useState('')
+  const [statusFilter, setStatusFilter] = useState<'ALL' | ExtractionStatus>('ALL')
+  const [topicFilter, setTopicFilter] = useState<'ALL' | TopicBucket>('ALL')
+  const [projectFilter, setProjectFilter] = useState('ALL')
+  const [sort, setSort] = useState<(typeof SORT_OPTIONS)[number]['value']>('RECENT')
+
+  const projectOptions = useMemo(
+    () => Array.from(new Set(CURRICULA.flatMap((c) => c.projects))).sort(),
+    [],
+  )
+
+  const rows = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    const filtered = CURRICULA.filter((c) => {
+      if (q && !`${c.name} ${c.keywords}`.toLowerCase().includes(q)) return false
+      if (statusFilter !== 'ALL' && c.extractionStatus !== statusFilter) return false
+      if (topicFilter !== 'ALL' && topicBucket(c.topicSections, c.totalSections) !== topicFilter)
+        return false
+      if (projectFilter === 'NONE' && c.projects.length > 0) return false
+      if (projectFilter !== 'ALL' && projectFilter !== 'NONE' && !c.projects.includes(projectFilter))
+        return false
+      return true
+    })
+    return filtered.sort((a, b) =>
+      sort === 'NAME' ? a.name.localeCompare(b.name) : b.updatedAt.localeCompare(a.updatedAt),
+    )
+  }, [search, statusFilter, topicFilter, projectFilter, sort])
+
+  return (
+    <ManagerShell user={{ name: '박지현', role: '총괄 매니저' }} cohort="7기" isLead={isLead}>
+      <PageHeader
+        breadcrumb="교안 › 7기"
+        title="교안 관리"
+        count={`총 ${CURRICULA.length}개`}
+        action={isLead && <Button>+ 교안 등록</Button>}
+      />
+
+      <TableFrame>
+        <TableToolbar>
+          <input
+            type="search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder={SEARCH_PLACEHOLDER}
+            className={`${PILL} placeholder:text-fg-subtle w-60 text-fg`}
+          />
+          <select
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value as typeof statusFilter)}
+            className={PILL}
+            aria-label="추출 상태 필터"
+          >
+            {STATUS_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>
+                추출 상태 · {o.label}
+              </option>
+            ))}
+          </select>
+          <select
+            value={topicFilter}
+            onChange={(e) => setTopicFilter(e.target.value as typeof topicFilter)}
+            className={PILL}
+            aria-label="주제 지정 필터"
+          >
+            {TOPIC_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>
+                주제 지정 · {o.label}
+              </option>
+            ))}
+          </select>
+          <select
+            value={projectFilter}
+            onChange={(e) => setProjectFilter(e.target.value)}
+            className={PILL}
+            aria-label="적용 프로젝트 필터"
+          >
+            <option value="ALL">적용 프로젝트 · 전체</option>
+            <option value="NONE">적용 프로젝트 · 미연결</option>
+            {projectOptions.map((p) => (
+              <option key={p} value={p}>
+                적용 프로젝트 · {p}
+              </option>
+            ))}
+          </select>
+          <select
+            value={sort}
+            onChange={(e) => setSort(e.target.value as typeof sort)}
+            className={`${PILL} ml-auto`}
+            aria-label="정렬"
+          >
+            {SORT_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>
+                정렬 · {o.label}
+              </option>
+            ))}
+          </select>
+        </TableToolbar>
+
+        <Table>
+          <TableHeader>
+            <TableRow className="hover:bg-transparent">
+              <TableHead>교안명</TableHead>
+              <TableHead>유형</TableHead>
+              <TableHead>버전</TableHead>
+              <TableHead>추출 상태</TableHead>
+              <TableHead>주제 지정</TableHead>
+              <TableHead>적용 프로젝트</TableHead>
+              <TableHead>최종 수정</TableHead>
+              <TableHead />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={8} className="text-fg-subtle py-8 text-center whitespace-normal">
+                  조건에 맞는 교안이 없습니다.
+                </TableCell>
+              </TableRow>
+            )}
+            {rows.map((c) => (
+              <TableRow key={c.id}>
+                <TableCell className="whitespace-normal">
+                  <p className="text-fg font-bold">
+                    {c.name}
+                    {c.isNew && (
+                      <Badge variant="info" className="ml-1.5 align-middle">
+                        방금 등록
+                      </Badge>
+                    )}
+                  </p>
+                  <p className="text-fg-subtle mt-0.5 text-2xs">{c.keywords}</p>
+                </TableCell>
+                <TableCell className="text-fg-muted text-xs">{c.type}</TableCell>
+                <TableCell className="text-fg-muted font-mono text-xs">{c.version}</TableCell>
+                <TableCell>
+                  <ExtractionStatusBadge status={c.extractionStatus} />
+                </TableCell>
+                <TableCell>
+                  <TopicAssignmentBadge assigned={c.topicSections} total={c.totalSections} />
+                </TableCell>
+                <TableCell className="whitespace-normal">
+                  {c.projects.length === 0 ? (
+                    <span className="text-fg-subtle text-2xs">— 미연결</span>
+                  ) : (
+                    <div className="flex flex-wrap gap-1">
+                      {c.projects.map((p) => (
+                        <Badge key={p} variant="neutral">
+                          {p}
+                        </Badge>
+                      ))}
+                    </div>
+                  )}
+                </TableCell>
+                <TableCell className="text-fg-subtle text-xs tabular-nums">{c.updatedAt}</TableCell>
+                <TableCell className="text-right">
+                  {isLead && (
+                    <div className="flex items-center justify-end gap-1.5">
+                      {c.extractionStatus === 'EXTRACTED' && (
+                        <Button variant="ghost" size="sm">
+                          주제 확인 →
+                        </Button>
+                      )}
+                      {c.extractionStatus === 'EXTRACTION_FAILED' && (
+                        <Button variant="ghost" size="sm">
+                          재처리
+                        </Button>
+                      )}
+                      <Button variant="ghost" size="sm" aria-label="더 보기">
+                        ⋯
+                      </Button>
+                    </div>
+                  )}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+
+        <TableFooter range={`${rows.length}개 중 1–${rows.length}`}>
+          <span className="bg-primary rounded-md px-2 py-0.5 text-xs font-semibold text-white">
+            1
+          </span>
+        </TableFooter>
+      </TableFrame>
+    </ManagerShell>
+  )
+}

--- a/src/features/curriculum/CurriculumListScreen.tsx
+++ b/src/features/curriculum/CurriculumListScreen.tsx
@@ -13,7 +13,12 @@ import {
 import { Badge } from '@/components/ui/Badge'
 import { Button } from '@/components/ui/Button'
 import { CURRICULA, type ExtractionStatus } from './mockData'
-import { ExtractionStatusBadge, TopicAssignmentBadge, topicBucket, type TopicBucket } from './components/StatusBadges'
+import {
+  ExtractionStatusBadge,
+  TopicAssignmentBadge,
+  topicBucket,
+  type TopicBucket,
+} from './components/StatusBadges'
 
 /*
   SC-M12 · CUR-03 교안 목록. 목업 — API 연동 없이 고정 배열(mockData)을 화면에서
@@ -70,7 +75,11 @@ export default function CurriculumListScreen() {
       if (topicFilter !== 'ALL' && topicBucket(c.topicSections, c.totalSections) !== topicFilter)
         return false
       if (projectFilter === 'NONE' && c.projects.length > 0) return false
-      if (projectFilter !== 'ALL' && projectFilter !== 'NONE' && !c.projects.includes(projectFilter))
+      if (
+        projectFilter !== 'ALL' &&
+        projectFilter !== 'NONE' &&
+        !c.projects.includes(projectFilter)
+      )
         return false
       return true
     })
@@ -165,7 +174,10 @@ export default function CurriculumListScreen() {
           <TableBody>
             {rows.length === 0 && (
               <TableRow>
-                <TableCell colSpan={8} className="text-fg-subtle py-8 text-center whitespace-normal">
+                <TableCell
+                  colSpan={8}
+                  className="text-fg-subtle py-8 text-center whitespace-normal"
+                >
                   조건에 맞는 교안이 없습니다.
                 </TableCell>
               </TableRow>

--- a/src/features/curriculum/components/StatusBadges.tsx
+++ b/src/features/curriculum/components/StatusBadges.tsx
@@ -35,7 +35,13 @@ const TOPIC_VARIANT: Record<Exclude<TopicBucket, 'NA'>, 'success' | 'warning' | 
   NONE: 'info',
 }
 
-export function TopicAssignmentBadge({ assigned, total }: { assigned: number | null; total: number | null }) {
+export function TopicAssignmentBadge({
+  assigned,
+  total,
+}: {
+  assigned: number | null
+  total: number | null
+}) {
   const bucket = topicBucket(assigned, total)
   if (bucket === 'NA') return <span className="text-fg-subtle text-2xs">—</span>
   return (

--- a/src/features/curriculum/components/StatusBadges.tsx
+++ b/src/features/curriculum/components/StatusBadges.tsx
@@ -1,0 +1,46 @@
+import { Badge } from '@/components/ui/Badge'
+import type { ExtractionStatus } from '../mockData'
+
+const EXTRACTION_LABEL: Record<ExtractionStatus, string> = {
+  UPLOADED: '업로드됨',
+  EXTRACTING: '추출 중…',
+  EXTRACTED: '추출 완료',
+  EXTRACTION_FAILED: '추출 실패',
+}
+
+const EXTRACTION_VARIANT: Record<ExtractionStatus, 'info' | 'danger' | 'neutral'> = {
+  UPLOADED: 'neutral',
+  EXTRACTING: 'info',
+  EXTRACTED: 'info',
+  EXTRACTION_FAILED: 'danger',
+}
+
+export function ExtractionStatusBadge({ status }: { status: ExtractionStatus }) {
+  return <Badge variant={EXTRACTION_VARIANT[status]}>{EXTRACTION_LABEL[status]}</Badge>
+}
+
+export type TopicBucket = 'NA' | 'NONE' | 'PARTIAL' | 'FULL'
+
+/** 주제 지정 상태 — 필터·배지가 같은 기준을 쓰도록 여기서 한 번만 판정한다 */
+export function topicBucket(assigned: number | null, total: number | null): TopicBucket {
+  if (total == null) return 'NA'
+  if (assigned === total) return 'FULL'
+  if (assigned === 0) return 'NONE'
+  return 'PARTIAL'
+}
+
+const TOPIC_VARIANT: Record<Exclude<TopicBucket, 'NA'>, 'success' | 'warning' | 'info'> = {
+  FULL: 'success',
+  PARTIAL: 'warning',
+  NONE: 'info',
+}
+
+export function TopicAssignmentBadge({ assigned, total }: { assigned: number | null; total: number | null }) {
+  const bucket = topicBucket(assigned, total)
+  if (bucket === 'NA') return <span className="text-fg-subtle text-2xs">—</span>
+  return (
+    <Badge variant={TOPIC_VARIANT[bucket]}>
+      {assigned} / {total} 섹션
+    </Badge>
+  )
+}

--- a/src/features/curriculum/mockData.ts
+++ b/src/features/curriculum/mockData.ts
@@ -1,0 +1,98 @@
+/*
+  CUR-03 교안 목록 목업 데이터. API 연동 전까지 화면을 검증하기 위한 고정 배열이다.
+  실 데이터가 붙으면 이 파일은 지운다.
+*/
+export type ExtractionStatus = 'UPLOADED' | 'EXTRACTING' | 'EXTRACTED' | 'EXTRACTION_FAILED'
+
+export type CurriculumRow = {
+  id: string
+  name: string
+  /** 부제 — 추출 키워드 요약 · 페이지 수 */
+  keywords: string
+  type: 'PDF'
+  version: string
+  extractionStatus: ExtractionStatus
+  /** 주제 지정된 섹션 수. 추출 완료 전에는 null(표시 대상 아님) */
+  topicSections: number | null
+  totalSections: number | null
+  /** 적용 프로젝트 — 빈 배열 = 미연결(기수 전체 자동 검색 대상, D103) */
+  projects: string[]
+  updatedAt: string
+  isNew?: boolean
+}
+
+export const CURRICULA: CurriculumRow[] = [
+  {
+    id: 'cur-1',
+    name: 'Kubernetes와 CICD',
+    keywords: 'K8s 아키텍처 · 컨테이너 배포 · Service/Ingress · CICD · 76p',
+    type: 'PDF',
+    version: 'v2',
+    extractionStatus: 'EXTRACTED',
+    topicSections: 5,
+    totalSections: 6,
+    projects: ['MSA 배포 실습'],
+    updatedAt: '06-18',
+  },
+  {
+    id: 'cur-2',
+    name: '클라우드 현대화 이해 서비스',
+    keywords: '클라우드 네이티브 · IaaS/PaaS/SaaS · 마이그레이션 · 151p',
+    type: 'PDF',
+    version: 'v1',
+    extractionStatus: 'EXTRACTED',
+    topicSections: 8,
+    totalSections: 8,
+    projects: ['클라우드 전환 PJT'],
+    updatedAt: '06-19',
+  },
+  {
+    id: 'cur-3',
+    name: 'AWS 핵심 서비스',
+    keywords: 'EC2 · VPC · IAM · S3 · RDS',
+    type: 'PDF',
+    version: 'v3',
+    extractionStatus: 'EXTRACTED',
+    topicSections: 0,
+    totalSections: 5,
+    projects: ['클라우드 전환 PJT', 'MSA 배포 실습'],
+    updatedAt: '06-15',
+  },
+  {
+    id: 'cur-4',
+    name: 'Docker 컨테이너 기초',
+    keywords: '이미지 · 레지스트리 · Dockerfile',
+    type: 'PDF',
+    version: 'v1',
+    extractionStatus: 'EXTRACTION_FAILED',
+    topicSections: null,
+    totalSections: null,
+    projects: ['MSA 배포 실습'],
+    updatedAt: '06-12',
+  },
+  {
+    id: 'cur-5',
+    name: 'Microservice 아키텍처',
+    keywords: '서비스 분해 · API 게이트웨이 · 사가',
+    type: 'PDF',
+    version: 'v1',
+    extractionStatus: 'EXTRACTING',
+    topicSections: null,
+    totalSections: null,
+    projects: [],
+    updatedAt: '06-19',
+  },
+  {
+    id: 'cur-6',
+    name: 'Terraform IaC 입문',
+    keywords: 'HCL · provider · state',
+    type: 'PDF',
+    version: 'v1',
+    extractionStatus: 'UPLOADED',
+    topicSections: null,
+    totalSections: null,
+    projects: [],
+    updatedAt: '06-19',
+    isNew: true,
+  },
+]

--- a/src/features/curriculum/routes.tsx
+++ b/src/features/curriculum/routes.tsx
@@ -1,0 +1,10 @@
+import type { RouteObject } from 'react-router'
+import CurriculumListScreen from './CurriculumListScreen'
+
+/*
+  경로 규약은 `/{역할}/{화면}` — dashboard와 동일. managerNav.ts의 '교안' 항목과
+  경로가 일치해야 좌측 네비에서 열린다.
+*/
+export const curriculumRoutes: RouteObject[] = [
+  { path: '/manager/curriculum', element: <CurriculumListScreen /> }, // SC-M12
+]


### PR DESCRIPTION
## 작업 내용
SC-M12 교안 관리 중 목록 화면(CUR-03)을 목업으로 구현.
API 연동 없이 Mock 데이터를 화면에서 직접 검색·필터·정렬한다.

## 리뷰 포인트
- ManagerShell·PageHeader·TableFrame·Table·Badge·Button 등 기존 공용 컴포넌트 재사용,
  교안 전용은 features/curriculum/components(StatusBadges)에만 둠
- 추출 상태·주제 지정 배지 색을 명세 기준으로 매핑
  (완료·중 info / 실패 danger / 업로드됨 neutral, 주제 N/N success·부분 warning·0 info)
- topicBucket()으로 필터와 배지가 같은 판정 기준을 공유해 어긋남을 방지
- 저작 액션(등록·재처리·⋯)은 isLead로 게이팅 (열람=총괄·담당, 저작=총괄만)
- 필터·검색은 shadcn Select·Input 승인 대기 중이라 임시로 기본 요소 사용,
  승인 후 교체 예정

## 남은 것 (이번 범위 밖)
- 교안 등록·상세 화면 (+ 교안 등록 / 주제 확인 버튼은 아직 미연결)

closes #14