### PR TITLE
[Fix] Center Login Form Layout

### DIFF
--- a/src/features/auth/components/AuthForm.tsx
+++ b/src/features/auth/components/AuthForm.tsx
@@ -9,10 +9,12 @@ interface Props {
 /** SC-A01 §3 · 우 폼 패널 컨테이너 (SC-A02·A03에서도 재사용) */
 export default function AuthForm({ title, subtitle, children }: Props) {
   return (
-    <div className="w-full p-8 sm:p-10 md:w-1/2">
-      <h2 className="text-xl font-bold text-fg">{title}</h2>
-      {subtitle && <p className="mt-1 text-[13px] text-fg-subtle">{subtitle}</p>}
-      <div className="mt-6">{children}</div>
+    <div className="flex w-full flex-col justify-center p-8 sm:p-10 md:w-1/2">
+      <div className="mx-auto w-full max-w-sm">
+        <h2 className="text-xl font-bold text-fg">{title}</h2>
+        {subtitle && <p className="mt-1 text-[13px] text-fg-subtle">{subtitle}</p>}
+        <div className="mt-6">{children}</div>
+      </div>
     </div>
   )
 }

--- a/src/features/auth/components/BrandPanel.tsx
+++ b/src/features/auth/components/BrandPanel.tsx
@@ -21,16 +21,18 @@ export default function BrandPanel({
   meta = '교육 운영기관 전용 · 초대 기반 계정',
 }: Props) {
   return (
-    <div className="hidden flex-col justify-center bg-[linear-gradient(150deg,var(--color-brand-1),var(--color-brand-2))] p-10 text-white md:flex md:w-1/2">
-      <div className="mb-10">
-        <Wordmark light />
+    <div className="hidden flex-col items-center justify-center bg-[linear-gradient(150deg,var(--color-brand-1),var(--color-brand-2))] p-10 text-white md:flex md:w-1/2">
+      <div className="w-full max-w-md">
+        <div className="mb-10">
+          <Wordmark light />
+        </div>
+
+        <h1 className="text-[26px] font-bold leading-snug">{title}</h1>
+
+        <p className="mt-5 text-sm leading-relaxed text-white/70">{description}</p>
+
+        <p className="mt-10 text-xs text-white/45">{meta}</p>
       </div>
-
-      <h1 className="text-[26px] font-bold leading-snug">{title}</h1>
-
-      <p className="mt-5 text-sm leading-relaxed text-white/70">{description}</p>
-
-      <p className="mt-10 text-xs text-white/45">{meta}</p>
     </div>
   )
 }


### PR DESCRIPTION
## 작업 내용
로그인 화면의 폼과 브랜드 패널을 가운데로 모아 좌우 균형을 맞춤.
컴포넌트 교체 없이 배치(className)만 수정.

## 리뷰 포인트
- AuthForm: 폼을 max-w-sm로 제한, 세로·가로 가운데 정렬
- BrandPanel: 콘텐츠에 max-w-md, 가로 가운데
- 폼 로직·컴포넌트는 변경 없음

closes #31