### PR TITLE
[Feat] Add SA-01 Organization List Screen

### DIFF
--- a/src/features/auth/authApi.ts
+++ b/src/features/auth/authApi.ts
@@ -8,7 +8,7 @@ import { accounts } from './mockDb'
 
 /** 서버가 내려주는 역할별 초기 화면 (initialScreen) */
 const INITIAL_SCREEN: Record<Role, string> = {
-  SUPERADMIN: '/superadmin/console', // SA-01
+  SUPERADMIN: '/superadmin/orgs', // SA-01
   OPERATOR: '/operator/dashboard', // OP-01
   MANAGER: '/manager/dashboard', // MG-01
   TRAINEE: '/trainee/home', // TR-01

--- a/src/features/superadmin/orgs/OrgListScreen.tsx
+++ b/src/features/superadmin/orgs/OrgListScreen.tsx
@@ -1,11 +1,374 @@
+import { useMemo, useState } from 'react'
+import { useNavigate } from 'react-router'
+import { PlusIcon, SearchIcon, XIcon } from 'lucide-react'
 import ConsoleShell from '@/shells/ConsoleShell'
-import PlaceholderScreen from '@/app/PlaceholderScreen'
+import PageHeader from '@/components/common/PageHeader'
+import { TableFrame } from '@/components/common/TableFrame'
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+  type SortDirection,
+} from '@/components/ui/Table'
+import { Badge } from '@/components/ui/Badge'
+import { Button } from '@/components/ui/Button'
+import { Empty, EmptyHeader, EmptyTitle, EmptyDescription } from '@/components/ui/Empty'
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from '@/components/ui/InputGroup'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/Select'
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+} from '@/components/ui/Pagination'
+import { ORGS, type Org, type OrgStatus } from './mockData'
+import OrgMetrics from './components/OrgMetrics'
+import OrgCreateDialog from './components/OrgCreateDialog'
+import { cn } from '@/lib/utils/cn'
 
-/** SA-01 기관 목록 — 화면 이식 전 자리표시. 실제 화면이 들어오면 이 파일 내용만 바뀐다. */
+/*
+  SA-01 기관 목록 — 슈퍼어드민의 실질 홈(정의서 §1). v1 원본이 없어 정의서 +
+  와이어프레임(superadmin/console.html#page-list)만 보고 새로 짰다.
+
+  검색·상태 필터만 둔다 — 와이어프레임 실제 렌더에 별도 정렬 셀렉트는 없다(자세한
+  판단은 mockData.ts 주석 참고). 대신 표 컬럼 헤더 자체를 Table.tsx의 기존
+  sortable/onSort API로 정렬 가능하게 한다 — 교육생 리스트 등 3개 화면이 이미 쓰는
+  같은 패턴(th.sortable, ↕ 아이콘)이라 새 컨트롤을 안 만들어도 된다.
+
+  "오퍼레이터 미배정"이 이 목록의 핵심 신호라(§3) 행 배경을 warning-soft로 올리고
+  이름 옆에 "신규" 배지를 단다 — 목록을 훑을 때 바로 눈에 띄어야 한다.
+  정지 기관은 숨기지 않고 대신 흐리게 둔다(§6 "정지 기관을 목록에서 숨기지 않는다").
+*/
+
+const STATUS_OPTIONS: { value: 'ALL' | OrgStatus; label: string }[] = [
+  { value: 'ALL', label: '전체' },
+  { value: 'ACTIVE', label: '활성' },
+  { value: 'SUSPENDED', label: '정지' },
+]
+const STATUS_ITEMS = Object.fromEntries(STATUS_OPTIONS.map((o) => [o.value, `상태 · ${o.label}`]))
+
+type SortKey = 'name' | 'cohortCount' | 'traineeCount' | 'monthlyAiCostUsd' | 'createdAt'
+
+/** 컬럼별 기본 방향 — 날짜는 최신이 먼저, 나머지는 오름차순이 자연스럽다 */
+const DEFAULT_DIRECTION: Record<SortKey, Exclude<SortDirection, false>> = {
+  name: 'asc',
+  cohortCount: 'asc',
+  traineeCount: 'asc',
+  monthlyAiCostUsd: 'asc',
+  createdAt: 'desc',
+}
+
+/** 영문이 한글보다 앞에 오게 — localeCompare('ko')만 쓰면 로케일 콜레이션에 맡겨져
+ * 어느 쪽이 먼저 올지 보장이 안 된다. 첫 글자가 라틴 문자인지로 먼저 그룹을 가르고,
+ * 그 안에서만 각 언어에 맞는 collator로 비교한다. */
+function compareOrgName(a: string, b: string): number {
+  const rank = (s: string) => (/^[A-Za-z]/.test(s) ? 0 : 1)
+  const ra = rank(a)
+  const rb = rank(b)
+  if (ra !== rb) return ra - rb
+  return a.localeCompare(b, ra === 0 ? 'en' : 'ko')
+}
+
+function compareOrgs(a: Org, b: Org, key: SortKey): number {
+  switch (key) {
+    case 'name':
+      return compareOrgName(a.name, b.name)
+    case 'cohortCount':
+      return a.cohortCount - b.cohortCount
+    case 'traineeCount':
+      return a.traineeCount - b.traineeCount
+    case 'monthlyAiCostUsd':
+      return a.monthlyAiCostUsd - b.monthlyAiCostUsd
+    case 'createdAt':
+      return a.createdAt.localeCompare(b.createdAt)
+  }
+}
+
+function OrgStatusBadge({ org }: { org: Org }) {
+  // 오퍼레이터 미배정이 상태 배지를 덮는다 — 이 목록의 핵심 신호라 활성/정지보다 우선한다.
+  if (org.operators.length === 0) {
+    return <Badge variant="warning">오퍼레이터 미배정</Badge>
+  }
+  return org.status === 'ACTIVE' ? (
+    <Badge variant="success">활성</Badge>
+  ) : (
+    <Badge variant="neutral">정지</Badge>
+  )
+}
+
 export default function OrgListScreen() {
+  const navigate = useNavigate()
+
+  // 복사해서 갖는다 — mockData.ORGS는 createOrg가 직접 mutate하는 공유 저장소라(중복
+  // 확인이 방금 만든 기관도 보게 하려고), 이 배열을 그대로 state로 들고 있으면 두 번
+  // 갱신될 때 참조가 꼬여 같은 기관이 중복으로 그려질 수 있다.
+  const [orgs, setOrgs] = useState<Org[]>(() => [...ORGS])
+  const [search, setSearch] = useState('')
+  const [statusFilter, setStatusFilter] = useState<'ALL' | OrgStatus>('ALL')
+  const [createOpen, setCreateOpen] = useState(false)
+  // 기본값 — 최근 생성된 기관이 맨 위
+  const [sort, setSort] = useState<{ key: SortKey; direction: Exclude<SortDirection, false> }>({
+    key: 'createdAt',
+    direction: 'desc',
+  })
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    return orgs.filter((o) => {
+      if (q && !o.name.toLowerCase().includes(q)) return false
+      if (statusFilter !== 'ALL' && o.status !== statusFilter) return false
+      return true
+    })
+  }, [orgs, search, statusFilter])
+
+  const sorted = useMemo(() => {
+    const dir = sort.direction === 'asc' ? 1 : -1
+    return [...filtered].sort((a, b) => compareOrgs(a, b, sort.key) * dir)
+  }, [filtered, sort])
+
+  const isPlatformEmpty = orgs.length === 0
+
+  function handleSort(key: SortKey) {
+    setSort((prev) =>
+      prev.key === key
+        ? { key, direction: prev.direction === 'asc' ? 'desc' : 'asc' }
+        : { key, direction: DEFAULT_DIRECTION[key] },
+    )
+  }
+
+  function sortProps(key: SortKey) {
+    return {
+      sortable: true as const,
+      sortDirection: (sort.key === key ? sort.direction : false) as SortDirection,
+      onSort: () => handleSort(key),
+    }
+  }
+
+  function handleCreated() {
+    // createOrg가 이미 mockData.ORGS 맨 앞에 넣어뒀다(mockData.ts 주석 참고) — 여기서
+    // 또 prepend하면 중복으로 그려진다. 공유 저장소를 다시 복사해오기만 한다.
+    setOrgs([...ORGS])
+  }
+
   return (
     <ConsoleShell role="superadmin">
-      <PlaceholderScreen code="SA-01" title="기관 목록" />
+      <PageHeader
+        title="기관"
+        action={
+          <Button onClick={() => setCreateOpen(true)}>
+            <PlusIcon /> 기관 생성
+          </Button>
+        }
+      />
+
+      <OrgMetrics orgs={orgs} />
+
+      {isPlatformEmpty ? (
+        <Empty>
+          <EmptyHeader>
+            <EmptyTitle>아직 등록된 기관이 없습니다</EmptyTitle>
+            <EmptyDescription>기관을 만들면 여기에 나타납니다.</EmptyDescription>
+          </EmptyHeader>
+          <Button onClick={() => setCreateOpen(true)}>
+            <PlusIcon /> 기관 생성
+          </Button>
+        </Empty>
+      ) : (
+        <>
+          <div className="mb-4 flex flex-wrap items-center gap-2">
+            <InputGroup className="h-9 w-64">
+              <InputGroupAddon>
+                <SearchIcon />
+              </InputGroupAddon>
+              <InputGroupInput
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="기관명 검색…"
+                aria-label="기관명 검색"
+              />
+              {search && (
+                <InputGroupAddon align="inline-end">
+                  <InputGroupButton
+                    size="icon-xs"
+                    aria-label="검색어 지우기"
+                    onClick={() => setSearch('')}
+                  >
+                    <XIcon />
+                  </InputGroupButton>
+                </InputGroupAddon>
+              )}
+            </InputGroup>
+
+            <Select
+              value={statusFilter}
+              onValueChange={(v) => setStatusFilter((v as typeof statusFilter) ?? 'ALL')}
+              items={STATUS_ITEMS}
+            >
+              <SelectTrigger className="h-9 min-w-32" aria-label="상태 필터">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {STATUS_OPTIONS.map((o) => (
+                  <SelectItem key={o.value} value={o.value}>
+                    상태 · {o.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {filtered.length === 0 ? (
+            <Empty>
+              <EmptyHeader>
+                <EmptyTitle>
+                  {search ? `"${search}"와 맞는 기관이 없습니다` : '조건에 맞는 기관이 없습니다'}
+                </EmptyTitle>
+                <EmptyDescription>전체 {orgs.length}개 기관에서 찾았습니다.</EmptyDescription>
+              </EmptyHeader>
+            </Empty>
+          ) : (
+            <>
+              <TableFrame>
+                <Table className="table-fixed border-0 bg-transparent rounded-none">
+                  <TableHeader>
+                    <TableRow className="hover:bg-transparent">
+                      <TableHead className="w-56" {...sortProps('name')}>
+                        기관명
+                      </TableHead>
+                      <TableHead className="w-16 text-right" {...sortProps('cohortCount')}>
+                        기수
+                      </TableHead>
+                      <TableHead className="w-20 text-right" {...sortProps('traineeCount')}>
+                        교육생
+                      </TableHead>
+                      <TableHead className="w-32 text-right" {...sortProps('monthlyAiCostUsd')}>
+                        이번 달 AI 비용
+                      </TableHead>
+                      <TableHead className="w-36">오퍼레이터</TableHead>
+                      <TableHead className="w-40">상태</TableHead>
+                      <TableHead className="w-28" {...sortProps('createdAt')}>
+                        생성일
+                      </TableHead>
+                      <TableHead className="w-8" />
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {sorted.map((org) => {
+                      const unassigned = org.operators.length === 0
+                      const suspended = org.status === 'SUSPENDED'
+                      return (
+                        <TableRow
+                          key={org.id}
+                          className={cn(
+                            'hover:bg-surface-2 cursor-pointer',
+                            unassigned && 'bg-warning-soft hover:bg-warning-soft',
+                          )}
+                          onClick={() => navigate(`/superadmin/orgs/${org.id}`)}
+                        >
+                          <TableCell
+                            className={cn(
+                              'w-56 font-bold',
+                              suspended && 'text-fg-muted font-normal',
+                            )}
+                          >
+                            <span className="flex items-center gap-1.5">
+                              {org.name}
+                              {unassigned && (
+                                <Badge variant="warning" className="text-[10px]">
+                                  신규
+                                </Badge>
+                              )}
+                            </span>
+                          </TableCell>
+                          <TableCell
+                            className={cn(
+                              'w-16 text-right tabular-nums',
+                              suspended && 'text-fg-muted',
+                            )}
+                          >
+                            {org.cohortCount}
+                          </TableCell>
+                          <TableCell
+                            className={cn(
+                              'w-20 text-right tabular-nums',
+                              suspended && 'text-fg-muted',
+                            )}
+                          >
+                            {org.traineeCount}
+                          </TableCell>
+                          <TableCell
+                            className={cn(
+                              'w-32 text-right tabular-nums',
+                              suspended && 'text-fg-muted',
+                            )}
+                          >
+                            ${org.monthlyAiCostUsd.toLocaleString()}
+                          </TableCell>
+                          <TableCell className="w-36 text-xs">
+                            {unassigned ? (
+                              <span className="text-warning font-semibold">미배정</span>
+                            ) : org.operators.length === 1 ? (
+                              org.operators[0]
+                            ) : (
+                              `${org.operators[0]} 외 ${org.operators.length - 1}`
+                            )}
+                          </TableCell>
+                          <TableCell className="w-40">
+                            <OrgStatusBadge org={org} />
+                          </TableCell>
+                          <TableCell
+                            className={cn(
+                              'w-28 text-xs',
+                              suspended ? 'text-fg-subtle' : 'text-fg-muted',
+                            )}
+                          >
+                            {org.createdAt}
+                          </TableCell>
+                          <TableCell aria-hidden="true" className="w-8 text-fg-subtle text-right">
+                            ›
+                          </TableCell>
+                        </TableRow>
+                      )
+                    })}
+                  </TableBody>
+                </Table>
+              </TableFrame>
+
+              <div className="mt-3 grid grid-cols-3 items-center">
+                <p className="text-fg-subtle text-xs">{`1–${sorted.length} / ${sorted.length}개`}</p>
+                <div className="flex justify-center">
+                  <Pagination className="mx-0 w-auto">
+                    <PaginationContent>
+                      <PaginationItem>
+                        <PaginationLink isActive aria-label="1쪽">
+                          1
+                        </PaginationLink>
+                      </PaginationItem>
+                    </PaginationContent>
+                  </Pagination>
+                </div>
+                <div />
+              </div>
+            </>
+          )}
+        </>
+      )}
+
+      <OrgCreateDialog open={createOpen} onOpenChange={setCreateOpen} onCreated={handleCreated} />
     </ConsoleShell>
   )
 }

--- a/src/features/superadmin/orgs/components/OrgCreateDialog.tsx
+++ b/src/features/superadmin/orgs/components/OrgCreateDialog.tsx
@@ -1,0 +1,216 @@
+import { useEffect, useState } from 'react'
+import { CheckIcon, XIcon } from 'lucide-react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/Dialog'
+import { Field, FieldLabel, FieldDescription } from '@/components/ui/Field'
+import { Input } from '@/components/ui/Input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/Select'
+import { Button } from '@/components/ui/Button'
+import { Alert } from '@/components/ui/Alert'
+import { checkOrgName, createOrg, type Org, type OrgApiErrorCode } from '../mockData'
+
+/*
+  SA-01 §3 "생성 모달" · 케이스 1(중복 기관명, 제출 전 차단) · 케이스 3(생성 실패 롤백).
+
+  기관명은 react-hook-form의 제출 시점 검증이 아니라 **입력 중 실시간**으로 서버에
+  물어야 해서(정의서 "실시간 중복 확인" · 목업 #dupname) 이 필드만 직접 상태로
+  관리하고 디바운스한다 — 폼 전체를 RHF로 감싸는 이득보다, RHF의 onChange 모드가
+  키 입력마다 재검증을 트리거해 디바운스와 부딪히는 손실이 더 크다(필드 3개짜리
+  작은 폼이라 분리 비용도 작다).
+
+  실패해도 입력값을 지우지 않는다(케이스3 "아무것도 만들어지지 않았고 입력한 내용은
+  그대로") — 그래서 실패 시 dialog를 닫지 않고 submitError만 세팅한다.
+*/
+
+const RETENTION_OPTIONS = [90, 180, 365] as const
+const RETENTION_ITEMS = Object.fromEntries(RETENTION_OPTIONS.map((d) => [String(d), `${d}일`]))
+
+const SUBMIT_ERROR_MESSAGE: Record<OrgApiErrorCode, string> = {
+  ORG_NAME_TAKEN: '이미 있는 기관명입니다.',
+  ORG_CREATE_FAILED: '기관을 만들지 못했습니다. 잠시 후 다시 시도해 주세요.',
+}
+
+type NameCheckState = 'idle' | 'checking' | 'available' | 'taken'
+
+export default function OrgCreateDialog({
+  open,
+  onOpenChange,
+  onCreated,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onCreated: (org: Org) => void
+}) {
+  const [name, setName] = useState('')
+  const [domain, setDomain] = useState('')
+  const [retentionDays, setRetentionDays] = useState<number>(180)
+  const [nameCheck, setNameCheck] = useState<NameCheckState>('idle')
+  const [submitting, setSubmitting] = useState(false)
+  const [submitError, setSubmitError] = useState<OrgApiErrorCode | null>(null)
+
+  // 열릴 때만 초기화한다 — 실패 후에도 dialog가 열려 있는 동안엔 입력값을 유지해야 한다.
+  useEffect(() => {
+    if (open) {
+      setName('')
+      setDomain('')
+      setRetentionDays(180)
+      setNameCheck('idle')
+      setSubmitError(null)
+    }
+  }, [open])
+
+  // 입력 중 실시간 중복 확인 — 디바운스 400ms(mockData.checkOrgName의 지연과 맞춤)
+  useEffect(() => {
+    const trimmed = name.trim()
+    if (!trimmed) {
+      setNameCheck('idle')
+      return
+    }
+    setNameCheck('checking')
+    let cancelled = false
+    const timer = setTimeout(() => {
+      checkOrgName(trimmed).then(({ available }) => {
+        if (!cancelled) setNameCheck(available ? 'available' : 'taken')
+      })
+    }, 400)
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
+    }
+  }, [name])
+
+  const canSubmit =
+    name.trim().length > 0 &&
+    domain.trim().length > 0 &&
+    nameCheck !== 'taken' &&
+    nameCheck !== 'checking' &&
+    !submitting
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!canSubmit) return
+
+    setSubmitting(true)
+    setSubmitError(null)
+    try {
+      const org = await createOrg({ name: name.trim(), domain: domain.trim(), retentionDays })
+      onCreated(org)
+      onOpenChange(false)
+    } catch (err) {
+      setSubmitError((err as { code: OrgApiErrorCode }).code)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>기관 생성</DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} noValidate className="flex flex-col gap-4">
+          {submitError && <Alert variant="danger">{SUBMIT_ERROR_MESSAGE[submitError]}</Alert>}
+
+          <Field data-invalid={nameCheck === 'taken'}>
+            <FieldLabel htmlFor="org-name">기관명</FieldLabel>
+            <div className="relative">
+              <Input
+                id="org-name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="기관명을 입력하세요"
+                disabled={submitting}
+                aria-invalid={nameCheck === 'taken'}
+                autoComplete="off"
+                className="pr-9"
+              />
+              {nameCheck === 'available' && (
+                <CheckIcon
+                  aria-hidden="true"
+                  className="text-success absolute top-1/2 right-3 size-4 -translate-y-1/2"
+                />
+              )}
+              {nameCheck === 'taken' && (
+                <XIcon
+                  aria-hidden="true"
+                  className="text-danger absolute top-1/2 right-3 size-4 -translate-y-1/2"
+                />
+              )}
+            </div>
+            {nameCheck === 'taken' ? (
+              <p className="text-danger text-xs font-medium">이미 있는 기관명입니다</p>
+            ) : nameCheck === 'available' ? (
+              <p className="text-success text-xs font-medium">사용 가능한 이름입니다</p>
+            ) : nameCheck === 'checking' ? (
+              <p className="text-fg-subtle text-xs">확인하는 중…</p>
+            ) : (
+              <FieldDescription>다른 기관과 겹치지 않는 이름이어야 합니다</FieldDescription>
+            )}
+          </Field>
+
+          <Field>
+            <FieldLabel htmlFor="org-domain">도메인</FieldLabel>
+            <Input
+              id="org-domain"
+              value={domain}
+              onChange={(e) => setDomain(e.target.value)}
+              placeholder="example.ac.kr"
+              disabled={submitting}
+              autoComplete="off"
+            />
+            <FieldDescription>이 도메인 주소로만 초대할 수 있습니다</FieldDescription>
+          </Field>
+
+          <Field>
+            <FieldLabel htmlFor="org-retention">데이터 보존기간</FieldLabel>
+            <Select
+              value={String(retentionDays)}
+              onValueChange={(v) => setRetentionDays(Number(v ?? retentionDays))}
+              disabled={submitting}
+              items={RETENTION_ITEMS}
+            >
+              <SelectTrigger id="org-retention" className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {RETENTION_OPTIONS.map((d) => (
+                  <SelectItem key={d} value={String(d)}>
+                    {d}일
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <FieldDescription>종료 기수 데이터 보관 기간</FieldDescription>
+          </Field>
+
+          <DialogFooter className="-mx-4 -mb-4 mt-0">
+            <Button
+              type="button"
+              variant="ghost"
+              disabled={submitting}
+              onClick={() => onOpenChange(false)}
+            >
+              취소
+            </Button>
+            <Button type="submit" disabled={!canSubmit}>
+              {submitting ? '만드는 중…' : '기관 생성'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/features/superadmin/orgs/components/OrgMetrics.tsx
+++ b/src/features/superadmin/orgs/components/OrgMetrics.tsx
@@ -1,0 +1,85 @@
+import type { ReactNode } from 'react'
+import { Card } from '@/components/ui/Card'
+import { Progress } from '@/components/ui/Progress'
+import type { Org } from '../mockData'
+import { PLATFORM_SNAPSHOT } from '../mockData'
+
+/*
+  와이어프레임 `.metrics`(4카드) — v1 콘솔 셸을 그대로 쓴다는 문서 첫머리 설명대로,
+  기관별 데이터가 아닌 플랫폼 스냅샷이다. PageHeader의 총 개수를 여기서 대신하므로
+  (CLAUDE.md §6 "메트릭 카드가 있으면 제목 총개수 생략") PageHeader엔 count를 안 준다.
+
+  Card 자신은 세로 패딩(--card-spacing)만 갖고 가로 패딩이 없다(CardContent가 있어야
+  px가 붙는다) — 여기선 헤더/콘텐츠로 안 나누는 단순 카드라 px-4를 직접 준다.
+*/
+
+function MetricCard({
+  label,
+  value,
+  sub,
+  children,
+}: {
+  label: string
+  value: string
+  sub?: ReactNode
+  children?: ReactNode
+}) {
+  return (
+    <Card size="sm" className="gap-1.5 px-4">
+      <p className="text-fg-subtle text-xs font-semibold">{label}</p>
+      <p className="text-2xl font-bold tracking-[-0.02em] tabular-nums">{value}</p>
+      {sub && <p className="text-fg-subtle text-xs">{sub}</p>}
+      {children}
+    </Card>
+  )
+}
+
+export default function OrgMetrics({ orgs }: { orgs: Org[] }) {
+  const activeCount = orgs.filter((o) => o.status === 'ACTIVE').length
+  const suspendedCount = orgs.filter((o) => o.status === 'SUSPENDED').length
+  const totalTrainees = orgs.reduce((sum, o) => sum + o.traineeCount, 0)
+  const totalCostUsd = orgs.reduce((sum, o) => sum + o.monthlyAiCostUsd, 0)
+  const budgetPct = Math.round((totalCostUsd / PLATFORM_SNAPSHOT.budgetUsd) * 100)
+  const storageAvg = (PLATFORM_SNAPSHOT.storageGb / Math.max(orgs.length, 1)).toFixed(1)
+
+  return (
+    <div className="mb-5 grid grid-cols-4 gap-4">
+      <MetricCard
+        label="총 기관"
+        value={`${orgs.length}`}
+        sub={`활성 ${activeCount} · 정지 ${suspendedCount}`}
+      />
+      <MetricCard
+        label="총 교육생"
+        value={totalTrainees.toLocaleString()}
+        sub={`활성 세션 ${PLATFORM_SNAPSHOT.activeSessions}`}
+      />
+      <MetricCard
+        label="이번 달 AI 비용"
+        value={`$${totalCostUsd.toLocaleString()}`}
+        sub={
+          <>
+            예산 ${PLATFORM_SNAPSHOT.budgetUsd.toLocaleString()} 대비{' '}
+            <span className="text-warning font-semibold">{budgetPct}%</span> · 전월{' '}
+            <span className="text-danger font-bold">+{PLATFORM_SNAPSHOT.costDeltaPct}%</span>
+          </>
+        }
+      >
+        {/*
+          Progress는 Track·Indicator를 스스로 렌더한다(components/ui/Progress.tsx) — children으로
+          또 넣으면 바가 두 겹으로 그려진다(app/UiPreviewScreen.tsx의 같은 경고 참고). 막대 색은
+          data-slot 셀렉터로 자동 렌더된 Indicator에 입힌다 — 64%(budgetPct)와 같은 warning 계열.
+        */}
+        <Progress
+          value={budgetPct}
+          className="mt-2 gap-0 [&_[data-slot=progress-track]]:h-1.5 [&_[data-slot=progress-indicator]]:bg-warning"
+        />
+      </MetricCard>
+      <MetricCard
+        label="저장량"
+        value={`${PLATFORM_SNAPSHOT.storageGb} GB`}
+        sub={`전월 대비 +${PLATFORM_SNAPSHOT.storageDeltaPct}% · 기관 평균 ${storageAvg}GB`}
+      />
+    </div>
+  )
+}

--- a/src/features/superadmin/orgs/mockData.ts
+++ b/src/features/superadmin/orgs/mockData.ts
@@ -1,0 +1,276 @@
+/*
+  SA-01 기관 목록 목업 데이터 + mock API. v1 원본이 없어(features-v1/superadmin 자체가
+  없음) 정의서(SA-01-org-list.md)·와이어프레임(superadmin/console.html#page-list)만
+  보고 새로 짰다.
+
+  API 격리는 auth 모듈(features/auth/authApi.ts)과 같은 관례 — 실 연동 시 각 함수의
+  Mock 블록만 지우고 fetch로 바꾸면 된다. 화면 코드는 안 바뀐다.
+
+  데이터 모델은 정의서 §4("기관명·상태·기수 수·교육생 수·이번 달 비용·오퍼레이터 배정
+  여부")를 기준으로 하되, 표에 실제로 그려지는 오퍼레이터 이름·생성일은 "오퍼레이터
+  배정 여부"의 자연스러운 확장으로 포함했다. "예산 초과" 배지·"정렬" 컨트롤은
+  와이어프레임 실제 렌더(#page-list)에 없어 뺐다 — 와이어프레임이 정의서 ASCII보다
+  구체적인 최종 계약이라 그쪽을 따랐다(둘이 갈릴 때의 판단, CLAUDE.md §3).
+
+  통화도 같은 이유로 정의서 ASCII의 ₩ 대신 와이어프레임의 $ 표기를 따랐다(AI 비용은
+  모델 단가 기준이라 달러가 자연스럽다 — SA-03도 같은 단위를 쓸 것으로 예상).
+*/
+
+export type OrgStatus = 'ACTIVE' | 'SUSPENDED'
+
+export type Org = {
+  id: string
+  name: string
+  domain: string
+  status: OrgStatus
+  cohortCount: number
+  traineeCount: number
+  /** 이번 달 AI 비용(USD) */
+  monthlyAiCostUsd: number
+  /** 오퍼레이터 이름 목록. 빈 배열 = "오퍼레이터 미배정"(이 목록의 핵심 신호) */
+  operators: string[]
+  /** YYYY-MM-DD */
+  createdAt: string
+}
+
+export const ORGS: Org[] = [
+  {
+    id: 'org-1',
+    name: '그린컴퍼니 부트캠프',
+    domain: 'greencompany.kr',
+    status: 'ACTIVE',
+    cohortCount: 3,
+    traineeCount: 148,
+    monthlyAiCostUsd: 412,
+    operators: ['박지현', '한도윤'],
+    createdAt: '2026-03-02',
+  },
+  {
+    id: 'org-2',
+    name: '넥스트러너스',
+    domain: 'nextlearners.io',
+    status: 'ACTIVE',
+    cohortCount: 2,
+    traineeCount: 96,
+    monthlyAiCostUsd: 268,
+    operators: ['서민아'],
+    createdAt: '2026-04-11',
+  },
+  {
+    id: 'org-3',
+    name: '코드스쿨 A트랙',
+    domain: 'codeschool-a.ac.kr',
+    status: 'ACTIVE',
+    cohortCount: 5,
+    traineeCount: 210,
+    monthlyAiCostUsd: 690,
+    operators: ['윤재호'],
+    createdAt: '2026-02-20',
+  },
+  {
+    id: 'org-4',
+    name: '블루아카데미',
+    domain: 'blueacademy.edu',
+    status: 'SUSPENDED',
+    cohortCount: 1,
+    traineeCount: 40,
+    monthlyAiCostUsd: 88,
+    operators: ['정민호'],
+    createdAt: '2026-01-15',
+  },
+  // 오퍼레이터 미배정 — 목록의 핵심 신호. 정의서 §6 "생성 실패는 아무것도 남기지
+  // 않는다"의 대구로, 이건 생성이 *성공*한 정상 흐름(활성 · 오퍼레이터 미배정)이다.
+  {
+    id: 'org-5',
+    name: '파이널랩',
+    domain: 'finallab.dev',
+    status: 'ACTIVE',
+    cohortCount: 0,
+    traineeCount: 0,
+    monthlyAiCostUsd: 0,
+    operators: [],
+    createdAt: '2026-07-14',
+  },
+  {
+    id: 'org-6',
+    name: '코드스쿨 B트랙',
+    domain: 'codeschool-b.ac.kr',
+    status: 'ACTIVE',
+    cohortCount: 4,
+    traineeCount: 176,
+    monthlyAiCostUsd: 520,
+    operators: ['이수진'],
+    createdAt: '2026-01-28',
+  },
+  {
+    id: 'org-7',
+    name: '데브캠프 서울',
+    domain: 'devcamp-seoul.com',
+    status: 'ACTIVE',
+    cohortCount: 2,
+    traineeCount: 84,
+    monthlyAiCostUsd: 190,
+    operators: ['최은비'],
+    createdAt: '2026-05-06',
+  },
+  {
+    id: 'org-8',
+    name: '테크브릿지 아카데미',
+    domain: 'techbridge.kr',
+    status: 'ACTIVE',
+    cohortCount: 1,
+    traineeCount: 52,
+    monthlyAiCostUsd: 121,
+    operators: ['강태현'],
+    createdAt: '2026-06-02',
+  },
+  {
+    id: 'org-9',
+    name: '넥스트코드 스쿨',
+    domain: 'nextcode-school.io',
+    status: 'ACTIVE',
+    cohortCount: 3,
+    traineeCount: 132,
+    monthlyAiCostUsd: 305,
+    operators: ['오하늘'],
+    createdAt: '2026-03-19',
+  },
+  {
+    id: 'org-10',
+    name: '코딩부스트',
+    domain: 'codingboost.kr',
+    status: 'SUSPENDED',
+    cohortCount: 1,
+    traineeCount: 28,
+    monthlyAiCostUsd: 0,
+    operators: ['남기석'],
+    createdAt: '2025-11-08',
+  },
+  {
+    id: 'org-11',
+    name: '프론티어 부트캠프',
+    domain: 'frontier-bootcamp.com',
+    status: 'ACTIVE',
+    cohortCount: 2,
+    traineeCount: 88,
+    monthlyAiCostUsd: 214,
+    operators: ['배수아'],
+    createdAt: '2026-04-25',
+  },
+  {
+    id: 'org-12',
+    name: '알고리즘하우스',
+    domain: 'algohouse.ac.kr',
+    status: 'ACTIVE',
+    cohortCount: 1,
+    traineeCount: 46,
+    monthlyAiCostUsd: 98,
+    operators: ['조민준'],
+    createdAt: '2026-06-30',
+  },
+  {
+    id: 'org-13',
+    name: '스택업 캠퍼스',
+    domain: 'stackup-campus.kr',
+    status: 'ACTIVE',
+    cohortCount: 2,
+    traineeCount: 74,
+    monthlyAiCostUsd: 176,
+    operators: ['임서연'],
+    createdAt: '2026-05-14',
+  },
+  {
+    id: 'org-14',
+    name: '리부트 아카데미',
+    domain: 'rebootacademy.kr',
+    status: 'ACTIVE',
+    cohortCount: 1,
+    traineeCount: 30,
+    monthlyAiCostUsd: 67,
+    operators: ['한지민'],
+    createdAt: '2026-07-01',
+  },
+]
+
+/** 목록 상단 지표 카드 — 오퍼레이터 배정처럼 기관별로 추적하는 값이 아니라, v1
+ * 콘솔 셸에서 그대로 넘어온 플랫폼 스냅샷이다(정의서 §4 밖의 운영 지표). */
+export const PLATFORM_SNAPSHOT = {
+  budgetUsd: 3300,
+  costDeltaPct: 18,
+  activeSessions: 37,
+  storageGb: 82,
+  storageDeltaPct: 6,
+}
+
+export type OrgApiErrorCode = 'ORG_NAME_TAKEN' | 'ORG_CREATE_FAILED'
+
+export interface OrgApiError {
+  code: OrgApiErrorCode
+}
+
+export interface CreateOrgInput {
+  name: string
+  domain: string
+  retentionDays: number
+}
+
+// ───────── Mock 전용 (백엔드 연동 시 이 블록 삭제) ─────────
+/** 데모용 트리거 — 이 문자열이 들어간 기관명은 항상 생성 실패로 응답한다(case3 확인용) */
+const CREATE_FAIL_TRIGGER = '실패'
+// ──────────────────────────────────────────────────────────
+
+/** GET /admin/orgs/check-name — 입력 중 실시간 중복 확인(case1) */
+export function checkOrgName(name: string): Promise<{ available: boolean }> {
+  // ===== Mock 버전 (현재 활성) =====
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      // 대소문자만 다른 이름도 중복으로 본다 — "CodeSchool"과 "codeschool"이 둘 다
+      // 목록에 있으면 사람이 구분해서 찾아야 하는 부담이 그대로 남는다.
+      const taken = ORGS.some((o) => o.name.trim().toLowerCase() === name.trim().toLowerCase())
+      resolve({ available: !taken })
+    }, 400)
+  })
+
+  // ===== 실제 백엔드 버전 =====
+  // const res = await fetch(`/admin/orgs/check-name?name=${encodeURIComponent(name)}`)
+  // return res.json() // { available }
+}
+
+/** POST /admin/orgs — 기관 생성. 실패해도 아무것도 만들어지지 않는다(case3, 롤백) */
+export function createOrg(input: CreateOrgInput): Promise<Org> {
+  // ===== Mock 버전 (현재 활성) =====
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      if (input.name.includes(CREATE_FAIL_TRIGGER)) {
+        reject({ code: 'ORG_CREATE_FAILED' } satisfies OrgApiError)
+        return
+      }
+      const org: Org = {
+        id: `org-${Date.now()}`,
+        name: input.name,
+        domain: input.domain,
+        status: 'ACTIVE',
+        cohortCount: 0,
+        traineeCount: 0,
+        monthlyAiCostUsd: 0,
+        operators: [], // 생성 직후는 항상 오퍼레이터 미배정(정의서 §3 "확정 시 활성 + 오퍼레이터 미배정")
+        createdAt: new Date().toISOString().slice(0, 10),
+      }
+      // 공유 목업 저장소(auth/mockDb.ts와 같은 관례: 함수가 직접 mutate)에도 반영한다.
+      // 여기 안 넣으면 checkOrgName이 방금 만든 기관을 못 보고, 같은 이름(대소문자만
+      // 다른 것 포함)을 또 만들 수 있게 된다 — 화면의 로컬 state(orgs)만 갱신하고
+      // 이 배열을 그대로 두면 재현되던 버그다.
+      ORGS.unshift(org)
+      resolve(org)
+    }, 600)
+  })
+
+  // ===== 실제 백엔드 버전 =====
+  // const res = await fetch('/admin/orgs', {
+  //   method: 'POST',
+  //   headers: { 'Content-Type': 'application/json' },
+  //   body: JSON.stringify(input),
+  // })
+  // if (!res.ok) return Promise.reject(await res.json()) // { code }
+  // return res.json()
+}


### PR DESCRIPTION
## 작업 내용
- SA-01 기관 목록 화면 신규 구현(v1 원본 없음, 정의서·와이어프레임 기준)
  - 지표 카드 4 + 검색·상태 필터 + 정렬 가능한 표 + 페이지네이션
  - 기관 생성 모달 — 이름 실시간 중복 확인(대소문자 무시) + 생성 실패 롤백
  - 오퍼레이터 미배정 강조, 정지 기관은 흐리게 표시
- 로그인 초기 화면 매핑 버그 수정 — SUPERADMIN이 존재하지 않는 라우트(/superadmin/console)로 가던 것을 실제 SA-01 라우트(/superadmin/orgs)로 수정

## 리뷰 포인트
- OrgCreateDialog의 실시간 중복확인(디바운스 400ms)이 mockData.ts의 checkOrgName과 맞물려 동작하는지
- 정지 기관 시각적 처리(§6)가 정의서 취지와 맞는지

closes #69