### PR TITLE
[Feat] Migrate AU-03 Password Reset to v2 ConsoleShell Skeleton

### DIFF
--- a/docs/plan/v2/wireframe/shared/password-reset.html
+++ b/docs/plan/v2/wireframe/shared/password-reset.html
@@ -336,12 +336,12 @@
         <div class="meta">1회성 링크 · 시간이 지나면 다시 요청해야 합니다</div>
       </div>
       <div class="formside">
-        <div class="scard warn">
-          <div class="ic">◷</div>
+        <div class="scard bad">
+          <div class="ic">!</div>
           <h3>유효하지 않은 링크입니다</h3>
           <p>이 링크로는 비밀번호를 바꿀 수 없어요.</p>
           <div class="aux">메일에 있는 링크를 다시 눌러 보세요. 계속 같으면 담당자에게 문의해 주세요.</div>
-          <div class="act"><span class="b">다시 요청하기</span></div>
+          <div class="act"><span class="b">문의하기</span></div>
         </div>
       </div>
     </div>

--- a/src/features/auth/PasswordResetScreen.tsx
+++ b/src/features/auth/PasswordResetScreen.tsx
@@ -1,6 +1,385 @@
-import PlaceholderScreen from '@/app/PlaceholderScreen'
+import { useEffect, useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { Link, useNavigate, useSearchParams } from 'react-router'
+import { EyeIcon, EyeOffIcon } from 'lucide-react'
+import { requestPasswordReset, verifyResetToken, confirmPasswordReset } from './passwordResetApi'
+import { resolvePasswordResetState } from './passwordResetStates'
+import type { PasswordResetState } from './passwordResetStates'
+import { checkPasswordPolicy } from './passwordPolicy'
+import type { PasswordResetApiError } from './passwordResetTypes'
+import { useCapsLockWarning } from './useCapsLockWarning'
+import BrandPanel from './components/BrandPanel'
+import AuthForm from './components/AuthForm'
+import TextLink from './components/TextLink'
+import AuthStatusCard from './components/AuthStatusCard'
+import Stepbar from './components/Stepbar'
+import { Alert } from '@/components/ui/Alert'
+import { Field, FieldLabel, FieldError, FieldDescription } from '@/components/ui/Field'
+import { Input } from '@/components/ui/Input'
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from '@/components/ui/InputGroup'
+import { Kbd } from '@/components/ui/Kbd'
+import { Button } from '@/components/ui/Button'
 
-/** AU-03 비밀번호 재설정 — 화면 이식 전 자리표시. 실제 화면이 들어오면 이 파일 내용만 바뀐다. */
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+interface RequestFormValues {
+  email: string
+}
+
+interface SetPasswordFormValues {
+  password: string
+  passwordConfirm: string
+}
+
+/** AU-03 §3 ① 요청 — 계정 유무·활성 상태와 무관하게 항상 같은 결과(계정 열거 방지) */
+function RequestStage() {
+  const [sentEmail, setSentEmail] = useState<string | null>(null)
+  const [resent, setResent] = useState(false)
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<RequestFormValues>({ defaultValues: { email: '' } })
+
+  async function onSubmit(values: RequestFormValues) {
+    await requestPasswordReset(values.email)
+    setSentEmail(values.email)
+  }
+
+  async function handleResend() {
+    if (!sentEmail) return
+    await requestPasswordReset(sentEmail)
+    setResent(true)
+  }
+
+  if (sentEmail) {
+    return (
+      <AuthStatusCard
+        variant="info"
+        icon="✉"
+        title="메일을 보냈습니다"
+        description={
+          <>
+            받은 편지함을 확인해 주세요.
+            <br />
+            입력하신 주소가 계정에 등록돼 있으면 재설정 링크가 도착합니다.
+          </>
+        }
+        aux="메일이 오지 않으면 스팸함을 확인해 주세요."
+        actions={
+          <>
+            {resent ? (
+              <span className="self-center text-[13px] text-fg-subtle">다시 보냈습니다.</span>
+            ) : (
+              <Button variant="ghost" onClick={handleResend}>
+                다시 보내기
+              </Button>
+            )}
+            <Button nativeButton={false} render={<Link to="/shared/login" />}>
+              로그인으로
+            </Button>
+          </>
+        }
+      />
+    )
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} noValidate className="space-y-4">
+      <Stepbar active={1} />
+
+      <Field data-invalid={!!errors.email}>
+        <FieldLabel htmlFor="reset-email">이메일</FieldLabel>
+        <Input
+          id="reset-email"
+          type="email"
+          placeholder="manager@org.com"
+          autoComplete="username"
+          disabled={isSubmitting}
+          aria-invalid={!!errors.email}
+          {...register('email', {
+            required: '이메일을 입력해주세요.',
+            pattern: { value: EMAIL_PATTERN, message: '올바른 이메일 형식이 아닙니다.' },
+          })}
+        />
+        <FieldError>{errors.email?.message}</FieldError>
+      </Field>
+
+      <div className="pt-1">
+        <Button type="submit" size="lg" disabled={isSubmitting}>
+          {isSubmitting ? '전송 중…' : '재설정 메일 보내기'}
+        </Button>
+      </div>
+
+      <div className="text-center">
+        <TextLink to="/shared/login">← 로그인으로</TextLink>
+      </div>
+    </form>
+  )
+}
+
+/** AU-03 §3 ② 설정 — 링크(?token=) 진입, 새 비밀번호 설정 */
+function SetPasswordStage({ token }: { token: string }) {
+  const navigate = useNavigate()
+  const [verifying, setVerifying] = useState(true)
+  const [tokenAlert, setTokenAlert] = useState<PasswordResetState | null>(null)
+  const [submitAlert, setSubmitAlert] = useState<string | null>(null)
+  const [done, setDone] = useState<'full' | 'partial' | null>(null)
+
+  const [showPassword, setShowPassword] = useState(false)
+  const [showPasswordConfirm, setShowPasswordConfirm] = useState(false)
+  const passwordCaps = useCapsLockWarning()
+  const passwordConfirmCaps = useCapsLockWarning()
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    trigger,
+    setError,
+    formState: { errors, isSubmitting },
+  } = useForm<SetPasswordFormValues>({ defaultValues: { password: '', passwordConfirm: '' } })
+
+  const password = watch('password')
+  const policyUnmet = errors.password ? checkPasswordPolicy(password) : []
+
+  const passwordField = register('password', {
+    validate: (value) => {
+      const unmet = checkPasswordPolicy(value)
+      return unmet.length === 0 || unmet.join(' · ')
+    },
+    // 확인란 에러가 이미 떠 있으면, 비밀번호 쪽을 고쳐도 확인란을 재검사해 스테일 에러 제거
+    onChange: () => {
+      if (errors.passwordConfirm) void trigger('passwordConfirm')
+    },
+  })
+  const passwordConfirmField = register('passwordConfirm', {
+    validate: (value, formValues) =>
+      value === formValues.password || '비밀번호가 일치하지 않습니다.',
+    deps: ['password'],
+  })
+
+  // 진입 시 토큰 검증 — 만료·사용됨·위변조면 폼을 렌더하지 않는다. 계정 활성 상태는 보지 않는다
+  useEffect(() => {
+    verifyResetToken(token)
+      .catch((err: PasswordResetApiError) => setTokenAlert(resolvePasswordResetState(err.code)))
+      .finally(() => setVerifying(false))
+  }, [token])
+
+  async function onSubmit(values: SetPasswordFormValues) {
+    setSubmitAlert(null)
+    try {
+      const res = await confirmPasswordReset({ token, password: values.password })
+      setDone(res.revokeFailed ? 'partial' : 'full')
+    } catch (err) {
+      const { code } = err as PasswordResetApiError
+      if (code === 'SAME_AS_CURRENT') {
+        setError('password', { type: 'manual', message: '지금 쓰는 비밀번호와 달라야 합니다' })
+        return
+      }
+      setSubmitAlert(resolvePasswordResetState(code).message)
+    }
+  }
+
+  if (verifying) {
+    return <p className="text-[13px] text-fg-subtle">링크를 확인하는 중…</p>
+  }
+
+  // password-reset.html #expired·#invalid — 토큰 검증 실패 상태 카드
+  if (tokenAlert) {
+    if (tokenAlert.action === 'REQUEST_AGAIN') {
+      return (
+        <AuthStatusCard
+          variant="warning"
+          icon="◷"
+          title="링크가 만료되었습니다"
+          description="재설정 링크는 한 번만, 정해진 시간 안에만 쓸 수 있어요."
+          aux="다시 요청하면 새 링크를 보내드립니다."
+          actions={
+            <Button nativeButton={false} render={<Link to="/shared/password-reset" />}>
+              다시 요청하기
+            </Button>
+          }
+        />
+      )
+    }
+    // RESET_TOKEN_INVALID — 위변조는 재요청해도 같은 일이 반복될 것이라 문의로 보낸다
+    // (§6, 보안 로그). AU-02의 동일 케이스와 같은 톤 — danger + 문의하기.
+    // 목업 #invalid 페이지가 한때 #expired를 복사한 채(scard warn·다시 요청하기
+    // 버튼)로 남아 있었는데, 케이스 계약표·정의서와 대조해 danger·문의하기로
+    // 정정했다(목업도 함께 수정).
+    return (
+      <AuthStatusCard
+        variant="danger"
+        icon="!"
+        title="유효하지 않은 링크입니다"
+        description="이 링크로는 비밀번호를 바꿀 수 없어요."
+        aux="메일에 있는 링크를 다시 눌러 보세요. 계속 같으면 담당자에게 문의해 주세요."
+        actions={
+          <Button nativeButton={false} render={<a href="mailto:support@iz-get.com" />}>
+            문의하기
+          </Button>
+        }
+      />
+    )
+  }
+
+  if (done) {
+    return (
+      <AuthStatusCard
+        variant={done === 'full' ? 'success' : 'warning'}
+        icon={done === 'full' ? '✓' : '!'}
+        title="비밀번호가 바뀌었습니다"
+        description="새 비밀번호로 다시 로그인해 주세요."
+        aux={
+          done === 'full'
+            ? '보안을 위해 다른 기기에서는 모두 로그아웃되었어요.'
+            : '다른 기기는 아직 로그아웃되지 않았을 수 있어요. 계속 시도하고 있습니다 — 공용 기기를 쓰셨다면 직접 로그아웃해 주세요.'
+        }
+        actions={
+          <Button onClick={() => navigate('/shared/login', { replace: true })}>로그인</Button>
+        }
+      />
+    )
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} noValidate className="space-y-4">
+      <Stepbar active={2} />
+
+      {/* 저장 실패(case7) — 비밀번호는 아직 안 바뀜, 폼은 유지 */}
+      {submitAlert && <Alert variant="danger">{submitAlert}</Alert>}
+
+      <Field data-invalid={!!errors.password}>
+        <FieldLabel htmlFor="reset-password">새 비밀번호</FieldLabel>
+        <InputGroup>
+          <InputGroupInput
+            id="reset-password"
+            type={showPassword ? 'text' : 'password'}
+            placeholder="비밀번호 설정"
+            autoComplete="new-password"
+            disabled={isSubmitting}
+            aria-invalid={!!errors.password}
+            {...passwordField}
+            onKeyDown={passwordCaps.onKeyDown}
+            onKeyUp={passwordCaps.onKeyUp}
+            onBlur={(event) => {
+              passwordCaps.onBlur(event)
+              passwordField.onBlur(event)
+            }}
+          />
+          <InputGroupAddon align="inline-end">
+            <InputGroupButton
+              size="icon-xs"
+              aria-label={showPassword ? '비밀번호 숨기기' : '비밀번호 표시'}
+              aria-pressed={showPassword}
+              disabled={isSubmitting}
+              onClick={() => setShowPassword((v) => !v)}
+            >
+              {showPassword ? <EyeOffIcon /> : <EyeIcon />}
+            </InputGroupButton>
+          </InputGroupAddon>
+        </InputGroup>
+        {passwordCaps.capsLock && (
+          <p role="status" className="flex items-center gap-1.5 text-xs text-warning">
+            <Kbd>⇪ Caps Lock</Kbd> 켜짐 — 대문자로 입력됩니다.
+          </p>
+        )}
+        {errors.password ? (
+          <FieldError>
+            {policyUnmet.length > 0 ? policyUnmet.join(' · ') : errors.password.message}
+          </FieldError>
+        ) : (
+          <FieldDescription>8자 이상 · 영문·숫자·특수문자 포함</FieldDescription>
+        )}
+      </Field>
+
+      <Field data-invalid={!!errors.passwordConfirm}>
+        <FieldLabel htmlFor="reset-password-confirm">새 비밀번호 확인</FieldLabel>
+        <InputGroup>
+          <InputGroupInput
+            id="reset-password-confirm"
+            type={showPasswordConfirm ? 'text' : 'password'}
+            placeholder="다시 입력"
+            autoComplete="new-password"
+            disabled={isSubmitting}
+            aria-invalid={!!errors.passwordConfirm}
+            {...passwordConfirmField}
+            onKeyDown={passwordConfirmCaps.onKeyDown}
+            onKeyUp={passwordConfirmCaps.onKeyUp}
+            onBlur={(event) => {
+              passwordConfirmCaps.onBlur(event)
+              passwordConfirmField.onBlur(event)
+            }}
+          />
+          <InputGroupAddon align="inline-end">
+            <InputGroupButton
+              size="icon-xs"
+              aria-label={showPasswordConfirm ? '비밀번호 숨기기' : '비밀번호 표시'}
+              aria-pressed={showPasswordConfirm}
+              disabled={isSubmitting}
+              onClick={() => setShowPasswordConfirm((v) => !v)}
+            >
+              {showPasswordConfirm ? <EyeOffIcon /> : <EyeIcon />}
+            </InputGroupButton>
+          </InputGroupAddon>
+        </InputGroup>
+        {passwordConfirmCaps.capsLock && (
+          <p role="status" className="flex items-center gap-1.5 text-xs text-warning">
+            <Kbd>⇪ Caps Lock</Kbd> 켜짐 — 대문자로 입력됩니다.
+          </p>
+        )}
+        <FieldError>{errors.passwordConfirm?.message}</FieldError>
+      </Field>
+
+      <div className="pt-1">
+        <Button type="submit" size="lg" disabled={isSubmitting}>
+          {isSubmitting ? '비밀번호를 바꾸는 중…' : submitAlert ? '다시 시도' : '비밀번호 변경'}
+        </Button>
+      </div>
+
+      <div className="text-center">
+        <TextLink to="/shared/login">← 로그인으로</TextLink>
+      </div>
+    </form>
+  )
+}
+
+/**
+ * AU-03 · 비밀번호 재설정 — 요청 → 설정 두 단계
+ * 라우트는 `/shared/password-reset` 하나뿐 — 쿼리 파라미터 `token` 유무로 컴포넌트
+ * 내부에서만 단계를 나눈다(§9 — 토큰 없이 ②에 오면 막다른 화면 대신 ①로 보낸다).
+ * 새 라우트를 추가하지 않는다.
+ */
 export default function PasswordResetScreen() {
-  return <PlaceholderScreen code="AU-03" title="비밀번호 재설정" />
+  const [searchParams] = useSearchParams()
+  const token = searchParams.get('token')
+
+  return (
+    <div className="flex min-h-screen w-full bg-canvas">
+      <div className="flex w-full bg-surface">
+        <BrandPanel />
+        {token ? (
+          <AuthForm
+            title="새 비밀번호 설정"
+            subtitle="지금 쓰던 비밀번호와 다른 비밀번호를 입력하세요."
+          >
+            <SetPasswordStage token={token} />
+          </AuthForm>
+        ) : (
+          <AuthForm
+            title="비밀번호 재설정"
+            subtitle="계정 이메일을 입력하면 재설정 링크를 보냅니다."
+          >
+            <RequestStage />
+          </AuthForm>
+        )}
+      </div>
+    </div>
+  )
 }

--- a/src/features/auth/components/AuthStatusCard.tsx
+++ b/src/features/auth/components/AuthStatusCard.tsx
@@ -1,0 +1,43 @@
+import type { ReactNode } from 'react'
+import { cn } from '@/lib/utils/cn'
+
+export type AuthStatusVariant = 'info' | 'warning' | 'danger' | 'success'
+
+const ICON_VARIANT_CLASS: Record<AuthStatusVariant, string> = {
+  info: 'bg-info-soft text-info',
+  warning: 'bg-warning-soft text-warning',
+  danger: 'bg-danger-soft text-danger',
+  success: 'bg-success-soft text-success',
+}
+
+interface Props {
+  variant: AuthStatusVariant
+  icon: ReactNode
+  title: string
+  description: ReactNode
+  aux?: ReactNode
+  actions: ReactNode
+}
+
+/**
+ * signup-activation.html / password-reset.html `.scard` — 폼을 통째로 대체하는
+ * 상태 화면(만료·위변조·완료 등) 전용 카드. 필드 아래 인라인 에러에는 쓰지 않는다.
+ */
+export default function AuthStatusCard({ variant, icon, title, description, aux, actions }: Props) {
+  return (
+    <div className="mx-auto w-full max-w-[460px] text-center">
+      <div
+        className={cn(
+          'mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-[15px] text-xl',
+          ICON_VARIANT_CLASS[variant],
+        )}
+      >
+        {icon}
+      </div>
+      <h3 className="text-base font-bold text-fg">{title}</h3>
+      <p className="mt-1.5 text-[13px] leading-relaxed text-fg-muted">{description}</p>
+      {aux && <p className="mt-3 text-xs leading-relaxed text-fg-subtle">{aux}</p>}
+      <div className="mt-5 flex justify-center gap-2">{actions}</div>
+    </div>
+  )
+}

--- a/src/features/auth/components/Stepbar.tsx
+++ b/src/features/auth/components/Stepbar.tsx
@@ -1,0 +1,10 @@
+/** password-reset.html `.stepbar` — AU-03 두 단계(요청·설정) 진행 표시 */
+export default function Stepbar({ active }: { active: 1 | 2 }) {
+  return (
+    <div className="mb-6 flex gap-2 text-[11px] text-fg-subtle">
+      <span className={active === 1 ? 'font-semibold text-primary' : ''}>1 요청</span>
+      <span>›</span>
+      <span className={active === 2 ? 'font-semibold text-primary' : ''}>2 설정</span>
+    </div>
+  )
+}

--- a/src/features/auth/passwordPolicy.ts
+++ b/src/features/auth/passwordPolicy.ts
@@ -1,0 +1,13 @@
+/**
+ * 비밀번호 정책(AU-02·AU-03 공용) — 미충족 기준 목록을 돌려준다.
+ * v1에서는 AU-02 전용 파일(inviteStates.ts)에 얹혀 있었는데, AU-03도 같은 함수가
+ * 필요해지면서(두 번째 실사용) 화면을 모르는 순수 함수로 여기 뺐다.
+ */
+export function checkPasswordPolicy(password: string): string[] {
+  const unmet: string[] = []
+  if (password.length < 8) unmet.push('8자 이상')
+  if (!/[A-Za-z]/.test(password)) unmet.push('영문 포함')
+  if (!/[0-9]/.test(password)) unmet.push('숫자 포함')
+  if (!/[^A-Za-z0-9]/.test(password)) unmet.push('특수문자 포함')
+  return unmet
+}

--- a/src/features/auth/passwordResetApi.ts
+++ b/src/features/auth/passwordResetApi.ts
@@ -1,0 +1,105 @@
+// ─────────────────────────────────────────────────────────────
+// 비밀번호 재설정 API 격리 모듈 (password-reset.html#cases · mockup c6911c0)
+// 백엔드 준비 시 각 함수의 Mock 블록만 지우고 아래 fetch를 켜면 됩니다.
+// ─────────────────────────────────────────────────────────────
+import type {
+  ConfirmResetRequest,
+  ConfirmResetResponse,
+  PasswordResetApiError,
+  ResetTokenInfo,
+} from './passwordResetTypes'
+import { accounts, resetAccountPassword } from './mockDb'
+
+// ───────── Mock 재설정 토큰 (백엔드 연동 시 이 블록 전체 삭제) ─────────
+/** 정상 토큰 — 어느 계정의 비밀번호를 바꿀지 결정 */
+const MOCK_RESET_TOKENS: Record<string, string> = {
+  'reset-valid': 'manager@org.com',
+  'reset-revokefail': 'manager@org.com', // 성공하지만 세션 폐기가 실패하는 case8 시연용
+  'reset-failing': 'manager@org.com', // 제출 단계에서 항상 실패하는 case7 시연용
+}
+
+/** 토큰 검증 단계에서 바로 실패하는 시연용 토큰 */
+const MOCK_RESET_TOKEN_ERRORS: Record<string, PasswordResetApiError> = {
+  'reset-expired': { code: 'RESET_TOKEN_EXPIRED' },
+  'reset-used': { code: 'RESET_TOKEN_USED' },
+  'reset-tampered': { code: 'RESET_TOKEN_INVALID' },
+}
+
+function delay<T>(value: T, ms = 500): Promise<T> {
+  return new Promise((resolve) => setTimeout(() => resolve(value), ms))
+}
+// ──────────────────────────────────────────────────────────────
+
+/** POST /auth/password-reset/request — 항상 202. 정상·없는 이메일·미활성 계정 셋 다 같은 응답(계정 열거 방지) */
+export function requestPasswordReset(_email: string): Promise<void> {
+  // ===== Mock 버전 =====
+  return delay(undefined)
+
+  // ===== 실제 백엔드 버전 =====
+  // await fetch('/auth/password-reset/request', {
+  //   method: 'POST',
+  //   headers: { 'Content-Type': 'application/json' },
+  //   body: JSON.stringify({ email }),
+  // })
+}
+
+/** GET /auth/password-reset/{token} — 토큰 검증(만료·사용됨·위변조만 판정, 계정 활성 상태는 보지 않는다) */
+export function verifyResetToken(token: string): Promise<ResetTokenInfo> {
+  // ===== Mock 버전 =====
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      const failure = MOCK_RESET_TOKEN_ERRORS[token]
+      if (failure) {
+        reject(failure)
+        return
+      }
+      const email = MOCK_RESET_TOKENS[token]
+      if (!email) {
+        reject({ code: 'RESET_TOKEN_INVALID' } satisfies PasswordResetApiError)
+        return
+      }
+      resolve({ email })
+    }, 400)
+  })
+
+  // ===== 실제 백엔드 버전 =====
+  // const res = await fetch(`/auth/password-reset/${token}`)
+  // if (!res.ok) return Promise.reject(await res.json())
+  // return res.json() // { email }
+}
+
+/** POST /auth/password-reset/confirm — 새 비밀번호 저장, 성공 시 서버가 기존 세션 전부 폐기 시도 */
+export function confirmPasswordReset(req: ConfirmResetRequest): Promise<ConfirmResetResponse> {
+  // ===== Mock 버전 =====
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      // case7 시연용 — 항상 저장 실패(롤백, 비밀번호 아직 안 바뀜)
+      if (req.token === 'reset-failing') {
+        reject({ code: 'RESET_FAILED' } satisfies PasswordResetApiError)
+        return
+      }
+      const email = MOCK_RESET_TOKENS[req.token]
+      if (!email) {
+        reject({ code: 'RESET_TOKEN_INVALID' } satisfies PasswordResetApiError)
+        return
+      }
+      const account = accounts[email]
+      // case6 — 지금 쓰는 비밀번호와 같음(클라이언트는 현재 비밀번호를 모르므로 서버가 판정)
+      if (account?.password === req.password) {
+        reject({ code: 'SAME_AS_CURRENT' } satisfies PasswordResetApiError)
+        return
+      }
+      resetAccountPassword(email, req.password)
+      resolve({ revokeFailed: req.token === 'reset-revokefail' })
+    }, 600)
+  })
+
+  // ===== 실제 백엔드 버전 =====
+  // const res = await fetch('/auth/password-reset/confirm', {
+  //   method: 'POST',
+  //   headers: { 'Content-Type': 'application/json' },
+  //   body: JSON.stringify(req), // { token, password }
+  // })
+  // if (!res.ok) return Promise.reject(await res.json())
+  // return res.json() // { revokeFailed }
+}

--- a/src/features/auth/passwordResetStates.ts
+++ b/src/features/auth/passwordResetStates.ts
@@ -1,0 +1,32 @@
+import type { PasswordResetErrorCode } from './passwordResetTypes'
+
+/** password-reset.html#cases (mockup c6911c0) · 토큰 검증 단계 상태별 UI */
+export interface PasswordResetState {
+  message: string
+  /** 알림 안에 노출할 후속 행동 */
+  action?: 'REQUEST_AGAIN' | 'CONTACT'
+}
+
+export function resolvePasswordResetState(code: PasswordResetErrorCode): PasswordResetState {
+  switch (code) {
+    // 2·3 — 만료·이미 사용됨 (할 일이 재요청으로 같아 한 화면)
+    case 'RESET_TOKEN_EXPIRED':
+    case 'RESET_TOKEN_USED':
+      return { message: '링크가 만료되었습니다', action: 'REQUEST_AGAIN' }
+
+    // 4 — 위변조·목적 불일치. 재요청해도 같은 일이 반복되므로 문의로 보낸다(보안 로그)
+    case 'RESET_TOKEN_INVALID':
+      return { message: '유효하지 않은 링크입니다', action: 'CONTACT' }
+
+    // 6 — 지금 쓰는 비밀번호와 같음. 필드 하단에 붙이므로 여기서는 도달하지 않지만
+    // confirmPasswordReset 실패 분기가 이 타입을 공유한다
+    case 'SAME_AS_CURRENT':
+      return { message: '지금 쓰는 비밀번호와 달라야 합니다' }
+
+    // 7 — 저장 실패·롤백. 비밀번호는 아직 안 바뀜
+    case 'RESET_FAILED':
+      return {
+        message: '잠시 문제가 있었어요. 다시 시도해 주세요. 비밀번호는 아직 바뀌지 않았습니다.',
+      }
+  }
+}

--- a/src/features/auth/passwordResetTypes.ts
+++ b/src/features/auth/passwordResetTypes.ts
@@ -1,0 +1,41 @@
+// ─────────────────────────────────────────────────────────────
+// 비밀번호 재설정 API 계약 · 출처: docs/plan/v2/wireframe/shared/password-reset.html#cases (mockup c6911c0)
+// ─────────────────────────────────────────────────────────────
+
+/** POST /auth/password-reset/request — 항상 202, 계정 유무·활성 상태와 무관하게 동일 응답 */
+export interface RequestResetRequest {
+  email: string
+}
+
+/** GET /auth/password-reset/{token} 응답 */
+export interface ResetTokenInfo {
+  email: string
+}
+
+/** POST /auth/password-reset/confirm */
+export interface ConfirmResetRequest {
+  token: string
+  password: string
+}
+
+/** POST /auth/password-reset/confirm 성공 응답 — 세션 폐기가 실패해도 비밀번호 변경 자체는 성공이다 */
+export interface ConfirmResetResponse {
+  /** true면 다른 기기 세션 폐기가 실패 — #donepartial 렌더, 서버는 계속 재시도 */
+  revokeFailed: boolean
+}
+
+/**
+ * 케이스 계약 · AUTH-05 전량 (구현 근거)
+ * PR_INACTIVE_ACCOUNT(v1 라운드)는 삭제됐다 — 미활성 계정은 ①요청 단계에서 이미
+ * 항상 202로 균일 처리되고, 토큰 검증 단계에서는 애초에 발생하지 않는 케이스다.
+ */
+export type PasswordResetErrorCode =
+  | 'RESET_TOKEN_EXPIRED' // 2 — 링크 만료
+  | 'RESET_TOKEN_USED' // 3 — 이미 사용됨 (2와 같은 화면)
+  | 'RESET_TOKEN_INVALID' // 4(신규) — 위변조·목적 불일치, 보안 로그
+  | 'SAME_AS_CURRENT' // 6(신규) — 지금 쓰는 비밀번호와 같음
+  | 'RESET_FAILED' // 7 — 저장 실패·롤백 (비밀번호 아직 안 바뀜)
+
+export interface PasswordResetApiError {
+  code: PasswordResetErrorCode
+}


### PR DESCRIPTION
## 작업 내용

`features-v1/auth/PasswordResetScreen.tsx`를 v2 스켈레톤(`features/auth/PasswordResetScreen.tsx`)으로 이식했다. AU-01(#53)과 같은 패턴 — v1 구현이 이미 v2 케이스 계약과 대부분 일치해 새로 짜지 않고 옮겼다.

> **원 구현 출처:** `PasswordResetScreen.tsx`의 케이스 계약 정렬 작업은 PR #44(이슈 #43, 팀원 @vneed154)가 했다. 이 PR은 그 구현을 v2 셸 구조로 옮기고 배선한 것 — `#invalid` 목업 버그(아래) 발견·수정 외에는 재설정 상태·에러코드 로직을 새로 작성하지 않았다.

- 공용 인프라(`passwordResetApi`·`passwordResetStates`·`passwordResetTypes`·`components/{AuthStatusCard,Stepbar}`)는 v1에서 **복사**(이동 아님, AU-01과 같은 이유 — AU-02가 아직 이식 전).
- `checkPasswordPolicy`를 AU-02 전용 파일(`inviteStates.ts`)에서 `features/auth/passwordPolicy.ts`(공용)로 분리 — AU-03이 이 함수의 두 번째 실사용처가 된 지금이 분리 시점.
- **목업 버그 발견·수정**: `shared/password-reset.html`의 `#invalid`(위변조) 상태가 `#expired`를 복사하며 버튼 라벨("다시 요청하기")을 안 고친 채 남아 있었다. 케이스 계약표·정의서 §6·AU-02의 동일 케이스 셋 다 "문의하기"를 요구한다 — v1 코드 주석이 이미 이 불일치를 의심하고 있었고("팀장 확인 필요"), 목업과 직접 대조해 확정했다. `scard warn`→`bad`, 아이콘 `◷`→`!`로 목업·코드 둘 다 수정.

## 리뷰 포인트

- `docs/plan/v2/wireframe/shared/password-reset.html` diff — 목업 자체를 고친 부분(코드 리뷰와 별개로, 이 목업이 배포되면 GitHub Pages에도 반영돼야 함 — 별도로 처리 예정)
- `features-v1/auth`는 이 PR에서 안 건드림(AU-02가 아직 그 폴더를 참조 중)

## 확인

- [x] `/shared/password-reset`에서 요청→`#sent`, `?token=reset-expired`→`#expired`, `?token=reset-tampered`→`#invalid`(danger+!+문의하기) 전부 실제 렌더 확인
- [x] `npm run typecheck` / `format:check` / `lint` / `build` / `check:design` 전부 통과
- [x] 하나의 PR = 하나의 기능

closes #54