### PR TITLE
[Feat] Migrate AU-01 Login to v2 ConsoleShell Skeleton

### DIFF
--- a/src/features/auth/AuthContext.tsx
+++ b/src/features/auth/AuthContext.tsx
@@ -1,0 +1,62 @@
+import { createContext, useContext, useState } from 'react'
+import type { ReactNode } from 'react'
+import type { Role } from './authTypes'
+
+/**
+ * 로그인 세션을 앱 전체가 공유하는 곳 (AUTH-09 · 인증 컨텍스트)
+ *
+ * ⚠️ 실서비스 주의:
+ * 지금은 데모라 sessionStorage에 보관해 새로고침을 견디게 했습니다.
+ * 실제로는 accessToken을 메모리에만 두고, 새로고침 시
+ * refreshToken(HttpOnly 쿠키)으로 재발급받아 세션을 복원하는 것이 안전합니다.
+ */
+export interface Session {
+  accessToken: string
+  role: Role
+  initialScreen: string
+}
+
+interface AuthValue {
+  session: Session | null
+  signIn: (session: Session) => void
+  signOut: () => void
+}
+
+const AuthContext = createContext<AuthValue | null>(null)
+const STORAGE_KEY = 'iz-get.session'
+
+function readStoredSession(): Session | null {
+  const raw = sessionStorage.getItem(STORAGE_KEY)
+  if (!raw) return null
+  try {
+    return JSON.parse(raw) as Session
+  } catch {
+    return null
+  }
+}
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [session, setSession] = useState<Session | null>(readStoredSession)
+
+  function signIn(next: Session) {
+    setSession(next)
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(next))
+  }
+
+  function signOut() {
+    setSession(null)
+    sessionStorage.removeItem(STORAGE_KEY)
+    // 실서비스에서는 여기서 POST /auth/logout 호출로 서버 토큰도 폐기 (AUTH-04)
+  }
+
+  return (
+    <AuthContext.Provider value={{ session, signIn, signOut }}>{children}</AuthContext.Provider>
+  )
+}
+
+/** 어느 컴포넌트에서든 로그인 정보를 꺼내 쓰는 훅 */
+export function useAuth() {
+  const ctx = useContext(AuthContext)
+  if (!ctx) throw new Error('useAuth는 AuthProvider 안에서만 사용할 수 있습니다.')
+  return ctx
+}

--- a/src/features/auth/LoginScreen.tsx
+++ b/src/features/auth/LoginScreen.tsx
@@ -1,6 +1,254 @@
-import PlaceholderScreen from '@/app/PlaceholderScreen'
+import { useEffect, useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { useNavigate, Navigate, Link } from 'react-router'
+import { EyeIcon, EyeOffIcon } from 'lucide-react'
+import { useAuth } from './AuthContext'
+import { login, resendInviteMail } from './authApi'
+import { resolveAuthState } from './authStates'
+import type { AuthState } from './authStates'
+import type { ApiError } from './authTypes'
+import { useCapsLockWarning } from './useCapsLockWarning'
+import BrandPanel from './components/BrandPanel'
+import AuthForm from './components/AuthForm'
+import TextLink from './components/TextLink'
+import { Alert } from '@/components/ui/Alert'
+import { Field, FieldLabel, FieldError } from '@/components/ui/Field'
+import { Input } from '@/components/ui/Input'
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from '@/components/ui/InputGroup'
+import { Kbd } from '@/components/ui/Kbd'
+import { Button } from '@/components/ui/Button'
 
-/** AU-01 로그인 — 화면 이식 전 자리표시. 실제 화면이 들어오면 이 파일 내용만 바뀐다. */
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+interface LoginFormValues {
+  email: string
+  password: string
+}
+
+/**
+ * AU-01 · 로그인 (전 화면 공통 관문)
+ * - 역할은 서버가 판정하며, 화면에 역할 선택 UI를 두지 않음
+ * - 실패는 화면을 벗어나지 않고 인라인 알림 + 재입력
+ * - 공개 회원가입 링크 없음 (초대 기반 계정)
+ * - 케이스 계약: docs/plan/v2/wireframe/shared/login.html#cases
+ */
 export default function LoginScreen() {
-  return <PlaceholderScreen code="AU-01" title="로그인" />
+  const navigate = useNavigate()
+  const { session, signIn } = useAuth()
+  const [alert, setAlert] = useState<AuthState | null>(null)
+  const [resendDone, setResendDone] = useState(false)
+  const [showPassword, setShowPassword] = useState(false)
+  const passwordCaps = useCapsLockWarning()
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors, isSubmitting },
+  } = useForm<LoginFormValues>({ defaultValues: { email: '', password: '' } })
+
+  const email = watch('email')
+  const passwordField = register('password', { required: '비밀번호를 입력해주세요.' })
+
+  // 잠금은 계정별 상태 — 이메일이 바뀌면 이전 계정의 잠금 알림을 유지하지 않는다
+  useEffect(() => {
+    setAlert((prev) => (prev?.blockSubmit ? null : prev))
+  }, [email])
+
+  async function onSubmit(values: LoginFormValues) {
+    setAlert(null)
+    setResendDone(false)
+
+    try {
+      const res = await login(values)
+      // 인증 컨텍스트에 세션 저장 → 이후 보호된 화면 진입 가능
+      signIn(res)
+      // 서버가 지정한 초기 화면으로 이동 (클라이언트가 역할→화면 매핑을 하지 않음)
+      navigate(res.initialScreen)
+    } catch (err) {
+      const { code, retryAfter } = err as ApiError
+      setAlert(resolveAuthState(code, retryAfter))
+    }
+  }
+
+  async function handleResend() {
+    await resendInviteMail(email)
+    setResendDone(true)
+  }
+
+  // 이미 로그인한 사용자가 로그인 화면에 오면 자기 초기 화면으로 되돌림
+  if (session) {
+    return <Navigate to={session.initialScreen} replace />
+  }
+
+  return (
+    <div className="flex min-h-screen w-full bg-canvas">
+      <div className="flex w-full bg-surface">
+        <BrandPanel />
+
+        {/* stableHeight: 알림이 뜨고 사라져도 제목·입력 필드 위치가 흔들리지 않게 (AU-01 §6) */}
+        <AuthForm title="로그인" subtitle="계정 정보를 입력하세요." stableHeight>
+          {/* noValidate: 브라우저 기본 검증 대신 RHF/Alert로 상태를 일원화 */}
+          <form onSubmit={handleSubmit(onSubmit)} noValidate className="space-y-4">
+            <Field data-invalid={!!errors.email}>
+              <FieldLabel htmlFor="login-email">이메일</FieldLabel>
+              <Input
+                id="login-email"
+                type="email"
+                placeholder="manager@org.com"
+                autoComplete="username"
+                disabled={isSubmitting}
+                aria-invalid={!!errors.email}
+                {...register('email', {
+                  required: '이메일을 입력해주세요.',
+                  pattern: { value: EMAIL_PATTERN, message: '올바른 이메일 형식이 아닙니다.' },
+                })}
+              />
+              <FieldError>{errors.email?.message}</FieldError>
+            </Field>
+
+            <Field data-invalid={!!errors.password}>
+              <FieldLabel htmlFor="login-password">비밀번호</FieldLabel>
+              <InputGroup>
+                <InputGroupInput
+                  id="login-password"
+                  type={showPassword ? 'text' : 'password'}
+                  placeholder="••••••••"
+                  autoComplete="current-password"
+                  disabled={isSubmitting}
+                  aria-invalid={!!errors.password}
+                  {...passwordField}
+                  onKeyDown={passwordCaps.onKeyDown}
+                  onKeyUp={passwordCaps.onKeyUp}
+                  onBlur={(event) => {
+                    passwordCaps.onBlur(event)
+                    passwordField.onBlur(event)
+                  }}
+                />
+                <InputGroupAddon align="inline-end">
+                  <InputGroupButton
+                    size="icon-xs"
+                    aria-label={showPassword ? '비밀번호 숨기기' : '비밀번호 표시'}
+                    aria-pressed={showPassword}
+                    disabled={isSubmitting}
+                    onClick={() => setShowPassword((v) => !v)}
+                  >
+                    {showPassword ? <EyeOffIcon /> : <EyeIcon />}
+                  </InputGroupButton>
+                </InputGroupAddon>
+              </InputGroup>
+              {/* role=status — 값이 가려진 필드라 화면을 못 보는 사용자에게도 읽혀야 한다 */}
+              {passwordCaps.capsLock && (
+                <p role="status" className="text-warning flex items-center gap-1.5 text-xs">
+                  <Kbd>⇪ Caps Lock</Kbd> 켜짐 — 대문자로 입력됩니다.
+                </p>
+              )}
+              <FieldError>{errors.password?.message}</FieldError>
+            </Field>
+
+            {/* 알림은 비밀번호 아래 · 버튼 위 — 폼 위쪽에 두면 뜰 때마다 입력 필드가 밀린다 */}
+            {alert && (
+              <Alert variant={alert.variant}>
+                {alert.message}
+                {alert.showResend && (
+                  <span className="ml-2">
+                    {resendDone ? (
+                      <span className="text-fg-subtle">초대 메일을 다시 보냈습니다.</span>
+                    ) : (
+                      <TextLink onClick={handleResend}>초대 메일 다시 받기</TextLink>
+                    )}
+                  </span>
+                )}
+              </Alert>
+            )}
+
+            <div className="pt-1">
+              <Button type="submit" size="lg" disabled={isSubmitting || alert?.blockSubmit}>
+                {isSubmitting ? '로그인 중…' : '로그인'}
+              </Button>
+            </div>
+          </form>
+
+          <div className="mt-4 text-center">
+            <TextLink to="/shared/password-reset">비밀번호를 잊으셨나요?</TextLink>
+          </div>
+
+          {/* 개발용 안내 — 실제 배포 시 제거 */}
+          <div className="mt-8 rounded-md bg-canvas px-3 py-2.5 text-[11px] leading-relaxed text-fg-subtle">
+            <b className="text-fg-muted">Mock 계정</b> · 비밀번호 <code>pass1234</code>
+            <br />
+            manager@org.com · trainee@org.com · admin@iz-get.com
+            <br />
+            <b className="text-fg-muted">상태 시연</b> · newtrainee@(미활성) · suspended@(정지) ·
+            error@ · rollback@ · cookie@ · noctx@org.com
+            <br />
+            같은 계정 3회 연속 실패 → 지연(잠금 아님, 30초 후 재시도)
+            <br />
+            <b className="text-fg-muted">초대 링크(AU-02)</b> ·{' '}
+            <Link to="/invite/mgr-8f3a" className="text-primary hover:underline">
+              매니저 가입
+            </Link>{' '}
+            ·{' '}
+            <Link to="/invite/stu-4c19" className="text-primary hover:underline">
+              교육생 활성화
+            </Link>
+            <br />
+            가입/활성화 후 <b className="text-fg-muted">newmanager@org.com</b> ·{' '}
+            <b className="text-fg-muted">newtrainee@org.com</b> + 직접 설정한 비밀번호로 로그인
+            <br />
+            <b className="text-fg-muted">비밀번호 재설정(AU-03)</b> ·{' '}
+            <Link
+              to="/shared/password-reset?token=reset-valid"
+              className="text-primary hover:underline"
+            >
+              정상
+            </Link>{' '}
+            ·{' '}
+            <Link
+              to="/shared/password-reset?token=reset-expired"
+              className="text-primary hover:underline"
+            >
+              만료
+            </Link>{' '}
+            ·{' '}
+            <Link
+              to="/shared/password-reset?token=reset-used"
+              className="text-primary hover:underline"
+            >
+              사용됨
+            </Link>{' '}
+            ·{' '}
+            <Link
+              to="/shared/password-reset?token=reset-tampered"
+              className="text-primary hover:underline"
+            >
+              위변조
+            </Link>{' '}
+            ·{' '}
+            <Link
+              to="/shared/password-reset?token=reset-revokefail"
+              className="text-primary hover:underline"
+            >
+              세션폐기실패
+            </Link>{' '}
+            ·{' '}
+            <Link
+              to="/shared/password-reset?token=reset-failing"
+              className="text-primary hover:underline"
+            >
+              저장실패
+            </Link>
+            <br />
+            reset-valid로 제출 시 비밀번호를 <code>pass1234</code>(현재값)로 넣으면 same-as-current
+            시연
+          </div>
+        </AuthForm>
+      </div>
+    </div>
+  )
 }

--- a/src/features/auth/authApi.ts
+++ b/src/features/auth/authApi.ts
@@ -1,0 +1,130 @@
+// ─────────────────────────────────────────────────────────────
+// 인증 API 격리 모듈
+// 백엔드 준비 시 각 함수의 Mock 블록만 삭제하고 아래 주석의 fetch를 켜면 됩니다.
+// (화면·컴포넌트 코드는 수정 불필요)
+// ─────────────────────────────────────────────────────────────
+import type { ApiError, LoginRequest, LoginResponse, Role } from './authTypes'
+import { accounts } from './mockDb'
+
+/** 서버가 내려주는 역할별 초기 화면 (initialScreen) */
+const INITIAL_SCREEN: Record<Role, string> = {
+  SUPERADMIN: '/superadmin/console', // SA-01
+  OPERATOR: '/operator/dashboard', // OP-01
+  MANAGER: '/manager/dashboard', // MG-01
+  TRAINEE: '/trainee/home', // TR-01
+}
+
+// ───────── Mock 전용 (백엔드 연동 시 이 블록 삭제) ─────────
+/** 상태 시연용 계정 — 9 case를 화면에서 직접 확인할 수 있게 함 */
+const MOCK_ERROR_ACCOUNTS: Record<string, ApiError> = {
+  'suspended@org.com': { code: 'AUTH_INACTIVE' },
+  'error@org.com': { code: 'AUTH_TOKEN_ISSUE' },
+  'rollback@org.com': { code: 'AUTH_ROLLBACK' },
+  'cookie@org.com': { code: 'AUTH_COOKIE' },
+  'noctx@org.com': { code: 'AUTH_NO_CONTEXT' },
+}
+
+const THROTTLE_THRESHOLD = 3
+/** 데모라 30초. 실제 서버는 정책값을 씁니다. */
+const THROTTLE_DURATION_MS = 30_000
+
+interface FailState {
+  count: number
+  throttledUntil?: number // timestamp
+}
+const failState: Record<string, FailState> = {}
+
+function stateOf(email: string): FailState {
+  if (!failState[email]) failState[email] = { count: 0 }
+  return failState[email]
+}
+
+function retryAfterSeconds(until: number): number {
+  return Math.max(1, Math.ceil((until - Date.now()) / 1000))
+}
+// ──────────────────────────────────────────────────────────
+
+/** POST /auth/login */
+export function login(req: LoginRequest): Promise<LoginResponse> {
+  // ===== Mock 버전 (현재 활성) =====
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      const forced = MOCK_ERROR_ACCOUNTS[req.email]
+      if (forced) {
+        reject(forced)
+        return
+      }
+
+      const state = stateOf(req.email)
+      const now = Date.now()
+
+      // 지연이 끝났으면 카운터 초기화
+      if (state.throttledUntil && now >= state.throttledUntil) {
+        state.count = 0
+        state.throttledUntil = undefined
+      }
+
+      // case2·3 · 지연 창 안에서 재시도 (제출 버튼 비활성. 계정을 잠그지 않는다)
+      if (state.throttledUntil) {
+        reject({
+          code: 'AUTH_THROTTLED',
+          retryAfter: retryAfterSeconds(state.throttledUntil),
+        } satisfies ApiError)
+        return
+      }
+
+      const account = accounts[req.email]
+
+      // case4 · 미활성 계정 (명단 등록만 되고 아직 초대 활성화 안 함)
+      if (account && !account.active) {
+        reject({ code: 'AUTH_UNVERIFIED' } satisfies ApiError)
+        return
+      }
+
+      if (account && account.password === req.password) {
+        state.count = 0
+        resolve({
+          accessToken: 'mock-access-token',
+          role: account.role,
+          initialScreen: INITIAL_SCREEN[account.role],
+        })
+        return
+      }
+
+      // 실패 누적 → 임계 도달 시 지연 시작 (case2·3, 잠금 아님)
+      state.count += 1
+      if (state.count >= THROTTLE_THRESHOLD) {
+        state.throttledUntil = now + THROTTLE_DURATION_MS
+        reject({
+          code: 'AUTH_THROTTLED',
+          retryAfter: retryAfterSeconds(state.throttledUntil),
+        } satisfies ApiError)
+        return
+      }
+      reject({ code: 'AUTH_INVALID' } satisfies ApiError)
+    }, 500)
+  })
+
+  // ===== 실제 백엔드 버전 (연동 시 위를 지우고 주석 해제 · 함수에 async 추가) =====
+  // const res = await fetch('/auth/login', {
+  //   method: 'POST',
+  //   headers: { 'Content-Type': 'application/json' },
+  //   credentials: 'include', // refreshToken(HttpOnly Cookie) 수신
+  //   body: JSON.stringify(req),
+  // })
+  // if (!res.ok) return Promise.reject(await res.json()) // { code, retryAfter? }
+  // return res.json() // { accessToken, role, initialScreen }
+}
+
+/** POST /auth/resend-invite — 초대 메일 재발송(email 기준). 계정 존재 여부 비노출(항상 동일 응답) */
+export function resendInviteMail(_email: string): Promise<void> {
+  // ===== Mock 버전 =====
+  return new Promise((resolve) => setTimeout(() => resolve(), 500))
+
+  // ===== 실제 백엔드 버전 =====
+  // await fetch('/auth/resend-invite', {
+  //   method: 'POST',
+  //   headers: { 'Content-Type': 'application/json' },
+  //   body: JSON.stringify({ email }),
+  // })
+}

--- a/src/features/auth/authStates.tsx
+++ b/src/features/auth/authStates.tsx
@@ -1,0 +1,80 @@
+import type { ReactNode } from 'react'
+import type { AuthErrorCode, AlertVariant } from './authTypes'
+
+/**
+ * shared/login.html#cases (mockup c6911c0) · 상태별 UI (AUTH-03 예외 9 case 전량 1:1)
+ * 문구는 계약값 그대로 — 임의 변경 금지(계정 열거 방지 등 보안 규칙 포함).
+ */
+export interface AuthState {
+  variant: AlertVariant
+  message: ReactNode
+  /** 제출 버튼 비활성 (case2·3 지연 창) */
+  blockSubmit?: boolean
+  /** 초대 메일 재발송 링크 노출 (case4 미활성) */
+  showResend?: boolean
+}
+
+/** case 6·7·8은 사용자에겐 동일 문구(내부 처리만 다름) */
+const SYSTEM_MESSAGE = '일시적 오류입니다. 잠시 후 다시 시도하세요.'
+
+export function resolveAuthState(code: AuthErrorCode, retryAfter?: number): AuthState {
+  switch (code) {
+    // 1 인증 실패 — 계정 존재 여부를 노출하지 않는 단일 문구
+    case 'AUTH_INVALID':
+      return { variant: 'danger', message: '이메일 또는 비밀번호가 올바르지 않습니다.' }
+
+    // 2·3 연속 실패 지연 (잠금 아님) — 대기 창 동안 제출 비활성, 남은 시도 횟수는 노출하지 않는다
+    case 'AUTH_THROTTLED':
+      return {
+        variant: 'warning',
+        message: (
+          <>
+            시도가 너무 잦습니다.
+            <br />
+            {retryAfter ?? 30}초 후 다시 시도해 주세요.
+          </>
+        ),
+        blockSubmit: true,
+      }
+
+    // 4 미활성 계정 — 초대 링크로 활성화 전, 재발송 가능
+    case 'AUTH_UNVERIFIED':
+      return {
+        variant: 'info',
+        message: '초대 링크로 먼저 계정을 활성화해 주세요',
+        showResend: true,
+      }
+
+    // 5 정지된 계정 — 재발송 불가, 문의만(문구에 포함)
+    case 'AUTH_INACTIVE':
+      return {
+        variant: 'danger',
+        message: (
+          <>
+            사용이 중지된 계정입니다.
+            <br />
+            담당자에게 문의해 주세요.
+          </>
+        ),
+      }
+
+    // 6·7·8 시스템 오류 (동일 문구)
+    case 'AUTH_TOKEN_ISSUE':
+    case 'AUTH_ROLLBACK':
+    case 'AUTH_COOKIE':
+      return { variant: 'danger', message: SYSTEM_MESSAGE }
+
+    // 9 권한 컨텍스트 결여
+    case 'AUTH_NO_CONTEXT':
+      return {
+        variant: 'danger',
+        message: (
+          <>
+            계정 권한 설정에 문제가 있습니다.
+            <br />
+            담당자에게 문의해 주세요.
+          </>
+        ),
+      }
+  }
+}

--- a/src/features/auth/authTypes.ts
+++ b/src/features/auth/authTypes.ts
@@ -1,0 +1,47 @@
+// ─────────────────────────────────────────────────────────────
+// 인증 API 계약 · 출처: docs/plan/screen/definition/SC-A01-login.md §5
+// 백엔드 팀과 이 형태를 그대로 맞추면 연동 시 수정이 없습니다.
+// ─────────────────────────────────────────────────────────────
+
+export type Role = 'SUPERADMIN' | 'OPERATOR' | 'MANAGER' | 'TRAINEE'
+
+/** SC-A01/A02 상태 알림 색 — @/components/ui/Alert의 variant 어휘와 맞춘다 */
+export type AlertVariant = 'danger' | 'warning' | 'info'
+
+/** POST /auth/login 요청 */
+export interface LoginRequest {
+  email: string
+  password: string
+}
+
+/**
+ * POST /auth/login 성공 응답
+ * - refreshToken은 Set-Cookie(Secure·HttpOnly)로 내려오며 화면에서 접근/저장하지 않음
+ * - initialScreen: 서버가 판정한 역할의 초기 화면 경로 (클라이언트가 역할→화면을 매핑하지 않음)
+ */
+export interface LoginResponse {
+  accessToken: string
+  role: Role
+  initialScreen: string
+}
+
+/**
+ * AUTH-03 예외 9 case (mockup c6911c0 · shared/login.html#cases 계약 기준)
+ * v1 대비: 잠금(2·3)을 지연 1종(AUTH_THROTTLED)으로 병합. 4·5 이름이 서로 바뀐다 —
+ * AUTH_UNVERIFIED = 미활성(초대 전) · AUTH_INACTIVE = 정지. 반대로 쓰지 않는다.
+ */
+export type AuthErrorCode =
+  | 'AUTH_INVALID' // 1 이메일/비번 불일치
+  | 'AUTH_THROTTLED' // 2·3 연속 실패 지연 (잠금 아님)
+  | 'AUTH_UNVERIFIED' // 4 미활성 계정 — 초대 활성화 전, 재발송 가능
+  | 'AUTH_INACTIVE' // 5 정지된 계정 — 문의만
+  | 'AUTH_TOKEN_ISSUE' // 6 Access 발급 실패
+  | 'AUTH_ROLLBACK' // 7 Refresh 발급·DB 실패 → 롤백
+  | 'AUTH_COOKIE' // 8 Refresh Cookie 설정 실패
+  | 'AUTH_NO_CONTEXT' // 9 role/org_id 부재
+
+export interface ApiError {
+  code: AuthErrorCode
+  /** case 2·3에서만 내려옴 — 재시도까지 남은 초 */
+  retryAfter?: number
+}

--- a/src/features/auth/components/AuthForm.tsx
+++ b/src/features/auth/components/AuthForm.tsx
@@ -1,0 +1,32 @@
+import type { ReactNode } from 'react'
+
+interface Props {
+  title: string
+  subtitle?: string
+  /**
+   * 폼 박스 최소 높이 고정 (AU-01 §6).
+   * 세로 중앙 정렬이라 알림이 뜨면 박스가 커져 중앙이 다시 계산되고 제목·입력 필드가 올라간다.
+   * 높이를 박아 두면 알림 유무와 무관하게 시작 위치가 같다 — 남는 공간은 카드 맨 아래로 간다.
+   * form 엘리먼트가 아니라 **이 컨테이너**에 걸어야 버튼 아래에 빈 칸이 생기지 않는다.
+   */
+  stableHeight?: boolean
+  children: ReactNode
+}
+
+/**
+ * AU-01 §3 · 우 폼 패널 컨테이너 (AU-02·AU-03에서도 재사용)
+ *
+ * 이음선(왼쪽)에 붙인다 — 반쪽 가운데(mx-auto)에 두면 브랜드 패널과 서로 멀어진다.
+ * BrandPanel 주석 참고(01-design-checklist.md "인증 이음선").
+ */
+export default function AuthForm({ title, subtitle, stableHeight, children }: Props) {
+  return (
+    <div className="flex w-full flex-col justify-center p-8 sm:p-10 md:w-1/2 md:pl-16">
+      <div className={`w-full max-w-sm ${stableHeight ? 'min-h-[440px]' : ''}`}>
+        <h2 className="text-xl font-bold text-fg">{title}</h2>
+        {subtitle && <p className="mt-1 text-[13px] text-fg-subtle">{subtitle}</p>}
+        <div className="mt-6">{children}</div>
+      </div>
+    </div>
+  )
+}

--- a/src/features/auth/components/BrandPanel.tsx
+++ b/src/features/auth/components/BrandPanel.tsx
@@ -1,0 +1,45 @@
+import type { ReactNode } from 'react'
+import Wordmark from '@/components/common/Wordmark'
+
+interface Props {
+  /** 마케팅 리드 — 화면마다 다름 */
+  title?: ReactNode
+  description?: string
+  meta?: string
+}
+
+/**
+ * AU-01 §3 · 좌 브랜드 패널 (AU-02·AU-03 등 인증 계열 화면에서 재사용)
+ *
+ * items-end + 이음선(오른쪽) 쪽 패딩 — 반쪽의 가운데에 두면 화면이 넓어질수록
+ * 폼과 서로 멀어진다(1512에서 340px, 1920에서 540px). 양쪽을 이음선에 붙이면
+ * 간격이 128px로 고정되어 어떤 폭에서도 한 덩어리로 읽힌다(01-design-checklist.md
+ * "인증 이음선"). 배경은 계속 꽉 찬다.
+ */
+export default function BrandPanel({
+  title = (
+    <>
+      코드 이해도를
+      <br />
+      검증합니다
+    </>
+  ),
+  description = '제출한 코드의 특정 지점을 두고 왜 그렇게 했는지 묻습니다. 그 자리에서 설명할 수 있는지가 이해도입니다.',
+  meta = '교육 운영기관 전용 · 초대 기반 계정',
+}: Props) {
+  return (
+    <div className="hidden flex-col items-end justify-center bg-[linear-gradient(150deg,var(--color-brand-1),var(--color-brand-2))] p-10 text-white md:flex md:w-1/2 md:pr-16">
+      <div className="w-full max-w-md">
+        <div className="mb-10">
+          <Wordmark light />
+        </div>
+
+        <h1 className="text-[26px] font-bold leading-snug">{title}</h1>
+
+        <p className="mt-5 text-sm leading-relaxed text-white/70">{description}</p>
+
+        <p className="mt-10 text-xs text-white/45">{meta}</p>
+      </div>
+    </div>
+  )
+}

--- a/src/features/auth/components/TextLink.tsx
+++ b/src/features/auth/components/TextLink.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from 'react'
+import { Link } from 'react-router'
+
+interface Props {
+  children: ReactNode
+  to?: string
+  onClick?: () => void
+}
+
+/** SC-A01 §4 · TextLink (보조 링크) */
+export default function TextLink({ children, to, onClick }: Props) {
+  const cls = 'text-[13px] font-medium text-primary underline-offset-2 hover:underline'
+
+  if (to) {
+    return (
+      <Link to={to} className={cls}>
+        {children}
+      </Link>
+    )
+  }
+  return (
+    <button type="button" onClick={onClick} className={cls}>
+      {children}
+    </button>
+  )
+}

--- a/src/features/auth/mockDb.ts
+++ b/src/features/auth/mockDb.ts
@@ -1,0 +1,70 @@
+// ─────────────────────────────────────────────────────────────
+// ⚠️ Mock 전용 계정 저장소 — 백엔드 연동 시 이 파일을 통째로 삭제하세요.
+// 로그인(authApi)과 가입·활성화(inviteApi)가 같은 데이터를 보도록 하는 임시 DB입니다.
+// 실제로는 서버 DB의 accounts 테이블이 이 역할을 합니다.
+// ─────────────────────────────────────────────────────────────
+import type { Role } from './authTypes'
+
+export interface MockAccount {
+  email: string
+  name: string
+  role: Role
+  /** null = 아직 비밀번호 미설정 (명단만 등록된 상태) */
+  password: string | null
+  /** false = 활성화 전 → 로그인 차단 (AUTH-03 case4 AUTH_UNVERIFIED) */
+  active: boolean
+}
+
+export const accounts: Record<string, MockAccount> = {
+  // 이미 가입·활성화 완료된 계정 (로그인 시연용)
+  'manager@org.com': {
+    email: 'manager@org.com',
+    name: '박매니저',
+    role: 'MANAGER',
+    password: 'pass1234',
+    active: true,
+  },
+  'trainee@org.com': {
+    email: 'trainee@org.com',
+    name: '김교육생',
+    role: 'TRAINEE',
+    password: 'pass1234',
+    active: true,
+  },
+  'admin@iz-get.com': {
+    email: 'admin@iz-get.com',
+    name: '슈퍼어드민',
+    role: 'SUPERADMIN',
+    password: 'pass1234',
+    active: true,
+  },
+
+  // 매니저가 명단(ORG-01)에 등록만 해둔 교육생 — 활성화 전이라 로그인 불가
+  'newtrainee@org.com': {
+    email: 'newtrainee@org.com',
+    name: '이신입',
+    role: 'TRAINEE',
+    password: null,
+    active: false,
+  },
+}
+
+/** 매니저 회원가입 → 계정 생성 (AUTH-01) */
+export function createManagerAccount(email: string, name: string, password: string) {
+  accounts[email] = { email, name, role: 'MANAGER', password, active: true }
+}
+
+/** 교육생 활성화 → 비밀번호 설정 + status=ACTIVE (AUTH-06) */
+export function activateTraineeAccount(email: string, password: string) {
+  const account = accounts[email]
+  if (!account) return
+  account.password = password
+  account.active = true
+}
+
+/** 비밀번호 재설정 → 비밀번호만 교체 (AU-03) */
+export function resetAccountPassword(email: string, password: string) {
+  const account = accounts[email]
+  if (!account) return
+  account.password = password
+}

--- a/src/features/auth/useCapsLockWarning.ts
+++ b/src/features/auth/useCapsLockWarning.ts
@@ -1,0 +1,20 @@
+import { useState, type FocusEvent, type KeyboardEvent } from 'react'
+
+/**
+ * Caps Lock이 켜진 채 비밀번호를 입력해도 값이 가려져 있어 화면만 봐선 원인을 알 수 없다.
+ * 로그인 실패 후 안내하는 것보다 입력 중에 알려주는 편이 낫다. 수식키 상태는 키 이벤트에서만
+ * 읽혀 첫 키를 누르는 순간부터 판정되고, 필드를 떠나면 그 자리에서만 의미 있는 경고라 지운다.
+ */
+export function useCapsLockWarning() {
+  const [capsLock, setCapsLock] = useState(false)
+
+  function detect(event: KeyboardEvent<HTMLInputElement>) {
+    setCapsLock(event.getModifierState('CapsLock'))
+  }
+
+  function reset(_event: FocusEvent<HTMLInputElement>) {
+    setCapsLock(false)
+  }
+
+  return { capsLock, onKeyDown: detect, onKeyUp: detect, onBlur: reset }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,11 +2,16 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { RouterProvider } from 'react-router'
 import { router } from '@/app/routes'
+import { AuthProvider } from '@/features/auth/AuthContext'
 import './index.css'
 
 /*
-  AuthProvider는 v1 격리와 함께 뺐다 — v2 뼈대(#50)는 인증을 다루지 않고,
-  인증을 다시 짤 때 features-v1/auth를 참고해 새로 붙인다.
+  전역 프로바이더가 둘이 됐다(AuthProvider · RouterProvider). 셋째가 생기면
+  app/providers.tsx로 뺀다 — 지금 빼면 wrapper 두 줄짜리 파일이 하나 늘 뿐이다.
+
+  AuthProvider가 바깥이다. 라우트 화면이 useAuth()를 쓰므로 라우터보다 위에 있어야 한다.
+  AU-01 이식(#52)으로 features/auth/AuthContext가 v2 자리에 생겨서 다시 연결했다
+  — features-v1/auth가 아니라 v2 쪽을 가리킨다.
 
   HashRouter가 아니라 createBrowserRouter를 쓴다(app/routes.tsx). 주소에 #이 없어야
   링크·SEO·초대 링크(/invite/:token)가 자연스럽다. 정적 호스팅에 올릴 때는 서버에서
@@ -14,6 +19,8 @@ import './index.css'
 */
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <RouterProvider router={router} />
+    <AuthProvider>
+      <RouterProvider router={router} />
+    </AuthProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
## 작업 내용

`features-v1/auth/LoginScreen.tsx`를 v2 스켈레톤(`features/auth/LoginScreen.tsx`)으로 이식했다. v1 구현이 이미 v2 케이스 계약(`shared/login.html#cases` — 에러코드 9종, 지연 방식, 문구까지)과 정확히 일치하는 상태라 새로 짜지 않고 그대로 옮겼다.

> **원 구현 출처:** `features-v1/auth/LoginScreen.tsx`의 케이스 계약 정렬 작업은 PR #44(이슈 #43, 팀원 @vneed154)가 했다. 이 PR은 그 구현을 v2 셸 구조로 옮기고 배선한 것 — 로그인 상태·에러코드·보안 로직 자체는 새로 작성하지 않았다.

- 공용 인프라(`AuthContext`·`authApi`·`authTypes`·`authStates`·`mockDb`·`useCapsLockWarning`·`components/{AuthForm,BrandPanel,TextLink}`)는 v1에서 **복사**(이동 아님) — `mockDb`는 아직 이식 전인 초대·비밀번호재설정 화면도 참조하므로 지금 이동하면 v1에 남은 그 화면들의 import가 깨진다. AU-02·AU-03까지 이식되면 `features-v1/auth`를 통째로 정리한다.
- `01-design-checklist.md`의 인증 이음선 규칙(브랜드 `items-end md:pr-16`, 폼 `mx-auto` 제거 + `md:pl-16`) 적용 — v1 코드가 이 부분만 체크리스트와 어긋나 있었다.
- `main.tsx`에 `AuthProvider` 복원(v2 `features/auth/AuthContext` 참조) — v1 격리(#50) 때 임시로 뺐던 것.

## 리뷰 포인트

- `features-v1/auth`는 이 PR에서 안 건드림(초대·재설정 화면이 아직 그 폴더의 공용 파일을 참조 중)
- 이음선 CSS(`md:pr-16`/`md:pl-16`)가 바뀐 부분 — 1512·1920 두 폭에서 시각 확인함

## 확인

- [x] `/shared/login`에서 자격 불일치(`AUTH_INVALID`) 알림 실제 재현, 로그인 성공 시 역할별 초기 화면(`/manager/dashboard`)으로 라우팅 확인
- [x] `npm run typecheck` / `format:check` / `lint` / `build` / `check:design` 전부 통과
- [x] 하나의 PR = 하나의 기능

closes #52