### PR TITLE
[Feat] Sync Trainee List (MG-05) to V2 Case Contract

### DIFF
--- a/docs/dev/components.html
+++ b/docs/dev/components.html
@@ -37,6 +37,13 @@
     --color-info-soft: #eaf2fa;
     --color-info-border: #c5daf0;
     --color-neutral-soft: #e0e3ea;
+    --color-reach-0: #df6150;
+    --color-reach-1: #ec9a5c;
+    --color-reach-2: #ecc95e;
+    --color-reach-3: #a9cf8e;
+    --color-reach-4: #57b083;
+    --color-reach-fg: #241108;
+    --color-reach-na-bg: #eceef1;
     --color-nav: #1e2436;
     --color-nav-active: #2a3147;
     --color-nav-fg: #aeb4c6;

--- a/docs/dev/design-system.html
+++ b/docs/dev/design-system.html
@@ -37,6 +37,13 @@
     --color-info-soft: #eaf2fa;
     --color-info-border: #c5daf0;
     --color-neutral-soft: #e0e3ea;
+    --color-reach-0: #df6150;
+    --color-reach-1: #ec9a5c;
+    --color-reach-2: #ecc95e;
+    --color-reach-3: #a9cf8e;
+    --color-reach-4: #57b083;
+    --color-reach-fg: #241108;
+    --color-reach-na-bg: #eceef1;
     --color-nav: #1e2436;
     --color-nav-active: #2a3147;
     --color-nav-fg: #aeb4c6;
@@ -181,7 +188,7 @@
   </div>
 
   <section>
-    <h2>색 <span class="cnt">31</span></h2>
+    <h2>색 <span class="cnt">38</span></h2>
     <p class="cap">값이 조정된 토큰 4개는 카드에 ✎ 표시가 있다</p>
     <div class="grp">
       <h3>표면</h3><p class="cap">무엇이 무엇 위에 얹히는지를 정한다</p>
@@ -611,7 +618,67 @@
 <div><p class="q">다크 모드와는 다른가</p><p class="a">다르다. 이건 특정 영역(사이드바)이 어두운 것이고, 다크 모드는 전체 테마가 뒤집히는 것이다. 다크 모드 요구는 현재 명세에 없다.</p></div>
     </div>
   </details>
+    </div><div class="grp">
+        <h3>그 외</h3>
+        <p class="cap">위 분류에 속하지 않는 것. 우리가 정의한 토큰이 여기 나타나면 분류가 빠진 것이다.</p>
+        <div class="grid"><div class="sw" tabindex="0">
+    <div class="swbox">
+      <i style="background:var(--color-reach-0)"></i>
+      <div class="swtxt">
+        <code class="n">reach-0</code>
+        <code class="v">#df6150</code>
+      </div>
     </div>
+  </div><div class="sw" tabindex="0">
+    <div class="swbox">
+      <i style="background:var(--color-reach-1)"></i>
+      <div class="swtxt">
+        <code class="n">reach-1</code>
+        <code class="v">#ec9a5c</code>
+      </div>
+    </div>
+  </div><div class="sw" tabindex="0">
+    <div class="swbox">
+      <i style="background:var(--color-reach-2)"></i>
+      <div class="swtxt">
+        <code class="n">reach-2</code>
+        <code class="v">#ecc95e</code>
+      </div>
+    </div>
+  </div><div class="sw" tabindex="0">
+    <div class="swbox">
+      <i style="background:var(--color-reach-3)"></i>
+      <div class="swtxt">
+        <code class="n">reach-3</code>
+        <code class="v">#a9cf8e</code>
+      </div>
+    </div>
+  </div><div class="sw" tabindex="0">
+    <div class="swbox">
+      <i style="background:var(--color-reach-4)"></i>
+      <div class="swtxt">
+        <code class="n">reach-4</code>
+        <code class="v">#57b083</code>
+      </div>
+    </div>
+  </div><div class="sw" tabindex="0">
+    <div class="swbox">
+      <i style="background:var(--color-reach-fg)"></i>
+      <div class="swtxt">
+        <code class="n">reach-fg</code>
+        <code class="v">#241108</code>
+      </div>
+    </div>
+  </div><div class="sw" tabindex="0">
+    <div class="swbox">
+      <i style="background:var(--color-reach-na-bg)"></i>
+      <div class="swtxt">
+        <code class="n">reach-na-bg</code>
+        <code class="v">#eceef1</code>
+      </div>
+    </div>
+  </div></div>
+      </div>
   </section>
 
   <section>

--- a/src/components/common/PageHeader.tsx
+++ b/src/components/common/PageHeader.tsx
@@ -15,18 +15,23 @@ type Props = {
   count?: string
   /** 상위 경로. 예: "교육생 › 7기" */
   breadcrumb?: string
+  /** count 옆에 붙는 세부 내역. 예: "활성 23 · 초대 대기 1 · 비활성 1"(MG-05 lhead .cnts2) */
+  breakdown?: ReactNode
   /** 주 액션 하나. 없으면 생략한다 */
   action?: ReactNode
 }
 
-export default function PageHeader({ title, count, breadcrumb, action }: Props) {
+export default function PageHeader({ title, count, breadcrumb, breakdown, action }: Props) {
   return (
     <div className="mb-4 flex flex-wrap items-end justify-between gap-3">
       <div>
         {breadcrumb && <p className="text-fg-subtle mb-0.5 text-xs">{breadcrumb}</p>}
-        <h1 className="text-xl font-bold tracking-[-0.01em]">
-          {title}
-          {count && <span className="text-fg-subtle ml-2 text-sm font-normal">{count}</span>}
+        <h1 className="flex items-baseline gap-3 text-xl font-bold tracking-[-0.01em]">
+          <span>
+            {title}
+            {count && <span className="text-fg-subtle ml-2 text-sm font-normal">{count}</span>}
+          </span>
+          {breakdown && <span className="text-fg-muted text-xs font-normal">{breakdown}</span>}
         </h1>
       </div>
       {action}

--- a/src/features/trainees/TraineeListScreen.tsx
+++ b/src/features/trainees/TraineeListScreen.tsx
@@ -138,7 +138,13 @@ function ConceptReachCell({ round, record }: { round: RoundId; record: RoundReco
 }
 
 /** 우수 누적 칸 — 그 회차 응시상태 3종이면 특이 문구가 우선한다(와이어프레임 prof) */
-function AceOrNoteCell({ trainee, record }: { trainee: TraineeRow; record: RoundRecord | undefined }) {
+function AceOrNoteCell({
+  trainee,
+  record,
+}: {
+  trainee: TraineeRow
+  record: RoundRecord | undefined
+}) {
   if (record?.status === 'INVALID') {
     return <span className="text-fg-subtle">이번 회차 채점하지 않음</span>
   }

--- a/src/features/trainees/TraineeListScreen.tsx
+++ b/src/features/trainees/TraineeListScreen.tsx
@@ -32,17 +32,32 @@ import {
   PaginationItem,
   PaginationLink,
 } from '@/components/ui/Pagination'
-import { TRAINEES, type AccountStatus } from './mockData'
+import {
+  TRAINEES,
+  ROUND_OPTIONS,
+  ROUND_CONCEPTS,
+  countLowLevels,
+  aceSummary,
+  type AccountStatus,
+  type RoundId,
+  type RoundRecord,
+  type RoundBadgeKind,
+  type TraineeRow,
+} from './mockData'
 import { AccountStatusBadge } from './components/AccountStatusBadge'
+import { RoundBadge } from './components/RoundBadge'
 import { maskEmail } from '@/lib/utils/mask'
+import { cn } from '@/lib/utils/cn'
 
 /*
-  SC-M11 · DASH-17 교육생 리스트. 목업 — API 연동 없이 고정 배열(mockData)을
-  화면에서 직접 검색·필터·정렬한다. 실 연동 시 이 필터 로직은 쿼리 파라미터로
-  옮겨간다.
+  SC-M11 · DASH-17 교육생 리스트 → MG-05(v2, 이슈 #45)로 갱신. 목업 — API 연동 없이
+  고정 배열(mockData)을 화면에서 직접 검색·필터·정렬한다. 실 연동 시 이 필터 로직은
+  쿼리 파라미터로 옮겨간다.
 
-  D104: 순수 디렉터리라 팀·회차·제출·점수는 없다. 위험도 정렬·판정도 배제한다
-  (DASH-17 L-7) — 정렬은 이름·반 같은 중립 축만 둔다.
+  D104의 "회차·측정 정보 없음"은 v1 상세(통로)를 전제로 한 판단이었다. v2 상세
+  (MG-06)가 타임라인으로 얇아지며 명부가 고유 가치(우수 프로필·팀 배치 판단)를
+  져야 해서 회차별 개념 도달·위험/우수 배지·우수 누적을 들였다(MG-05 §4). 팀·제출
+  현황은 여전히 없다 — MG-08 소관.
 
   페이지 범위·격리·권한(L-2~L-8, P-1~P-7)은 서버가 판정하는 영역이라 이 목업엔
   없다 — 검색 결과 없음(L-1)만 클라이언트에서 표현 가능하다.
@@ -51,16 +66,99 @@ import { maskEmail } from '@/lib/utils/mask'
 const ACCOUNT_OPTIONS: { value: 'ALL' | AccountStatus; label: string }[] = [
   { value: 'ACTIVE', label: '활성' },
   { value: 'ALL', label: '전체' },
-  { value: 'INVITED', label: '초대됨' },
+  { value: 'INVITED', label: '초대 대기' },
   { value: 'INACTIVE', label: '비활성' },
 ]
 const ACCOUNT_ITEMS = Object.fromEntries(ACCOUNT_OPTIONS.map((o) => [o.value, `계정 · ${o.label}`]))
 
+const ROUND_ITEMS = Object.fromEntries(ROUND_OPTIONS.map((o) => [o.value, `회차 · ${o.label}`]))
+
 const SORT_OPTIONS = [
-  { value: 'NAME', label: '이름순' },
-  { value: 'CLASS', label: '반순' },
+  { value: 'NAME', label: '이름' },
+  { value: 'CLASS', label: '반' },
+  { value: 'ACE_COUNT', label: '우수 누적' },
+  { value: 'LOW_COUNT', label: '2단 이하' },
 ] as const
 const SORT_ITEMS = Object.fromEntries(SORT_OPTIONS.map((o) => [o.value, `정렬 · ${o.label}`]))
+
+/** 도달 단계 배경색(0~4단) — MG-02 히트맵과 같은 5단 스케일. 0·4단은 배경이 진해 흰 글자 */
+const REACH_STYLE: Record<0 | 1 | 2 | 3 | 4, string> = {
+  0: 'bg-reach-0 text-white',
+  1: 'bg-reach-1 text-reach-fg',
+  2: 'bg-reach-2 text-reach-fg',
+  3: 'bg-reach-3 text-reach-fg',
+  4: 'bg-reach-4 text-white',
+}
+
+/** 문항 없음(코드에 그 개념이 없어 못 물었다) 해치 무늬 — 회색 두 톤 반복 대각선 */
+const NA_PATTERN = {
+  background:
+    'repeating-linear-gradient(45deg, var(--color-reach-na-bg), var(--color-reach-na-bg) 4px, var(--color-border) 4px, var(--color-border) 8px)',
+}
+
+/** 그 회차 배지 종류 — 응시상태 3종은 record.status를, ATTENDED는 record.badge를 그대로 쓴다 */
+function roundBadgeKind(record: RoundRecord | undefined): RoundBadgeKind | null {
+  if (!record) return null
+  if (record.status !== 'ATTENDED') return record.status
+  return record.badge ?? null
+}
+
+function ConceptReachCell({ round, record }: { round: RoundId; record: RoundRecord | undefined }) {
+  if (!record || record.status !== 'ATTENDED') {
+    return <span className="text-fg-subtle">아직 없음</span>
+  }
+  const concepts = ROUND_CONCEPTS[round]
+  return (
+    <span className="flex gap-[3px]">
+      {record.levels.map((level, i) =>
+        level === null ? (
+          <span
+            key={i}
+            title={concepts[i]}
+            style={NA_PATTERN}
+            className="text-fg-subtle flex h-[22px] w-[26px] items-center justify-center rounded-[4px] text-2xs"
+          >
+            ―
+          </span>
+        ) : (
+          <span
+            key={i}
+            title={concepts[i]}
+            className={cn(
+              'flex h-[22px] w-[26px] items-center justify-center rounded-[4px] text-2xs font-bold tabular-nums',
+              REACH_STYLE[level],
+            )}
+          >
+            {level}
+          </span>
+        ),
+      )}
+    </span>
+  )
+}
+
+/** 우수 누적 칸 — 그 회차 응시상태 3종이면 특이 문구가 우선한다(와이어프레임 prof) */
+function AceOrNoteCell({ trainee, record }: { trainee: TraineeRow; record: RoundRecord | undefined }) {
+  if (record?.status === 'INVALID') {
+    return <span className="text-fg-subtle">이번 회차 채점하지 않음</span>
+  }
+  if (record?.status === 'ABSENT') {
+    return <span className="text-fg-subtle">응시 창을 놓침</span>
+  }
+  if (record?.status === 'DROPPED') {
+    return <span className="text-fg-subtle">{record.note}</span>
+  }
+  const ace = aceSummary(trainee)
+  if (ace.count === 0) {
+    return <span className="text-fg-subtle">—</span>
+  }
+  return (
+    <span>
+      <b className="text-success font-bold">우수 {ace.count}회</b>
+      <span className="text-fg-subtle"> · {ace.rounds.join('·')}차</span>
+    </span>
+  )
+}
 
 export default function TraineeListScreen() {
   const navigate = useNavigate()
@@ -69,6 +167,7 @@ export default function TraineeListScreen() {
   const [classFilter, setClassFilter] = useState('ALL')
   const [accountFilter, setAccountFilter] = useState<'ALL' | AccountStatus>('ACTIVE')
   const [sort, setSort] = useState<(typeof SORT_OPTIONS)[number]['value']>('NAME')
+  const [round, setRound] = useState<RoundId>(ROUND_OPTIONS[ROUND_OPTIONS.length - 1].value)
 
   const classOptions = useMemo(
     () => Array.from(new Set(TRAINEES.map((t) => t.className))).sort(),
@@ -80,6 +179,13 @@ export default function TraineeListScreen() {
     return items
   }, [classOptions])
 
+  // 헤더 브레이크다운은 전체 모집단 기준 — 계정 필터를 바꿔도 안 바뀐다(범위 개수와 다른 값)
+  const accountCounts = useMemo(() => {
+    const counts: Record<AccountStatus, number> = { ACTIVE: 0, INVITED: 0, INACTIVE: 0 }
+    for (const t of TRAINEES) counts[t.accountStatus]++
+    return counts
+  }, [])
+
   const rows = useMemo(() => {
     const q = search.trim().toLowerCase()
     const filtered = TRAINEES.filter((t) => {
@@ -90,18 +196,61 @@ export default function TraineeListScreen() {
       if (accountFilter !== 'ALL' && t.accountStatus !== accountFilter) return false
       return true
     })
-    return filtered.sort((a, b) =>
-      sort === 'CLASS'
-        ? a.className.localeCompare(b.className, 'en') || a.name.localeCompare(b.name, 'ko')
-        : a.name.localeCompare(b.name, 'ko'),
-    )
-  }, [search, classFilter, accountFilter, sort])
+    // 미응시 등 그 회차 데이터가 없는 사람은 -1로 둬서 "많은 순"에서 항상 뒤로 밀린다.
+    const lowCount = (t: TraineeRow) => {
+      const r = t.rounds?.[round]
+      return r?.status === 'ATTENDED' ? countLowLevels(r.levels) : -1
+    }
+    return filtered.sort((a, b) => {
+      if (sort === 'CLASS') {
+        return a.className.localeCompare(b.className, 'en') || a.name.localeCompare(b.name, 'ko')
+      }
+      if (sort === 'ACE_COUNT') {
+        return aceSummary(b).count - aceSummary(a).count || a.name.localeCompare(b.name, 'ko')
+      }
+      if (sort === 'LOW_COUNT') {
+        return lowCount(b) - lowCount(a) || a.name.localeCompare(b.name, 'ko')
+      }
+      return a.name.localeCompare(b.name, 'ko')
+    })
+  }, [search, classFilter, accountFilter, sort, round])
 
   return (
     <ManagerShell user={{ name: '박지현', role: '총괄 매니저' }} cohort="7기" isLead>
-      <PageHeader breadcrumb="교육생 › 7기" title="교육생" count={`${TRAINEES.length}명`} />
+      <PageHeader
+        breadcrumb="교육생 › 7기 › 담당 반"
+        title="교육생"
+        count={`${TRAINEES.length}명`}
+        breakdown={
+          <>
+            활성 <b className="text-fg font-bold">{accountCounts.ACTIVE}</b>
+            <span className="text-fg-subtle">
+              {' '}
+              · 초대 대기 <b className="text-fg font-bold">{accountCounts.INVITED}</b> · 비활성{' '}
+              <b className="text-fg font-bold">{accountCounts.INACTIVE}</b>
+            </span>
+          </>
+        }
+      />
 
       <div className="mb-4 flex flex-wrap items-center gap-2">
+        <Select
+          value={round}
+          onValueChange={(v) => setRound((v as RoundId) ?? round)}
+          items={ROUND_ITEMS}
+        >
+          <SelectTrigger className="h-9 min-w-32 text-sm font-semibold" aria-label="회차 선택">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {ROUND_OPTIONS.map((o) => (
+              <SelectItem key={o.value} value={o.value}>
+                회차 · {o.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
         <InputGroup className="h-9 w-60">
           <InputGroupAddon>
             <SearchIcon />
@@ -161,7 +310,7 @@ export default function TraineeListScreen() {
         </Select>
 
         <Select value={sort} onValueChange={(v) => setSort(v as typeof sort)} items={SORT_ITEMS}>
-          <SelectTrigger className="ml-auto h-9 min-w-32" aria-label="정렬">
+          <SelectTrigger className="h-9 min-w-32" aria-label="정렬">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
@@ -179,7 +328,10 @@ export default function TraineeListScreen() {
           <TableHeader>
             <TableRow className="hover:bg-transparent">
               <TableHead>교육생</TableHead>
-              <TableHead>반</TableHead>
+              <TableHead>개념 3건 도달</TableHead>
+              <TableHead>2단 이하</TableHead>
+              <TableHead>이번 회차</TableHead>
+              <TableHead>우수 누적</TableHead>
               <TableHead>계정</TableHead>
               <TableHead />
             </TableRow>
@@ -188,53 +340,78 @@ export default function TraineeListScreen() {
             {rows.length === 0 && (
               <TableRow>
                 <TableCell
-                  colSpan={4}
+                  colSpan={7}
                   className="text-fg-subtle py-8 text-center whitespace-normal"
                 >
                   조건에 맞는 교육생이 없습니다.
                 </TableCell>
               </TableRow>
             )}
-            {rows.map((t) => (
-              <TableRow
-                key={t.id}
-                className="hover:bg-surface-2 cursor-pointer"
-                onClick={() => navigate(`/manager/trainees/${t.id}`)}
-              >
-                <TableCell>
-                  <div className="flex items-center gap-3">
-                    <Avatar aria-hidden="true">
-                      <AvatarFallback className="bg-primary-soft text-primary font-semibold">
-                        {t.name.slice(0, 1)}
-                      </AvatarFallback>
-                    </Avatar>
-                    <div>
-                      <Link
-                        to={`/manager/trainees/${t.id}`}
-                        aria-label={`${t.name} 상세 보기`}
-                        className="text-fg hover:text-primary font-semibold hover:underline"
-                        onClick={(e) => e.stopPropagation()}
-                      >
-                        {t.name}
-                      </Link>
-                      <p className="text-fg-subtle text-2xs">{maskEmail(t.email)}</p>
+            {rows.map((t) => {
+              const record = t.rounds?.[round]
+              const low = record?.status === 'ATTENDED' ? countLowLevels(record.levels) : null
+              const hot = low !== null && low >= 2
+              return (
+                <TableRow
+                  key={t.id}
+                  className="hover:bg-surface-2 cursor-pointer"
+                  onClick={() => navigate(`/manager/trainees/${t.id}`)}
+                >
+                  <TableCell>
+                    <div className="flex items-center gap-3">
+                      <Avatar aria-hidden="true">
+                        <AvatarFallback className="bg-primary-soft text-primary font-semibold">
+                          {t.name.slice(0, 1)}
+                        </AvatarFallback>
+                      </Avatar>
+                      <div>
+                        <span className="flex items-center gap-1.5">
+                          <Link
+                            to={`/manager/trainees/${t.id}`}
+                            aria-label={`${t.name} 상세 보기`}
+                            className="text-fg hover:text-primary font-semibold hover:underline"
+                            onClick={(e) => e.stopPropagation()}
+                          >
+                            {t.name}
+                          </Link>
+                          <span className="text-fg-subtle text-2xs">{t.className}</span>
+                        </span>
+                        <p className="text-fg-subtle text-2xs">{maskEmail(t.email)}</p>
+                      </div>
                     </div>
-                  </div>
-                </TableCell>
-                <TableCell className="text-fg-muted text-xs">{t.className}</TableCell>
-                <TableCell>
-                  <AccountStatusBadge status={t.accountStatus} />
-                  {t.accountStatus === 'INACTIVE' && t.inactiveReason && (
-                    <p className="text-fg-subtle mt-0.5 text-2xs">
-                      {t.inactiveReason} · {t.inactiveAt}
-                    </p>
-                  )}
-                </TableCell>
-                <TableCell aria-hidden="true" className="text-fg-subtle text-right">
-                  ›
-                </TableCell>
-              </TableRow>
-            ))}
+                  </TableCell>
+                  <TableCell className="text-xs">
+                    <ConceptReachCell round={round} record={record} />
+                  </TableCell>
+                  <TableCell className="text-xs tabular-nums">
+                    {low === null ? (
+                      <span className="text-fg-subtle">—</span>
+                    ) : (
+                      <span className={hot ? 'text-warning' : 'text-fg-muted'}>
+                        <b className={cn('font-bold', hot ? 'text-warning' : 'text-fg')}>{low}</b>/3
+                      </span>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <RoundBadge kind={roundBadgeKind(record)} />
+                  </TableCell>
+                  <TableCell className="text-xs">
+                    <AceOrNoteCell trainee={t} record={record} />
+                  </TableCell>
+                  <TableCell>
+                    <AccountStatusBadge status={t.accountStatus} />
+                    {t.accountStatus === 'INACTIVE' && t.inactiveReason && (
+                      <p className="text-fg-subtle mt-0.5 text-2xs">
+                        {t.inactiveReason} · {t.inactiveAt}
+                      </p>
+                    )}
+                  </TableCell>
+                  <TableCell aria-hidden="true" className="text-fg-subtle text-right">
+                    ›
+                  </TableCell>
+                </TableRow>
+              )
+            })}
           </TableBody>
         </Table>
       </TableFrame>

--- a/src/features/trainees/components/AccountStatusBadge.tsx
+++ b/src/features/trainees/components/AccountStatusBadge.tsx
@@ -3,7 +3,7 @@ import type { AccountStatus } from '../mockData'
 
 const LABEL: Record<AccountStatus, string> = {
   ACTIVE: '활성',
-  INVITED: '초대됨',
+  INVITED: '초대 대기',
   INACTIVE: '비활성',
 }
 

--- a/src/features/trainees/components/RoundBadge.tsx
+++ b/src/features/trainees/components/RoundBadge.tsx
@@ -1,0 +1,31 @@
+import { Badge } from '@/components/ui/Badge'
+import type { RoundBadgeKind } from '../mockData'
+
+const LABEL: Record<RoundBadgeKind, string> = {
+  DECLINE: '단계 하락',
+  LOW_PERSISTENT: '지속 저점',
+  ACE: '우수',
+  ABSENT: '미응시',
+  INVALID: '무효 응시',
+  DROPPED: '중단',
+}
+
+/*
+  와이어프레임 .rbadge 대조(docs/plan/v2/wireframe/manager/trainees.html) —
+  down(단계 하락)은 danger가 아니라 warning, void(무효 응시)는 neutral이 아니라
+  danger다. 감으로 고르면 이렇게 어긋난다.
+*/
+const VARIANT: Record<RoundBadgeKind, 'success' | 'warning' | 'danger' | 'neutral'> = {
+  DECLINE: 'warning',
+  LOW_PERSISTENT: 'danger',
+  ACE: 'success',
+  ABSENT: 'neutral',
+  INVALID: 'danger',
+  DROPPED: 'neutral',
+}
+
+/** 이번 회차 배지 — 위험 2종 · 우수 · 응시상태 3종(14-1) 중 하나. 일반(kind 없음)은 배지 없이 "—" */
+export function RoundBadge({ kind }: { kind: RoundBadgeKind | null }) {
+  if (!kind) return <span className="text-fg-subtle">—</span>
+  return <Badge variant={VARIANT[kind]}>{LABEL[kind]}</Badge>
+}

--- a/src/features/trainees/mockData.ts
+++ b/src/features/trainees/mockData.ts
@@ -2,10 +2,43 @@
   DASH-17 교육생 리스트 목업. API 연동 전까지 화면을 검증하기 위한 고정 배열이다.
   실 데이터가 붙으면 이 파일은 지운다.
 
-  D104: 순수 디렉터리라 정체성(이름·반)과 계정 상태만 갖는다. 팀·회차·제출·점수는
-  측정과 독립이라 여기 없다 — 그건 프로젝트 워크스페이스·대시보드·개별 상세 소관.
+  이슈 #45(MG-05 v2)로 D104의 "회차·측정 정보 없음" 판단이 뒤집혔다 — v1은 상세가
+  통로였지만 v2 상세(MG-06)는 타임라인 하나로 얇아져 명부가 회차별 개념 도달·이번
+  회차 배지·우수 누적을 직접 진다. 팀·제출 현황은 여전히 여기 없다(MG-08 소관).
 */
 export type AccountStatus = 'ACTIVE' | 'INVITED' | 'INACTIVE'
+
+export type RoundId = '1' | '2' | '3'
+
+export const ROUND_OPTIONS: { value: RoundId; label: string }[] = [
+  { value: '1', label: '미프 1차' },
+  { value: '2', label: '미프 2차' },
+  { value: '3', label: '미프 3차' },
+]
+
+/** 그 회차의 검증 개념 3건 — 회차마다 다르다(MG-02). 히트맵의 같은 순서와 맞는다 */
+export const ROUND_CONCEPTS: Record<RoundId, [string, string, string]> = {
+  '1': ['인증 흐름', 'API 설계', '에러 처리'],
+  '2': ['상태 관리', 'API 설계', '테스트 전략'],
+  '3': ['HITL Trigger', 'Graph 구성', 'State 관리'],
+}
+
+/** 개념 도달 단계(0~4). null = ▨ 문항 없음(코드에 그 개념이 없어 못 물었다, MG-02) */
+export type ConceptLevel = 0 | 1 | 2 | 3 | 4 | null
+
+export type RoundBadgeKind = 'DECLINE' | 'LOW_PERSISTENT' | 'ACE' | 'ABSENT' | 'INVALID' | 'DROPPED'
+
+/** 응시상태 3종(14-1: 미응시·무효 응시·중단)은 원인·처방이 달라 값을 나눈다 */
+export type RoundRecord =
+  | {
+      status: 'ATTENDED'
+      levels: [ConceptLevel, ConceptLevel, ConceptLevel]
+      /** 위험 유형(9-2) 또는 우수(9-3). 없으면 일반 */
+      badge?: 'DECLINE' | 'LOW_PERSISTENT' | 'ACE'
+    }
+  | { status: 'ABSENT' }
+  | { status: 'INVALID' }
+  | { status: 'DROPPED'; note: string }
 
 export type TraineeRow = {
   id: string
@@ -16,13 +49,48 @@ export type TraineeRow = {
   /** 비활성 사유·일자. INACTIVE일 때만 값이 있다 */
   inactiveReason?: string
   inactiveAt?: string
+  /** 회차별 응시·도달 기록. 그 회차 키가 없으면 "아직 없음"(초대 대기 등 데이터 자체가 없는 경우) */
+  rounds?: Partial<Record<RoundId, RoundRecord>>
 }
 
 export const TRAINEES: TraineeRow[] = [
-  { id: 't-1', name: '강민준', email: 'minjun@ex.com', className: 'A반', accountStatus: 'ACTIVE' },
-  { id: 't-2', name: '김서연', email: 'seoyeon@ex.com', className: 'A반', accountStatus: 'ACTIVE' },
+  {
+    id: 't-1',
+    name: '강민준',
+    email: 'minjun@ex.com',
+    className: 'A반',
+    accountStatus: 'ACTIVE',
+    rounds: {
+      '1': { status: 'ATTENDED', levels: [3, 3, 4] },
+      '2': { status: 'ATTENDED', levels: [4, 3, 4] },
+      '3': { status: 'ATTENDED', levels: [3, 4, 3] },
+    },
+  },
+  {
+    id: 't-2',
+    name: '김서연',
+    email: 'seoyeon@ex.com',
+    className: 'A반',
+    accountStatus: 'ACTIVE',
+    rounds: {
+      '1': { status: 'ATTENDED', levels: [4, 4, 3], badge: 'ACE' },
+      '2': { status: 'ATTENDED', levels: [4, 3, 4], badge: 'ACE' },
+      '3': { status: 'ATTENDED', levels: [4, 4, 4], badge: 'ACE' },
+    },
+  },
   { id: 't-3', name: '서지우', email: 'jiwoo@ex.com', className: 'B반', accountStatus: 'INVITED' },
-  { id: 't-4', name: '한도현', email: 'dohyun@ex.com', className: 'A반', accountStatus: 'ACTIVE' },
+  {
+    id: 't-4',
+    name: '한도현',
+    email: 'dohyun@ex.com',
+    className: 'A반',
+    accountStatus: 'ACTIVE',
+    rounds: {
+      '1': { status: 'ATTENDED', levels: [3, 2, 4] },
+      '2': { status: 'ATTENDED', levels: [2, 3, 3] },
+      '3': { status: 'ABSENT' },
+    },
+  },
   {
     id: 't-5',
     name: '오세훈',
@@ -31,10 +99,48 @@ export const TRAINEES: TraineeRow[] = [
     accountStatus: 'INACTIVE',
     inactiveReason: '이탈',
     inactiveAt: '08.02',
+    rounds: {
+      '1': { status: 'ATTENDED', levels: [2, 1, 3] },
+      '2': { status: 'ATTENDED', levels: [3, 2, 2] },
+      '3': { status: 'DROPPED', note: '세션 중단 · 07-14' },
+    },
   },
-  { id: 't-6', name: '이하은', email: 'haeun@ex.com', className: 'B반', accountStatus: 'ACTIVE' },
-  { id: 't-7', name: '박지민', email: 'jimin@ex.com', className: 'C반', accountStatus: 'ACTIVE' },
-  { id: 't-8', name: '최윤서', email: 'yoonseo@ex.com', className: 'B반', accountStatus: 'ACTIVE' },
+  {
+    id: 't-6',
+    name: '이하은',
+    email: 'haeun@ex.com',
+    className: 'B반',
+    accountStatus: 'ACTIVE',
+    rounds: {
+      '1': { status: 'ATTENDED', levels: [4, 4, 3], badge: 'ACE' },
+      '2': { status: 'ATTENDED', levels: [3, 3, 4] },
+      '3': { status: 'ATTENDED', levels: [2, 1, 2], badge: 'LOW_PERSISTENT' },
+    },
+  },
+  {
+    id: 't-7',
+    name: '박지민',
+    email: 'jimin@ex.com',
+    className: 'C반',
+    accountStatus: 'ACTIVE',
+    rounds: {
+      '1': { status: 'ATTENDED', levels: [3, 3, 3] },
+      '2': { status: 'ATTENDED', levels: [4, 3, 3] },
+      '3': { status: 'ATTENDED', levels: [0, 1, 3], badge: 'DECLINE' },
+    },
+  },
+  {
+    id: 't-8',
+    name: '최윤서',
+    email: 'yoonseo@ex.com',
+    className: 'B반',
+    accountStatus: 'ACTIVE',
+    rounds: {
+      '1': { status: 'ATTENDED', levels: [3, 3, 3] },
+      '2': { status: 'ATTENDED', levels: [3, 4, 3] },
+      '3': { status: 'INVALID' },
+    },
+  },
   { id: 't-9', name: '정우진', email: 'woojin@ex.com', className: 'A반', accountStatus: 'INVITED' },
   {
     id: 't-10',
@@ -45,9 +151,45 @@ export const TRAINEES: TraineeRow[] = [
     inactiveReason: '휴식',
     inactiveAt: '07.20',
   },
-  { id: 't-11', name: '윤도윤', email: 'doyoon@ex.com', className: 'B반', accountStatus: 'ACTIVE' },
-  { id: 't-12', name: '임서준', email: 'seojun@ex.com', className: 'C반', accountStatus: 'ACTIVE' },
+  {
+    id: 't-11',
+    name: '윤도윤',
+    email: 'doyoon@ex.com',
+    className: 'B반',
+    accountStatus: 'ACTIVE',
+    rounds: {
+      '1': { status: 'ATTENDED', levels: [3, 3, 3] },
+      '2': { status: 'ATTENDED', levels: [3, 3, 4] },
+      '3': { status: 'ATTENDED', levels: [4, 3, 3] },
+    },
+  },
+  {
+    id: 't-12',
+    name: '임서준',
+    email: 'seojun@ex.com',
+    className: 'C반',
+    accountStatus: 'ACTIVE',
+    rounds: {
+      '1': { status: 'ATTENDED', levels: [3, 3, 3] },
+      '2': { status: 'ATTENDED', levels: [4, 4, 3] },
+      '3': { status: 'ATTENDED', levels: [3, null, 4] },
+    },
+  },
 ]
+
+/** 2단 이하 개수. 3(그 회차 검증 개념 수)은 고정 분모라 셀 수와 별개로 저장하지 않는다 */
+export function countLowLevels(levels: ConceptLevel[]): number {
+  return levels.filter((l) => l !== null && l <= 2).length
+}
+
+/** 우수 누적 — 회차 배지에서 파생한다(개념 아님, MG-05 §3). 이중 저장하지 않는다 */
+export function aceSummary(trainee: TraineeRow): { count: number; rounds: RoundId[] } {
+  const rounds = (Object.entries(trainee.rounds ?? {}) as [RoundId, RoundRecord][])
+    .filter(([, r]) => r.status === 'ATTENDED' && r.badge === 'ACE')
+    .map(([id]) => id)
+    .sort((a, b) => Number(a) - Number(b))
+  return { count: rounds.length, rounds }
+}
 
 /*
   SC-M06 개별 상세 목업. 화면 정의서(§4)는 5축(자기수정 포함)을 명시하지만,

--- a/src/index.css
+++ b/src/index.css
@@ -83,6 +83,17 @@
   --color-info-border: #c5daf0;
   --color-neutral-soft: #e0e3ea;
 
+  /* ── 개념 도달 단계(0~4) — MG-05·MG-02 공유 색 스케일(MG-02 §3 "색 스케일 — 여기서
+     확정하고 MG-06이 물려받는다"). danger/warning/success 5색 의미 팔레트와 별개다 —
+     여긴 위험도 그라디언트 5단이라 의미 색 이름 하나에 대응시킬 수 없다. */
+  --color-reach-0: #df6150;
+  --color-reach-1: #ec9a5c;
+  --color-reach-2: #ecc95e;
+  --color-reach-3: #a9cf8e;
+  --color-reach-4: #57b083;
+  --color-reach-fg: #241108; /* 1~3단 위 어두운 글자. 0·4단은 배경이 진해 흰 글자를 쓴다 */
+  --color-reach-na-bg: #eceef1; /* 문항없음 해치 무늬 밝은 줄. 어두운 줄은 --color-border와 같다 */
+
   /* ── 좌측 네비게이션 (어두운 면) ──────────────
      매니저·슈퍼어드민 셸의 사이드바 전용. 와이어 12개 파일에서 값이 일치한다. */
   --color-nav: #1e2436;


### PR DESCRIPTION
## 작업 요약
교육생 명부(SC-M11/v1, 4컬럼 순수 디렉터리)를 MG-05 v2 케이스 계약에 맞춰 동기화.
회차 select · 개념 3건 도달(5단 색 스케일) · 2단 이하 · 이번 회차 배지(위험 2종·우수·응시상태 3종) ·
우수 누적 · 정렬 4종을 추가했고, 와이어프레임(docs/plan/v2/wireframe/manager/trainees.html)과
색·구조 대조까지 마쳤다.

## 리뷰 포인트
- RoundBadge.tsx VARIANT 매핑 — 감으로 고르면 틀리는 지점(단계 하락=warning, 무효 응시=danger)이라 주석 남겨둠
- PageHeader.tsx에 `breakdown` optional prop 추가(기존 화면 동작 불변, 순수 추가) — 공용 컴포넌트라 리뷰 포인트로 남김
- index.css에 `--color-reach-0~4` 등 새 색 토큰 추가(기존 토큰 변경 없음) — MG-02 히트맵도 같은 스케일을 쓸 예정이라 여기서 확정
- countLowLevels 분모가 고정 3 — 회차 중 문항없음(null)이 섞이면 "2단 이하 n/3"이 실제 채점 개념 수보다 큰 분모로 보일 수 있음(엣지 케이스, MG-05 정의서에 명시 안 됨)

closes #45