### PR TITLE
[Feat] Curriculum Detail Screen with Section Topics and Coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ dist-ssr
 # 스크린샷·브라우저 도구 산출물 (루트 오염 방지)
 /*.png
 .playwright-mcp/
+
+# 세션 간 인수인계 메모 (로컬 전용, 공유 안 함)
+docs/dev/handoff.md

--- a/src/features/curriculum/CurriculumDetailScreen.tsx
+++ b/src/features/curriculum/CurriculumDetailScreen.tsx
@@ -1,0 +1,209 @@
+import type { ReactNode } from 'react'
+import { Link, useParams } from 'react-router'
+import { ArrowLeft, RotateCwIcon } from 'lucide-react'
+import ManagerShell from '@/shells/ManagerShell'
+import PageHeader from '@/components/common/PageHeader'
+import { Card } from '@/components/ui/Card'
+import { Button } from '@/components/ui/Button'
+import { TableFrame } from '@/components/common/TableFrame'
+import { CURRICULA, CURRICULUM_DETAILS, type ExtractionStatus } from './mockData'
+import { ExtractionStatusBadge } from './components/StatusBadges'
+import SectionTopicTable from './components/SectionTopicTable'
+import CoverageSummary from './components/CoverageSummary'
+
+/*
+  SC-M12 · CUR-01+CUR-02 교안 상세(D103 통합 1화면). 목록 행(교안명·"주제 확인 →")으로 진입.
+
+  위→아래로 ①섹션·주제 표 ②커버리지 요약 ③범위 좁히기 안내 ④축→섹션 위치 고정
+  규칙. 구 '교안 연결' 탭은 교안 구성과 중복이라 이 한 화면으로 합쳤다(D103).
+
+  열람은 총괄·담당 둘 다, 저작(재분석·주제 편집)은 총괄만(D91) — isLead가 저작만
+  가린다. 인증이 붙기 전까지 역할은 목록 화면과 같은 방식으로 고정한다.
+
+  ★ 화면에 없는 것(D93 삭제): 추출 신뢰도 바·폴백 배지·"AI 제안" 표시·evidence
+  덤프. 추출 내부(신뢰도·refine·청크)는 telemetry라 매니저 화면에 노출하지 않는다.
+
+  레이아웃: 콘텐츠를 중앙 max-w-5xl로 모아 양옆 여백을 준다(넓은 모니터에서 오른쪽이
+  휑해 보이지 않게). 뒤로가기는 등록 화면과 같은 큰 화살표 버튼 패턴을 재사용한다.
+*/
+
+// 축 → 섹션 내 위치 규칙. 고정값이고 편집 대상이 아니다(D94). 리포트 시점에 학생의
+// 취약 (주제,축)으로 섹션 안 위치를 안내할 때 쓰는 규칙을 그대로 보여준다.
+const AXIS_RULES: { axis: string; location: string }[] = [
+  { axis: '반례대응', location: '주의 · 반례 부분' },
+  { axis: '코드이해', location: '개념 설명 부분' },
+  { axis: '대안비교', location: '비교 · 트레이드오프 부분' },
+  { axis: '자기수정', location: '복구 · 수정 부분' },
+  { axis: '의사소통', location: '교안 위치 안내 대상 아님(코드 설명 능력)' },
+]
+
+const COHORT_LABEL = '7기'
+const USER = { name: '박지현', role: '총괄 매니저' }
+
+export default function CurriculumDetailScreen() {
+  const { id = '' } = useParams()
+  const isLead = true
+
+  const curriculum = CURRICULA.find((c) => c.id === id)
+  const detail = CURRICULUM_DETAILS[id]
+
+  if (!curriculum) {
+    return (
+      <ManagerShell user={USER} cohort={COHORT_LABEL} isLead={isLead}>
+        <div className="mx-auto max-w-5xl">
+          <BackRow title="교안 상세" />
+          <Card className="items-center gap-2 p-10 text-center">
+            <p className="text-lg font-semibold">교안을 찾을 수 없습니다</p>
+            <p className="text-fg-subtle text-sm">삭제되었거나 잘못된 주소일 수 있습니다.</p>
+          </Card>
+        </div>
+      </ManagerShell>
+    )
+  }
+
+  const status = curriculum.extractionStatus
+  // 추출이 끝나 섹션·주제 데이터가 있을 때만 표·커버리지·규칙을 보여준다.
+  const showStructure = status === 'EXTRACTED' && !!detail
+
+  return (
+    <ManagerShell user={USER} cohort={COHORT_LABEL} isLead={isLead}>
+      <div className="mx-auto max-w-5xl">
+        {/* 뒤로가기 + 교안명(제목) + 버전 + 상태 — 등록 화면과 같은 큰 버튼 패턴 */}
+        <BackRow title={curriculum.name}>
+          <span className="text-fg-muted font-mono text-sm font-normal">{curriculum.version}</span>
+          <ExtractionStatusBadge status={status} />
+          {detail && (
+            <span className="text-fg-subtle text-sm">· {detail.sections.length}개 섹션</span>
+          )}
+          {isLead && (status === 'EXTRACTED' || status === 'EXTRACTION_FAILED') && (
+            <Button variant="ghost" size="sm" className="ml-auto">
+              <RotateCwIcon />
+              재분석
+            </Button>
+          )}
+        </BackRow>
+        <p className="text-fg-subtle mb-6 text-sm">
+          {curriculum.type} · 최종 수정 {curriculum.updatedAt}
+        </p>
+
+        {showStructure ? (
+          <div className="flex flex-col gap-8">
+            {/* 안내 — 프로젝트 연결 없이도 기수 전체에서 위치를 찾는다는 것을 알린다(D103) */}
+            <p className="text-fg-muted text-base">
+              주제는 자동으로 추출됩니다. 이 기수 학생이 그 주제에서 막히면 이 교안 위치가
+              안내됩니다 — 프로젝트 연결은 필요 없습니다. 틀린 주제만 고치세요.
+            </p>
+
+            {/* ① 섹션·주제 표 */}
+            <TableFrame>
+              <SectionTopicTable sections={detail.sections} editable={isLead} />
+            </TableFrame>
+
+            {/* ② 커버리지 요약 */}
+            <CoverageSummary
+              cohortLabel={COHORT_LABEL}
+              total={detail.cohortTopicTotal}
+              covered={detail.coveredCount}
+              uncovered={detail.uncoveredTopics}
+            />
+
+            {/* ③ 범위 좁히기 안내 — 기본은 기수 전체, 링크는 선택적 좁히기(D103) */}
+            <p className="text-fg-subtle text-sm">
+              특정 프로젝트만 이 교안으로 한정하려면{' '}
+              <b className="text-fg-muted">[프로젝트] → 개요 → 적용 교안</b>에서 지정하세요.
+              지정하지 않으면 기수 전체 교안에서 자동으로 가장 맞는 위치를 찾습니다.
+            </p>
+
+            {/* ④ 축 → 섹션 내 위치 고정 규칙 */}
+            <div className="border-border bg-surface-2 rounded-md border p-6">
+              <div className="mb-4 flex items-center gap-2">
+                <h4 className="text-base font-semibold">축 → 섹션 내 위치 규칙</h4>
+                <span className="border-border-strong text-fg-subtle rounded-full border bg-white px-2.5 py-0.5 text-xs font-semibold">
+                  고정 · 편집 대상 아님
+                </span>
+              </div>
+              <div className="flex flex-wrap gap-2.5">
+                {AXIS_RULES.map((r) => (
+                  <span
+                    key={r.axis}
+                    className="border-border text-fg-muted inline-flex items-center gap-1.5 rounded-full border bg-white px-3.5 py-1.5 text-sm"
+                  >
+                    <b className="text-fg">{r.axis}</b>→<span>{r.location}</span>
+                  </span>
+                ))}
+              </div>
+            </div>
+          </div>
+        ) : (
+          <StructurePending status={status} isLead={isLead} />
+        )}
+      </div>
+    </ManagerShell>
+  )
+}
+
+/*
+  뒤로가기(큰 화살표) + 제목 한 줄. 등록 화면(CurriculumUploadScreen)의 패턴을
+  그대로 따른다 — PageHeader의 h1은 접근성용으로 sr-only, 시각 제목은 이 줄에 둔다.
+*/
+function BackRow({ title, children }: { title: string; children?: ReactNode }) {
+  return (
+    <>
+      <div className="[&_h1]:sr-only">
+        <PageHeader breadcrumb="교안 목록 › 교안 상세" title="교안 상세" />
+      </div>
+      <div className="mt-2 mb-2 flex items-center gap-2.5">
+        <Button
+          variant="ghost"
+          size="sm"
+          aria-label="교안 목록으로 돌아가기"
+          nativeButton={false}
+          render={<Link to="/manager/curriculum" />}
+          className="p-1.5"
+        >
+          <ArrowLeft className="size-5" />
+        </Button>
+        <span className="text-fg text-xl font-bold tracking-[-0.01em]">{title}</span>
+        {children}
+      </div>
+    </>
+  )
+}
+
+// 추출이 끝나지 않았거나(대기·진행) 실패했거나, 추출은 됐지만 상세 데이터를 못 불러온
+// 교안 — 표 대신 상태별 안내만 보여준다.
+function StructurePending({ status, isLead }: { status: ExtractionStatus; isLead: boolean }) {
+  const COPY: Record<ExtractionStatus, { title: string; body: string }> = {
+    UPLOADED: {
+      title: '구조 분석 대기 중',
+      body: '업로드가 끝났습니다. 곧 구조 추출이 시작되면 섹션과 주제가 표시됩니다.',
+    },
+    EXTRACTING: {
+      title: '구조 분석 중…',
+      body: '교안에서 섹션 경계를 추출하고 있습니다. 완료되면 섹션·주제 표가 나타납니다.',
+    },
+    EXTRACTION_FAILED: {
+      title: '구조 추출 실패',
+      body: '이 교안은 구조를 추출하지 못했습니다. 재분석하거나 목록에서 삭제할 수 있습니다.',
+    },
+    // 추출은 완료됐는데 섹션 데이터를 못 불러온 경우(정상 흐름에선 발생하지 않음).
+    EXTRACTED: {
+      title: '섹션 정보를 불러올 수 없습니다',
+      body: '추출은 완료됐지만 섹션·주제 데이터를 불러오지 못했습니다. 잠시 후 다시 시도하세요.',
+    },
+  }
+  const { title, body } = COPY[status]
+
+  return (
+    <Card className="items-center gap-2 p-10 text-center">
+      <p className="text-lg font-semibold">{title}</p>
+      <p className="text-fg-subtle max-w-md text-sm">{body}</p>
+      {status === 'EXTRACTION_FAILED' && isLead && (
+        <Button variant="ghost" size="sm" className="mt-2">
+          <RotateCwIcon />
+          재분석
+        </Button>
+      )}
+    </Card>
+  )
+}

--- a/src/features/curriculum/CurriculumListScreen.tsx
+++ b/src/features/curriculum/CurriculumListScreen.tsx
@@ -262,8 +262,15 @@ export default function CurriculumListScreen() {
             {rows.map((c) => (
               <TableRow key={c.id}>
                 <TableCell className="whitespace-normal">
-                  <p className="text-fg font-bold">
-                    {c.name}
+                  <p className="font-bold">
+                    {/* 교안명 클릭 = 상세 진입(SC-M12 §7 "목록 행 클릭 → 진입"). 상세는
+                        모든 추출 상태를 처리하므로 EXTRACTED가 아니어도 링크한다. */}
+                    <Link
+                      to={`/manager/curriculum/${c.id}`}
+                      className="text-fg hover:text-primary hover:underline"
+                    >
+                      {c.name}
+                    </Link>
                     {c.isNew && (
                       <Badge variant="info" className="ml-1.5 align-middle">
                         방금 등록
@@ -298,7 +305,12 @@ export default function CurriculumListScreen() {
                   {isLead && (
                     <div className="flex items-center justify-end gap-1.5">
                       {c.extractionStatus === 'EXTRACTED' && (
-                        <Button variant="ghost" size="sm">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          nativeButton={false}
+                          render={<Link to={`/manager/curriculum/${c.id}`} />}
+                        >
                           주제 확인 →
                         </Button>
                       )}

--- a/src/features/curriculum/components/CoverageSummary.tsx
+++ b/src/features/curriculum/components/CoverageSummary.tsx
@@ -1,0 +1,59 @@
+import { Card } from '@/components/ui/Card'
+
+/*
+  SC-M12 · CUR-02 커버리지 요약.
+
+  "이 기수 프로젝트가 측정하는 주제 N개 중 M개를 이 교안이 커버"를 보여준다.
+  전적으로 읽기다 — 자동 계산이고 매니저 액션이 없다(§6 CUR-02 case 5).
+
+  미커버 주제는 "한 교안이 전부 커버할 필요 없음"이라 오류가 아니라, 기수에 교안을
+  더 올리라는 커버리지 신호다(D103). 그래서 위험(danger)이 아니라 주의(warning)
+  색으로, "교안 추가 권장" 문구와 함께 보여준다.
+*/
+type Props = {
+  /** 기수 라벨. 예: "7기" */
+  cohortLabel: string
+  /** 이 기수 프로젝트가 측정하는 전체 주제 수 */
+  total: number
+  /** 그중 이 교안이 커버하는 수 */
+  covered: number
+  /** 이 기수 어느 교안도 안 다루는 주제 */
+  uncovered: string[]
+}
+
+export default function CoverageSummary({ cohortLabel, total, covered, uncovered }: Props) {
+  return (
+    <Card className="gap-4 p-6">
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <h3 className="text-base font-semibold">커버리지 요약</h3>
+        <span className="text-fg-subtle text-xs">자동 계산 · 매니저 액션 없음</span>
+      </div>
+
+      <p className="text-fg-muted text-base">
+        이 기수({cohortLabel}) 프로젝트가 측정하는 주제{' '}
+        <b className="text-fg tabular-nums">{total}개</b> 중{' '}
+        <b className="text-primary tabular-nums">{covered}개</b>를 이 교안이 커버합니다.
+      </p>
+
+      {uncovered.length === 0 ? (
+        <p className="text-success text-sm">이 기수 측정 주제를 모두 커버합니다.</p>
+      ) : (
+        <div className="flex flex-col gap-2">
+          <p className="text-fg-subtle text-xs">
+            미커버 — 이 기수 교안 어디에도 없음 · 교안 추가 권장
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {uncovered.map((topic) => (
+              <span
+                key={topic}
+                className="bg-warning-soft text-warning border-warning-border inline-flex items-center rounded-full border px-3 py-1.5 text-sm"
+              >
+                {topic}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+    </Card>
+  )
+}

--- a/src/features/curriculum/components/SectionTopicTable.tsx
+++ b/src/features/curriculum/components/SectionTopicTable.tsx
@@ -1,0 +1,182 @@
+import { useState } from 'react'
+import { XIcon, PlusIcon } from 'lucide-react'
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from '@/components/ui/Table'
+import { Input } from '@/components/ui/Input'
+import type { Section } from '../mockData'
+
+/*
+  SC-M12 · CUR-01+CUR-02 교안 상세의 섹션·주제 표.
+
+  주제 칩은 D102 "AI 기본값 + 사람 편집" 모델이다 — AI가 추출 키워드로 초안을
+  채워두고, 총괄이 훑어 틀린 칩만 ✕ 하거나 + 로 더한다. 신뢰도·"AI 제안" 배지는
+  화면에 절대 노출하지 않는다(GOV-03·D102). 그래서 이 컴포넌트는 topics를 그냥
+  문자열 배열로만 다루고, 어느 것이 AI 초안인지 구분하지 않는다.
+
+  API 연동 전이라 편집은 로컬 상태(useState)로만 유지된다. 실 연동 시 추가/삭제는
+  POST/DELETE /curriculum/{cid}/sections/{sid}/topics 로 즉시 저장된다(별도 확정
+  액션 없음 — §7). 열람은 양쪽이지만 편집(저작)은 총괄만(D91)이라 editable로 가린다.
+
+  중복 주제는 저장 차단(CUR-02 case 7). 판정은 대소문자를 무시한다("Pod"와 "pod"는
+  같은 주제). 중복이면 입력을 지우지 않고 그대로 둔 채 빨간 테두리 + 안내를 띄우고,
+  한 글자라도 바뀌면 다시 평상 상태로 돌린다.
+*/
+type Props = {
+  sections: Section[]
+  /** 저작 권한(총괄). false면 칩은 읽기 전용 — ✕·+ 미표시 */
+  editable: boolean
+}
+
+export default function SectionTopicTable({ sections, editable }: Props) {
+  // 섹션별 주제 목록을 로컬로 들고 편집한다. 초기값은 목업 props.
+  const [topicsBySection, setTopicsBySection] = useState<Record<string, string[]>>(() =>
+    Object.fromEntries(sections.map((s) => [s.id, s.topics])),
+  )
+  // 지금 +입력창이 열린 섹션 id. null이면 모두 닫힘.
+  const [addingFor, setAddingFor] = useState<string | null>(null)
+  const [draft, setDraft] = useState('')
+  // 중복 입력 상태 — true면 빨간 테두리 + 안내. 입력이 바뀌면 false로 되돌린다.
+  const [duplicate, setDuplicate] = useState(false)
+
+  function isDuplicate(sectionId: string, value: string) {
+    const norm = value.trim().toLowerCase()
+    return topicsBySection[sectionId].some((t) => t.toLowerCase() === norm)
+  }
+
+  function removeTopic(sectionId: string, topic: string) {
+    setTopicsBySection((prev) => ({
+      ...prev,
+      [sectionId]: prev[sectionId].filter((t) => t !== topic),
+    }))
+  }
+
+  function openAdd(sectionId: string) {
+    setDraft('')
+    setDuplicate(false)
+    setAddingFor(sectionId)
+  }
+
+  function closeAdd() {
+    setDraft('')
+    setDuplicate(false)
+    setAddingFor(null)
+  }
+
+  function commitAdd(sectionId: string) {
+    const value = draft.trim()
+    if (!value) {
+      closeAdd()
+      return
+    }
+    // 대소문자 무시 중복이면 지우지 않고 안내만 — 사용자가 값을 고칠 수 있게 연다.
+    if (isDuplicate(sectionId, value)) {
+      setDuplicate(true)
+      return
+    }
+    setTopicsBySection((prev) => ({
+      ...prev,
+      [sectionId]: [...prev[sectionId], value],
+    }))
+    closeAdd()
+  }
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow className="hover:bg-transparent">
+          <TableHead className="w-56 text-sm">섹션</TableHead>
+          <TableHead className="w-40 pr-10 text-sm">페이지</TableHead>
+          <TableHead className="pl-2 text-sm">다루는 주제</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {sections.map((section) => {
+          const topics = topicsBySection[section.id]
+          const isAdding = addingFor === section.id
+          return (
+            <TableRow key={section.id} className="hover:bg-transparent">
+              <TableCell className="text-fg align-top text-base font-semibold whitespace-normal">
+                {section.name}
+              </TableCell>
+              <TableCell className="text-fg-muted pr-10 align-top font-mono text-sm tabular-nums">
+                {section.pageRange}
+              </TableCell>
+              <TableCell className="pl-2 whitespace-normal">
+                <div className="flex flex-wrap items-start gap-2">
+                  {topics.length === 0 && !isAdding && (
+                    <span className="text-fg-subtle py-1 text-sm">
+                      아직 지정된 주제가 없습니다.
+                    </span>
+                  )}
+
+                  {topics.map((topic) => (
+                    <span
+                      key={topic}
+                      className="border-border-strong bg-surface-2 text-fg inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm"
+                    >
+                      {topic}
+                      {editable && (
+                        <button
+                          type="button"
+                          aria-label={`${topic} 주제 삭제`}
+                          onClick={() => removeTopic(section.id, topic)}
+                          className="text-fg-subtle hover:text-danger cursor-pointer leading-none"
+                        >
+                          <XIcon className="size-3.5" />
+                        </button>
+                      )}
+                    </span>
+                  ))}
+
+                  {editable &&
+                    (isAdding ? (
+                      <div className="flex flex-col gap-1">
+                        <Input
+                          autoFocus
+                          value={draft}
+                          aria-invalid={duplicate}
+                          onChange={(e) => {
+                            setDraft(e.target.value)
+                            // 한 글자라도 바뀌면 중복 경고를 푼다(파란 테두리 복귀).
+                            if (duplicate) setDuplicate(false)
+                          }}
+                          onBlur={() => commitAdd(section.id)}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter') commitAdd(section.id)
+                            if (e.key === 'Escape') closeAdd()
+                          }}
+                          placeholder="주제 입력 후 Enter"
+                          aria-label={`${section.name} 주제 추가`}
+                          className="h-8 w-44 text-sm"
+                        />
+                        {duplicate && (
+                          <span role="alert" className="text-danger text-xs">
+                            같은 이름의 주제가 있습니다.
+                          </span>
+                        )}
+                      </div>
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={() => openAdd(section.id)}
+                        className="border-border-strong text-primary hover:bg-canvas inline-flex cursor-pointer items-center gap-1 rounded-full border border-dashed bg-white px-3 py-1.5 text-sm"
+                      >
+                        <PlusIcon className="size-3.5" />
+                        추가
+                      </button>
+                    ))}
+                </div>
+              </TableCell>
+            </TableRow>
+          )
+        })}
+      </TableBody>
+    </Table>
+  )
+}

--- a/src/features/curriculum/mockData.ts
+++ b/src/features/curriculum/mockData.ts
@@ -96,3 +96,124 @@ export const CURRICULA: CurriculumRow[] = [
     isNew: true,
   },
 ]
+
+/*
+  CUR-01+CUR-02 교안 상세 목업. 교안별 섹션·주제(SectionTopic)와 기수 커버리지.
+  주제 칩은 화면에서 로컬 상태로 편집한다 — 실 연동 시 GET /curriculum/{cid}/structure
+  와 GET /cohorts/{id}/curriculum/coverage 응답으로 대체된다.
+
+  D102: 주제는 AI가 추출 키워드로 초안을 채우지만, 신뢰도·"AI 제안" 배지는 화면에
+  절대 노출하지 않는다(폼 자동완성처럼). 여기 데이터에도 그런 필드를 두지 않는다.
+*/
+export type Section = {
+  id: string
+  name: string
+  /** 페이지 범위. 예: "p.5–20" */
+  pageRange: string
+  /** 다루는 주제 칩. 추출 키워드로 자동 채움 + 총괄 편집 */
+  topics: string[]
+}
+
+export type CurriculumDetail = {
+  /** 추출된 섹션 인덱스 */
+  sections: Section[]
+  /** 이 기수 프로젝트가 측정하는 전체 주제 수 */
+  cohortTopicTotal: number
+  /** 그중 이 교안이 커버하는 주제 수 */
+  coveredCount: number
+  /** 이 기수 어느 교안도 안 다루는 주제 — 커버리지 요약의 "미커버" 목록 */
+  uncoveredTopics: string[]
+}
+
+/*
+  추출 완료(EXTRACTED) 교안만 상세 데이터를 갖는다. EXTRACTING·UPLOADED·
+  EXTRACTION_FAILED 교안은 상세 화면에서 상태별 안내만 보여주고 표는 없다.
+*/
+export const CURRICULUM_DETAILS: Record<string, CurriculumDetail> = {
+  'cur-1': {
+    sections: [
+      {
+        id: 's1',
+        name: 'Kubernetes 아키텍처',
+        pageRange: 'p.5–20',
+        topics: ['Master/Worker Node', 'API Server', 'etcd', 'kubelet'],
+      },
+      {
+        id: 's2',
+        name: '컨테이너 배포',
+        pageRange: 'p.21–34',
+        topics: ['Pod', 'ReplicaSet', 'Deployment', 'YAML'],
+      },
+      {
+        id: 's3',
+        name: '컨테이너 통신',
+        pageRange: 'p.35–46',
+        topics: ['Service', 'ClusterIP/NodePort', 'LoadBalancer', 'Ingress'],
+      },
+      {
+        id: 's4',
+        name: '컨테이너 볼륨·환경변수',
+        pageRange: 'p.47–53',
+        topics: ['Volume', 'PV/PVC', 'ConfigMap', 'Secret'],
+      },
+      {
+        id: 's5',
+        name: 'CICD Pipeline',
+        pageRange: 'p.54–70',
+        topics: ['DevOps', 'CI', 'CD', '애자일'],
+      },
+      {
+        id: 's6',
+        name: 'AWS CICD',
+        pageRange: 'p.71–74',
+        topics: ['CodePipeline', '릴리즈 프로세스'],
+      },
+    ],
+    cohortTopicTotal: 12,
+    coveredCount: 9,
+    uncoveredTopics: ['관측성 · 모니터링', '보안 · 시크릿 관리', '비용 최적화'],
+  },
+  'cur-2': {
+    sections: [
+      {
+        id: 's1',
+        name: '클라우드 네이티브 개요',
+        pageRange: 'p.3–18',
+        topics: ['클라우드 네이티브', '12 Factor'],
+      },
+      { id: 's2', name: '서비스 모델', pageRange: 'p.19–40', topics: ['IaaS', 'PaaS', 'SaaS'] },
+      {
+        id: 's3',
+        name: '마이그레이션 전략',
+        pageRange: 'p.41–66',
+        topics: ['6R', '리프트앤시프트', '리팩터링'],
+      },
+      {
+        id: 's4',
+        name: '가용성·확장성',
+        pageRange: 'p.67–88',
+        topics: ['오토스케일링', '로드밸런싱'],
+      },
+      { id: 's5', name: '관측성', pageRange: 'p.89–104', topics: ['모니터링', '로깅', '트레이싱'] },
+      { id: 's6', name: '보안 기초', pageRange: 'p.105–120', topics: ['IAM', '시크릿 관리'] },
+      { id: 's7', name: '비용 관리', pageRange: 'p.121–138', topics: ['비용 최적화', '태깅'] },
+      { id: 's8', name: '거버넌스', pageRange: 'p.139–151', topics: ['정책', '컴플라이언스'] },
+    ],
+    cohortTopicTotal: 12,
+    coveredCount: 12,
+    uncoveredTopics: [],
+  },
+  // 추출은 됐지만 주제가 아직 하나도 지정되지 않은 교안 (CUR-02 case 2: 수동 입력 유도)
+  'cur-3': {
+    sections: [
+      { id: 's1', name: 'EC2 · 컴퓨팅', pageRange: 'p.1–12', topics: [] },
+      { id: 's2', name: 'VPC · 네트워킹', pageRange: 'p.13–24', topics: [] },
+      { id: 's3', name: 'IAM · 권한', pageRange: 'p.25–34', topics: [] },
+      { id: 's4', name: 'S3 · 스토리지', pageRange: 'p.35–44', topics: [] },
+      { id: 's5', name: 'RDS · 데이터베이스', pageRange: 'p.45–56', topics: [] },
+    ],
+    cohortTopicTotal: 12,
+    coveredCount: 0,
+    uncoveredTopics: ['관측성 · 모니터링', '보안 · 시크릿 관리', '비용 최적화'],
+  },
+}

--- a/src/features/curriculum/routes.tsx
+++ b/src/features/curriculum/routes.tsx
@@ -1,12 +1,17 @@
 import type { RouteObject } from 'react-router'
 import CurriculumListScreen from './CurriculumListScreen'
 import CurriculumUploadScreen from './CurriculumUploadScreen'
+import CurriculumDetailScreen from './CurriculumDetailScreen'
 
 /*
   경로 규약은 `/{역할}/{화면}` — dashboard와 동일. managerNav.ts의 '교안' 항목과
   경로가 일치해야 좌측 네비에서 열린다.
+
+  `:id` 상세는 `/new`보다 뒤에 둔다 — react-router는 정적 세그먼트를 동적보다 먼저
+  맞추지만, 순서로도 의도를 드러낸다(등록 폼이 교안 하나로 오인되지 않게).
 */
 export const curriculumRoutes: RouteObject[] = [
   { path: '/manager/curriculum', element: <CurriculumListScreen /> }, // SC-M12
   { path: '/manager/curriculum/new', element: <CurriculumUploadScreen /> }, // SC-M12 · CUR-03 등록
+  { path: '/manager/curriculum/:id', element: <CurriculumDetailScreen /> }, // SC-M12 · CUR-01+02 상세
 ]


### PR DESCRIPTION
## 작업 내용
SC-M12 교안 관리의 세 번째 화면 '교안 상세'(CUR-01+CUR-02 통합 1화면, D103)를 구현했다. 목록의 교안명·"주제 확인 →"으로 진입.

- 섹션·주제 표(SectionTopicTable) — 주제 칩 ✕삭제 / +추가 로컬 편집, 대소문자 무시 중복 차단
- 커버리지 요약(CoverageSummary) — 기수 측정 주제 N개 중 M 커버 · 미커버 목록 (읽기 전용)
- 범위 좁히기 안내 + 축→섹션 위치 고정 규칙
- 상태별 UI (추출 중 · 대기 · 실패)
- 목록 교안명 → 상세 링크 연결(§7 "목록 행 클릭 → 진입")

## 리뷰 포인트
- 신뢰도·"AI 제안" 배지 비노출 유지(GOV-03·D102)
- 저작(재분석·칩 편집)은 총괄만 게이팅(D91)
- 중복 칩: 대소문자 무시 판정 + 빨간 테두리/안내, 입력 변경 시 복귀
- API 연동 전이라 mockData 기반 — 실 연동 시 GET /curriculum/{cid}/structure, coverage로 대체

## 확인
- typecheck 통과 / lint 에러 0
- 로컬에서 상세 진입·칩 편집·커버리지·상태별 UI 정상 확인

closes #38
