### PR TITLE
[Feat] Migrate MG-05 Trainee List to v2 ConsoleShell Skeleton

### DIFF
--- a/src/features/manager/trainees/TraineeListScreen.tsx
+++ b/src/features/manager/trainees/TraineeListScreen.tsx
@@ -1,11 +1,471 @@
+import { useMemo, useState } from 'react'
+import { Link, useNavigate } from 'react-router'
+import { SearchIcon, XIcon } from 'lucide-react'
 import ConsoleShell from '@/shells/ConsoleShell'
-import PlaceholderScreen from '@/app/PlaceholderScreen'
+import PageHeader from '@/components/common/PageHeader'
+import { TableFrame } from '@/components/common/TableFrame'
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from '@/components/ui/Table'
+import { Avatar, AvatarFallback } from '@/components/ui/Avatar'
+import { Empty, EmptyHeader, EmptyTitle, EmptyDescription } from '@/components/ui/Empty'
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from '@/components/ui/InputGroup'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/Select'
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+} from '@/components/ui/Pagination'
+import {
+  TRAINEES,
+  ROUND_OPTIONS,
+  ROUND_CONCEPTS,
+  countLowLevels,
+  aceSummary,
+  type AccountStatus,
+  type RoundId,
+  type RoundRecord,
+  type RoundBadgeKind,
+  type TraineeRow,
+} from './mockData'
+import { AccountStatusBadge } from './components/AccountStatusBadge'
+import { RoundBadge } from './components/RoundBadge'
+import { maskEmail } from '@/lib/utils/mask'
+import { cn } from '@/lib/utils/cn'
 
-/** MG-05 교육생 명부 — 화면 이식 전 자리표시. 실제 화면이 들어오면 이 파일 내용만 바뀐다. */
+/*
+  MG-05 교육생 명부 — 목업 API 연동 없이 고정 배열(mockData)을 화면에서 직접
+  검색·필터·정렬한다. 실 연동 시 이 필터 로직은 쿼리 파라미터로 옮겨간다.
+
+  회차별 개념 도달·위험/우수 배지·우수 누적은 v1(SC-M11 · "찾아서 상세로 가는
+  통로")에는 없었다 — v2 상세(MG-06)가 타임라인 하나로 얇아지며 명부가 고유 가치
+  (우수 프로필·팀 배치 판단)를 져야 해서 들어왔다(MG-05 §4). 팀·제출 현황은 여전히
+  없다 — MG-08 소관.
+*/
+
+const ACCOUNT_OPTIONS: { value: 'ALL' | AccountStatus; label: string }[] = [
+  { value: 'ACTIVE', label: '활성' },
+  { value: 'ALL', label: '전체' },
+  { value: 'INVITED', label: '초대 대기' },
+  { value: 'INACTIVE', label: '비활성' },
+]
+const ACCOUNT_ITEMS = Object.fromEntries(ACCOUNT_OPTIONS.map((o) => [o.value, `계정 · ${o.label}`]))
+const ACCOUNT_LABEL = Object.fromEntries(ACCOUNT_OPTIONS.map((o) => [o.value, o.label]))
+
+const ROUND_ITEMS = Object.fromEntries(ROUND_OPTIONS.map((o) => [o.value, `회차 · ${o.label}`]))
+
+const SORT_OPTIONS = [
+  { value: 'NAME', label: '이름' },
+  { value: 'CLASS', label: '반' },
+  { value: 'ACE_COUNT', label: '우수 누적' },
+  { value: 'LOW_COUNT', label: '2단 이하' },
+] as const
+const SORT_ITEMS = Object.fromEntries(SORT_OPTIONS.map((o) => [o.value, `정렬 · ${o.label}`]))
+
+/** 도달 단계 배경색(0~4단) — MG-02 히트맵과 같은 5단 스케일. 0·4단은 배경이 진해 흰 글자 */
+const REACH_STYLE: Record<0 | 1 | 2 | 3 | 4, string> = {
+  0: 'bg-reach-0 text-white',
+  1: 'bg-reach-1 text-reach-fg',
+  2: 'bg-reach-2 text-reach-fg',
+  3: 'bg-reach-3 text-reach-fg',
+  4: 'bg-reach-4 text-white',
+}
+
+/** 문항 없음(코드에 그 개념이 없어 못 물었다) 해치 무늬 — 회색 두 톤 반복 대각선 */
+const NA_PATTERN = {
+  background:
+    'repeating-linear-gradient(45deg, var(--color-reach-na-bg), var(--color-reach-na-bg) 4px, var(--color-border) 4px, var(--color-border) 8px)',
+}
+
+/** 그 회차 배지 종류 — 응시상태 3종은 record.status를, ATTENDED는 record.badge를 그대로 쓴다 */
+function roundBadgeKind(record: RoundRecord | undefined): RoundBadgeKind | null {
+  if (!record) return null
+  if (record.status !== 'ATTENDED') return record.status
+  return record.badge ?? null
+}
+
+function ConceptReachCell({ round, record }: { round: RoundId; record: RoundRecord | undefined }) {
+  if (!record || record.status !== 'ATTENDED') {
+    return <span className="text-fg-subtle">아직 없음</span>
+  }
+  const concepts = ROUND_CONCEPTS[round]
+  return (
+    <span className="flex gap-[3px]">
+      {record.levels.map((level, i) =>
+        level === null ? (
+          <span
+            key={i}
+            title={concepts[i]}
+            style={NA_PATTERN}
+            className="text-fg-subtle flex h-[22px] w-[26px] items-center justify-center rounded-[4px] text-2xs"
+          >
+            ―
+          </span>
+        ) : (
+          <span
+            key={i}
+            title={concepts[i]}
+            className={cn(
+              'flex h-[22px] w-[26px] items-center justify-center rounded-[4px] text-2xs font-bold tabular-nums',
+              REACH_STYLE[level],
+            )}
+          >
+            {level}
+          </span>
+        ),
+      )}
+    </span>
+  )
+}
+
+/** 우수 누적 칸 — 그 회차 응시상태 3종이면 특이 문구가 우선한다(와이어프레임 prof) */
+function AceOrNoteCell({
+  trainee,
+  record,
+}: {
+  trainee: TraineeRow
+  record: RoundRecord | undefined
+}) {
+  if (record?.status === 'INVALID') {
+    return <span className="text-fg-subtle">이번 회차 채점하지 않음</span>
+  }
+  if (record?.status === 'ABSENT') {
+    return <span className="text-fg-subtle">응시 창을 놓침</span>
+  }
+  if (record?.status === 'DROPPED') {
+    return <span className="text-fg-subtle">{record.note}</span>
+  }
+  const ace = aceSummary(trainee)
+  if (ace.count === 0) {
+    return <span className="text-fg-subtle">—</span>
+  }
+  return (
+    <span>
+      <b className="text-success font-bold">우수 {ace.count}회</b>
+      <span className="text-fg-subtle"> · {ace.rounds.join('·')}차</span>
+    </span>
+  )
+}
+
 export default function TraineeListScreen() {
+  const navigate = useNavigate()
+
+  const [search, setSearch] = useState('')
+  const [classFilter, setClassFilter] = useState('ALL')
+  const [accountFilter, setAccountFilter] = useState<'ALL' | AccountStatus>('ACTIVE')
+  const [sort, setSort] = useState<(typeof SORT_OPTIONS)[number]['value']>('NAME')
+  const [round, setRound] = useState<RoundId>(ROUND_OPTIONS[ROUND_OPTIONS.length - 1].value)
+
+  const classOptions = useMemo(
+    () => Array.from(new Set(TRAINEES.map((t) => t.className))).sort(),
+    [],
+  )
+  const classItems = useMemo(() => {
+    const items: Record<string, string> = { ALL: '반 · 전체' }
+    for (const c of classOptions) items[c] = `반 · ${c}`
+    return items
+  }, [classOptions])
+
+  // 헤더 브레이크다운은 전체 모집단 기준 — 계정 필터를 바꿔도 안 바뀐다(범위 개수와 다른 값)
+  const accountCounts = useMemo(() => {
+    const counts: Record<AccountStatus, number> = { ACTIVE: 0, INVITED: 0, INACTIVE: 0 }
+    for (const t of TRAINEES) counts[t.accountStatus]++
+    return counts
+  }, [])
+
+  const rows = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    const filtered = TRAINEES.filter((t) => {
+      // 검색은 원본 이메일 기준 매칭 — 표시만 가리고(마스킹) 매니저가 이메일로
+      // 찾는 실무 동작은 막지 않는다.
+      if (q && !`${t.name} ${t.email}`.toLowerCase().includes(q)) return false
+      if (classFilter !== 'ALL' && t.className !== classFilter) return false
+      if (accountFilter !== 'ALL' && t.accountStatus !== accountFilter) return false
+      return true
+    })
+    // 미응시 등 그 회차 데이터가 없는 사람은 -1로 둬서 "많은 순"에서 항상 뒤로 밀린다.
+    const lowCount = (t: TraineeRow) => {
+      const r = t.rounds?.[round]
+      return r?.status === 'ATTENDED' ? countLowLevels(r.levels) : -1
+    }
+    return filtered.sort((a, b) => {
+      if (sort === 'CLASS') {
+        return a.className.localeCompare(b.className, 'en') || a.name.localeCompare(b.name, 'ko')
+      }
+      if (sort === 'ACE_COUNT') {
+        return aceSummary(b).count - aceSummary(a).count || a.name.localeCompare(b.name, 'ko')
+      }
+      if (sort === 'LOW_COUNT') {
+        return lowCount(b) - lowCount(a) || a.name.localeCompare(b.name, 'ko')
+      }
+      return a.name.localeCompare(b.name, 'ko')
+    })
+  }, [search, classFilter, accountFilter, sort, round])
+
+  // #noroster — 반에 배정된 교육생이 아예 0명(기수 세팅 중). 명단은 오퍼레이터가
+  // 등록하므로 생성 유도를 넣지 않는다(F6). #noresult(검색·필터로 0건)와는 원인이
+  // 달라 문구를 분리한다 — 하나로 묶으면 매니저가 무엇을 기다려야 하는지 모른다.
+  const isRosterEmpty = TRAINEES.length === 0
+
   return (
     <ConsoleShell role="manager">
-      <PlaceholderScreen code="MG-05" title="교육생 명부" />
+      <PageHeader
+        breadcrumb="교육생 › 7기 › 담당 반"
+        title="교육생"
+        count={`${TRAINEES.length}명`}
+        breakdown={
+          <>
+            활성 <b className="text-fg font-bold">{accountCounts.ACTIVE}</b>
+            <span className="text-fg-subtle">
+              {' '}
+              · 초대 대기 <b className="text-fg font-bold">{accountCounts.INVITED}</b> · 비활성{' '}
+              <b className="text-fg font-bold">{accountCounts.INACTIVE}</b>
+            </span>
+          </>
+        }
+      />
+
+      <div className="mb-4 flex flex-wrap items-center gap-2">
+        <Select
+          value={round}
+          onValueChange={(v) => setRound((v as RoundId) ?? round)}
+          items={ROUND_ITEMS}
+        >
+          <SelectTrigger className="h-9 min-w-32 text-sm font-semibold" aria-label="회차 선택">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {ROUND_OPTIONS.map((o) => (
+              <SelectItem key={o.value} value={o.value}>
+                회차 · {o.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <InputGroup className="h-9 w-60">
+          <InputGroupAddon>
+            <SearchIcon />
+          </InputGroupAddon>
+          <InputGroupInput
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="이름 · 이메일 검색"
+            aria-label="교육생 검색"
+          />
+          {search && (
+            <InputGroupAddon align="inline-end">
+              <InputGroupButton
+                size="icon-xs"
+                aria-label="검색어 지우기"
+                onClick={() => setSearch('')}
+              >
+                <XIcon />
+              </InputGroupButton>
+            </InputGroupAddon>
+          )}
+        </InputGroup>
+
+        <Select
+          value={classFilter}
+          onValueChange={(v) => setClassFilter(v ?? 'ALL')}
+          items={classItems}
+        >
+          <SelectTrigger className="h-9 min-w-32" aria-label="반 필터">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="ALL">반 · 전체</SelectItem>
+            {classOptions.map((c) => (
+              <SelectItem key={c} value={c}>
+                반 · {c}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={accountFilter}
+          onValueChange={(v) => setAccountFilter(v as typeof accountFilter)}
+          items={ACCOUNT_ITEMS}
+        >
+          <SelectTrigger className="h-9 min-w-32" aria-label="계정 필터">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {ACCOUNT_OPTIONS.map((o) => (
+              <SelectItem key={o.value} value={o.value}>
+                계정 · {o.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select value={sort} onValueChange={(v) => setSort(v as typeof sort)} items={SORT_ITEMS}>
+          <SelectTrigger className="h-9 min-w-32" aria-label="정렬">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {SORT_OPTIONS.map((o) => (
+              <SelectItem key={o.value} value={o.value}>
+                정렬 · {o.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {isRosterEmpty ? (
+        <Empty>
+          <EmptyHeader>
+            <EmptyTitle>이 반에 등록된 교육생이 없습니다</EmptyTitle>
+            <EmptyDescription>
+              기수 명단과 반 배정이 끝나면 여기에 나타납니다.
+              <br />
+              명단은 <b className="text-fg-muted">오퍼레이터가 등록</b>합니다.
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      ) : rows.length === 0 ? (
+        <Empty>
+          <EmptyHeader>
+            <EmptyTitle>
+              {search ? `"${search}"와 맞는 사람이 없습니다` : '조건에 맞는 교육생이 없습니다'}
+            </EmptyTitle>
+            <EmptyDescription>
+              담당 반 {classOptions.length}개 · {TRAINEES.length}명에서 찾았습니다.
+              {accountFilter !== 'ALL' && (
+                <>
+                  <br />
+                  계정 필터가 <b className="text-fg-muted">{ACCOUNT_LABEL[accountFilter]}</b>으로
+                  걸려 있어요 — 초대 대기나 비활성일 수 있습니다.
+                </>
+              )}
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      ) : (
+        <>
+          <TableFrame>
+            <Table className="border-0 bg-transparent rounded-none">
+              <TableHeader>
+                <TableRow className="hover:bg-transparent">
+                  <TableHead>교육생</TableHead>
+                  <TableHead>개념 3건 도달</TableHead>
+                  <TableHead>2단 이하</TableHead>
+                  <TableHead>이번 회차</TableHead>
+                  <TableHead>우수 누적</TableHead>
+                  <TableHead>계정</TableHead>
+                  <TableHead />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rows.map((t) => {
+                  const record = t.rounds?.[round]
+                  const low = record?.status === 'ATTENDED' ? countLowLevels(record.levels) : null
+                  const hot = low !== null && low >= 2
+                  return (
+                    <TableRow
+                      key={t.id}
+                      className="hover:bg-surface-2 cursor-pointer"
+                      onClick={() => navigate(`/manager/trainees/${t.id}`)}
+                    >
+                      <TableCell>
+                        <div className="flex items-center gap-3">
+                          <Avatar aria-hidden="true">
+                            <AvatarFallback className="bg-primary-soft text-primary font-semibold">
+                              {t.name.slice(0, 1)}
+                            </AvatarFallback>
+                          </Avatar>
+                          <div>
+                            <span className="flex items-center gap-1.5">
+                              <Link
+                                to={`/manager/trainees/${t.id}`}
+                                aria-label={`${t.name} 상세 보기`}
+                                className="text-fg hover:text-primary font-semibold hover:underline"
+                                onClick={(e) => e.stopPropagation()}
+                              >
+                                {t.name}
+                              </Link>
+                              <span className="text-fg-subtle text-2xs">{t.className}</span>
+                            </span>
+                            <p className="text-fg-subtle text-2xs">{maskEmail(t.email)}</p>
+                          </div>
+                        </div>
+                      </TableCell>
+                      <TableCell className="text-xs">
+                        <ConceptReachCell round={round} record={record} />
+                      </TableCell>
+                      <TableCell className="text-xs tabular-nums">
+                        {low === null ? (
+                          <span className="text-fg-subtle">—</span>
+                        ) : (
+                          <span className={hot ? 'text-warning' : 'text-fg-muted'}>
+                            <b className={cn('font-bold', hot ? 'text-warning' : 'text-fg')}>
+                              {low}
+                            </b>
+                            /3
+                          </span>
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        <RoundBadge kind={roundBadgeKind(record)} />
+                      </TableCell>
+                      <TableCell className="text-xs">
+                        <AceOrNoteCell trainee={t} record={record} />
+                      </TableCell>
+                      <TableCell>
+                        <AccountStatusBadge status={t.accountStatus} />
+                        {t.accountStatus === 'INACTIVE' && t.inactiveReason && (
+                          <p className="text-fg-subtle mt-0.5 text-2xs">
+                            {t.inactiveReason} · {t.inactiveAt}
+                          </p>
+                        )}
+                      </TableCell>
+                      <TableCell aria-hidden="true" className="text-fg-subtle text-right">
+                        ›
+                      </TableCell>
+                    </TableRow>
+                  )
+                })}
+              </TableBody>
+            </Table>
+          </TableFrame>
+
+          <div className="mt-3 grid grid-cols-3 items-center">
+            <p className="text-fg-subtle text-xs">{`${rows.length}개 중 1–${rows.length}`}</p>
+            <div className="flex justify-center">
+              <Pagination className="mx-0 w-auto">
+                <PaginationContent>
+                  <PaginationItem>
+                    <PaginationLink isActive aria-label="1쪽">
+                      1
+                    </PaginationLink>
+                  </PaginationItem>
+                </PaginationContent>
+              </Pagination>
+            </div>
+            <div />
+          </div>
+        </>
+      )}
     </ConsoleShell>
   )
 }

--- a/src/features/manager/trainees/components/AccountStatusBadge.tsx
+++ b/src/features/manager/trainees/components/AccountStatusBadge.tsx
@@ -1,0 +1,18 @@
+import { Badge } from '@/components/ui/Badge'
+import type { AccountStatus } from '../mockData'
+
+const LABEL: Record<AccountStatus, string> = {
+  ACTIVE: '활성',
+  INVITED: '초대 대기',
+  INACTIVE: '비활성',
+}
+
+const VARIANT: Record<AccountStatus, 'success' | 'info' | 'neutral'> = {
+  ACTIVE: 'success',
+  INVITED: 'info',
+  INACTIVE: 'neutral',
+}
+
+export function AccountStatusBadge({ status }: { status: AccountStatus }) {
+  return <Badge variant={VARIANT[status]}>{LABEL[status]}</Badge>
+}

--- a/src/features/manager/trainees/components/RoundBadge.tsx
+++ b/src/features/manager/trainees/components/RoundBadge.tsx
@@ -1,0 +1,31 @@
+import { Badge } from '@/components/ui/Badge'
+import type { RoundBadgeKind } from '../mockData'
+
+const LABEL: Record<RoundBadgeKind, string> = {
+  DECLINE: '단계 하락',
+  LOW_PERSISTENT: '지속 저점',
+  ACE: '우수',
+  ABSENT: '미응시',
+  INVALID: '무효 응시',
+  DROPPED: '중단',
+}
+
+/*
+  와이어프레임 .rbadge 대조(docs/plan/v2/wireframe/manager/trainees.html) —
+  down(단계 하락)은 danger가 아니라 warning, void(무효 응시)는 neutral이 아니라
+  danger다. 감으로 고르면 이렇게 어긋난다.
+*/
+const VARIANT: Record<RoundBadgeKind, 'success' | 'warning' | 'danger' | 'neutral'> = {
+  DECLINE: 'warning',
+  LOW_PERSISTENT: 'danger',
+  ACE: 'success',
+  ABSENT: 'neutral',
+  INVALID: 'danger',
+  DROPPED: 'neutral',
+}
+
+/** 이번 회차 배지 — 위험 2종 · 우수 · 응시상태 3종(14-1) 중 하나. 일반(kind 없음)은 배지 없이 "—" */
+export function RoundBadge({ kind }: { kind: RoundBadgeKind | null }) {
+  if (!kind) return <span className="text-fg-subtle">—</span>
+  return <Badge variant={VARIANT[kind]}>{LABEL[kind]}</Badge>
+}

--- a/src/features/manager/trainees/mockData.ts
+++ b/src/features/manager/trainees/mockData.ts
@@ -1,0 +1,192 @@
+/*
+  MG-05 교육생 명부 목업. API 연동 전까지 화면을 검증하기 위한 고정 배열이다.
+  실 데이터가 붙으면 이 파일은 지운다.
+
+  MG-06(교육생 상세)이 쓰던 축 점수·세션·개입 카드 데이터는 여기 없다 — v2 상세는
+  타임라인 하나로 재설계되어(구조가 다름) 이 목록 전용 목업과 같이 두지 않는다.
+  features-v1/trainees/mockData.ts에는 아직 남아있다(MG-06 이식 전까지).
+*/
+export type AccountStatus = 'ACTIVE' | 'INVITED' | 'INACTIVE'
+
+export type RoundId = '1' | '2' | '3'
+
+export const ROUND_OPTIONS: { value: RoundId; label: string }[] = [
+  { value: '1', label: '미프 1차' },
+  { value: '2', label: '미프 2차' },
+  { value: '3', label: '미프 3차' },
+]
+
+/** 그 회차의 검증 개념 3건 — 회차마다 다르다(MG-02). 히트맵의 같은 순서와 맞는다 */
+export const ROUND_CONCEPTS: Record<RoundId, [string, string, string]> = {
+  '1': ['인증 흐름', 'API 설계', '에러 처리'],
+  '2': ['상태 관리', 'API 설계', '테스트 전략'],
+  '3': ['HITL Trigger', 'Graph 구성', 'State 관리'],
+}
+
+/** 개념 도달 단계(0~4). null = ▨ 문항 없음(코드에 그 개념이 없어 못 물었다, MG-02) */
+export type ConceptLevel = 0 | 1 | 2 | 3 | 4 | null
+
+export type RoundBadgeKind = 'DECLINE' | 'LOW_PERSISTENT' | 'ACE' | 'ABSENT' | 'INVALID' | 'DROPPED'
+
+/** 응시상태 3종(14-1: 미응시·무효 응시·중단)은 원인·처방이 달라 값을 나눈다 */
+export type RoundRecord =
+  | {
+      status: 'ATTENDED'
+      levels: [ConceptLevel, ConceptLevel, ConceptLevel]
+      /** 위험 유형(9-2) 또는 우수(9-3). 없으면 일반 */
+      badge?: 'DECLINE' | 'LOW_PERSISTENT' | 'ACE'
+    }
+  | { status: 'ABSENT' }
+  | { status: 'INVALID' }
+  | { status: 'DROPPED'; note: string }
+
+export type TraineeRow = {
+  id: string
+  name: string
+  email: string
+  className: string
+  accountStatus: AccountStatus
+  /** 비활성 사유·일자. INACTIVE일 때만 값이 있다 */
+  inactiveReason?: string
+  inactiveAt?: string
+  /** 회차별 응시·도달 기록. 그 회차 키가 없으면 "아직 없음"(초대 대기 등 데이터 자체가 없는 경우) */
+  rounds?: Partial<Record<RoundId, RoundRecord>>
+}
+
+export const TRAINEES: TraineeRow[] = [
+  {
+    id: 't-1',
+    name: '강민준',
+    email: 'minjun@ex.com',
+    className: 'A반',
+    accountStatus: 'ACTIVE',
+    rounds: {
+      '1': { status: 'ATTENDED', levels: [3, 3, 4] },
+      '2': { status: 'ATTENDED', levels: [4, 3, 4] },
+      '3': { status: 'ATTENDED', levels: [3, 4, 3] },
+    },
+  },
+  {
+    id: 't-2',
+    name: '김서연',
+    email: 'seoyeon@ex.com',
+    className: 'A반',
+    accountStatus: 'ACTIVE',
+    rounds: {
+      '1': { status: 'ATTENDED', levels: [4, 4, 3], badge: 'ACE' },
+      '2': { status: 'ATTENDED', levels: [4, 3, 4], badge: 'ACE' },
+      '3': { status: 'ATTENDED', levels: [4, 4, 4], badge: 'ACE' },
+    },
+  },
+  { id: 't-3', name: '서지우', email: 'jiwoo@ex.com', className: 'B반', accountStatus: 'INVITED' },
+  {
+    id: 't-4',
+    name: '한도현',
+    email: 'dohyun@ex.com',
+    className: 'A반',
+    accountStatus: 'ACTIVE',
+    rounds: {
+      '1': { status: 'ATTENDED', levels: [3, 2, 4] },
+      '2': { status: 'ATTENDED', levels: [2, 3, 3] },
+      '3': { status: 'ABSENT' },
+    },
+  },
+  {
+    id: 't-5',
+    name: '오세훈',
+    email: 'sehun@ex.com',
+    className: 'C반',
+    accountStatus: 'INACTIVE',
+    inactiveReason: '이탈',
+    inactiveAt: '08.02',
+    rounds: {
+      '1': { status: 'ATTENDED', levels: [2, 1, 3] },
+      '2': { status: 'ATTENDED', levels: [3, 2, 2] },
+      '3': { status: 'DROPPED', note: '세션 중단 · 07-14' },
+    },
+  },
+  {
+    id: 't-6',
+    name: '이하은',
+    email: 'haeun@ex.com',
+    className: 'B반',
+    accountStatus: 'ACTIVE',
+    rounds: {
+      '1': { status: 'ATTENDED', levels: [4, 4, 3], badge: 'ACE' },
+      '2': { status: 'ATTENDED', levels: [3, 3, 4] },
+      '3': { status: 'ATTENDED', levels: [2, 1, 2], badge: 'LOW_PERSISTENT' },
+    },
+  },
+  {
+    id: 't-7',
+    name: '박지민',
+    email: 'jimin@ex.com',
+    className: 'C반',
+    accountStatus: 'ACTIVE',
+    rounds: {
+      '1': { status: 'ATTENDED', levels: [3, 3, 3] },
+      '2': { status: 'ATTENDED', levels: [4, 3, 3] },
+      '3': { status: 'ATTENDED', levels: [0, 1, 3], badge: 'DECLINE' },
+    },
+  },
+  {
+    id: 't-8',
+    name: '최윤서',
+    email: 'yoonseo@ex.com',
+    className: 'B반',
+    accountStatus: 'ACTIVE',
+    rounds: {
+      '1': { status: 'ATTENDED', levels: [3, 3, 3] },
+      '2': { status: 'ATTENDED', levels: [3, 4, 3] },
+      '3': { status: 'INVALID' },
+    },
+  },
+  { id: 't-9', name: '정우진', email: 'woojin@ex.com', className: 'A반', accountStatus: 'INVITED' },
+  {
+    id: 't-10',
+    name: '신아린',
+    email: 'arin@ex.com',
+    className: 'C반',
+    accountStatus: 'INACTIVE',
+    inactiveReason: '휴식',
+    inactiveAt: '07.20',
+  },
+  {
+    id: 't-11',
+    name: '윤도윤',
+    email: 'doyoon@ex.com',
+    className: 'B반',
+    accountStatus: 'ACTIVE',
+    rounds: {
+      '1': { status: 'ATTENDED', levels: [3, 3, 3] },
+      '2': { status: 'ATTENDED', levels: [3, 3, 4] },
+      '3': { status: 'ATTENDED', levels: [4, 3, 3] },
+    },
+  },
+  {
+    id: 't-12',
+    name: '임서준',
+    email: 'seojun@ex.com',
+    className: 'C반',
+    accountStatus: 'ACTIVE',
+    rounds: {
+      '1': { status: 'ATTENDED', levels: [3, 3, 3] },
+      '2': { status: 'ATTENDED', levels: [4, 4, 3] },
+      '3': { status: 'ATTENDED', levels: [3, null, 4] },
+    },
+  },
+]
+
+/** 2단 이하 개수. 3(그 회차 검증 개념 수)은 고정 분모라 셀 수와 별개로 저장하지 않는다 */
+export function countLowLevels(levels: ConceptLevel[]): number {
+  return levels.filter((l) => l !== null && l <= 2).length
+}
+
+/** 우수 누적 — 회차 배지에서 파생한다(개념 아님, MG-05 §3). 이중 저장하지 않는다 */
+export function aceSummary(trainee: TraineeRow): { count: number; rounds: RoundId[] } {
+  const rounds = (Object.entries(trainee.rounds ?? {}) as [RoundId, RoundRecord][])
+    .filter(([, r]) => r.status === 'ATTENDED' && r.badge === 'ACE')
+    .map(([id]) => id)
+    .sort((a, b) => Number(a) - Number(b))
+  return { count: rounds.length, rounds }
+}


### PR DESCRIPTION
## 작업 내용

`features-v1/trainees/TraineeListScreen.tsx`를 v2 스켈레톤(`features/manager/trainees/`)으로 이식했다.

> **원 구현 출처:** MG-05 v2 케이스 계약 동기화는 PR #46(이슈 #45, 팀원 @vneed154)이 했다. 이 PR은 그 구현을 v2 셸 구조로 옮기고, 목업 대비 빠졌던 케이스 2종을 채운 것.

- `mockData.ts`는 목록 관련 export만 가져왔다 — 축 점수·세션·개입 카드 등 상세(MG-06) 전용 데이터는 옮기지 않았다. MG-06은 v2에서 3탭+7컴포넌트 구조를 버리고 단일 타임라인으로 재설계되어(정의서 §7) 다른 데이터 모델이 필요하다.
- 목업 케이스 8종 중 코드에 없던 2종 추가:
  - `#noroster` — 반에 배정된 교육생 0명(기수 세팅 중). 생성 유도 없음(F6)
  - `#noresult` — 검색·필터 0건. "어느 범위에서 찾았는지" + "계정 필터가 걸려 있다"를 같이 표시(기존엔 "조건에 맞는 교육생이 없습니다"뿐이었음)
  - 둘 다 `components/ui/Empty`로 구현

## 리뷰 포인트

- **MG-06(교육생 상세)은 포함하지 않는다** — 별도 이슈로 새로 설계 예정(v1은 3탭+7컴포넌트, v2는 단일 타임라인으로 구조 자체가 다름)
- `features-v1/trainees`는 이 PR에서 안 지움(MG-06이 아직 그 폴더의 상세 목업을 참조 중)

## 확인

- [x] `/manager/trainees`에서 명부·회차 전환·정렬·필터 정상 동작 확인
- [x] `#noresult`(검색 0건, 범위+필터 명시) 실제 렌더 확인. `#noroster`는 코드 로직(`TRAINEES.length === 0`) 검토로 확인(정적 목업이라 브라우저에서 직접 재현 불가)
- [x] `npm run typecheck` / `format:check` / `lint` / `build` / `check:design` 전부 통과
- [x] 하나의 PR = 하나의 기능

closes #58