### PR TITLE
[Feat] Add SA-02 Organization Detail Screen

### DIFF
--- a/src/features/superadmin/orgs/OrgDetailScreen.tsx
+++ b/src/features/superadmin/orgs/OrgDetailScreen.tsx
@@ -1,11 +1,109 @@
+import { useState } from 'react'
+import { Link, useParams } from 'react-router'
+import { ArrowLeft } from 'lucide-react'
 import ConsoleShell from '@/shells/ConsoleShell'
-import PlaceholderScreen from '@/app/PlaceholderScreen'
+import PageHeader from '@/components/common/PageHeader'
+import { Card } from '@/components/ui/Card'
+import { Button } from '@/components/ui/Button'
+import { Badge } from '@/components/ui/Badge'
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/Tabs'
+import { getOrgDetail, orgStatusBadge } from './mockData'
+import OverviewTab from './components/detail/OverviewTab'
+import OperatorsTab from './components/detail/OperatorsTab'
+import UsageTab from './components/detail/UsageTab'
+import SettingsTab from './components/detail/SettingsTab'
 
-/** SA-02 기관 상세 — 화면 이식 전 자리표시. 실제 화면이 들어오면 이 파일 내용만 바뀐다. */
+/*
+  SA-02 기관 상세 — 탭 4(개요·오퍼레이터·사용량 · 비용·설정). 정의서
+  (SA-02-org-detail.md) · 와이어프레임(superadmin/console.html#page-overview
+  이하)만 보고 새로 짰다(v1 원본 없음, SA-01과 같은 사정). 케이스별 판단은
+  mockData.ts의 "SA-02 기관 상세" 섹션 주석에 몰아뒀다.
+
+  탭들이 mockData.detailStore를 직접 mutate하는 mock API(초대·정지·설정 변경·삭제
+  요청)를 쓰기 때문에, 이 화면은 그 변경을 React state로 들고 있지 않고 "다시
+  읽어오기"로 반영한다 — refresh()가 getOrgDetail을 재호출해 org·detail을 새
+  객체로 세팅한다(SA-01 OrgListScreen의 setOrgs([...ORGS])와 같은 패턴).
+*/
+
 export default function OrgDetailScreen() {
+  const { id = '' } = useParams()
+  const [snapshot, setSnapshot] = useState(() => getOrgDetail(id))
+
+  function refresh() {
+    setSnapshot(getOrgDetail(id))
+  }
+
+  if (!snapshot) {
+    return (
+      <ConsoleShell role="superadmin">
+        <div className="mx-auto max-w-3xl">
+          <div className="[&_h1]:sr-only">
+            <PageHeader breadcrumb="기관" title="기관 상세" />
+          </div>
+          <div className="mb-4 flex items-center gap-2.5">
+            <BackButton />
+            <span className="text-fg text-xl font-bold tracking-[-0.01em]">기관 상세</span>
+          </div>
+          <Card className="items-center gap-2 p-10 text-center">
+            <p className="text-lg font-semibold">기관을 찾을 수 없습니다</p>
+            <p className="text-fg-subtle text-sm">삭제되었거나 잘못된 주소일 수 있습니다.</p>
+          </Card>
+        </div>
+      </ConsoleShell>
+    )
+  }
+
+  const { org, detail } = snapshot
+  const badge = orgStatusBadge(org)
+
   return (
     <ConsoleShell role="superadmin">
-      <PlaceholderScreen code="SA-02" title="기관 상세" />
+      <div className="[&_h1]:sr-only">
+        <PageHeader breadcrumb={`기관 › ${org.name}`} title="기관 상세" />
+      </div>
+
+      <div className="mb-4 flex items-center gap-2.5">
+        <BackButton />
+        <span className="text-fg text-xl font-bold tracking-[-0.01em]">{org.name}</span>
+        <Badge variant={badge.variant}>{badge.label}</Badge>
+      </div>
+
+      <Tabs defaultValue="overview">
+        <TabsList className="mb-4">
+          <TabsTrigger value="overview">개요</TabsTrigger>
+          <TabsTrigger value="operators">오퍼레이터</TabsTrigger>
+          <TabsTrigger value="usage">사용량 · 비용</TabsTrigger>
+          <TabsTrigger value="settings">설정</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="overview">
+          <OverviewTab org={org} detail={detail} />
+        </TabsContent>
+        <TabsContent value="operators">
+          <OperatorsTab org={org} detail={detail} onChange={refresh} />
+        </TabsContent>
+        <TabsContent value="usage">
+          <UsageTab org={org} />
+        </TabsContent>
+        <TabsContent value="settings">
+          <SettingsTab org={org} detail={detail} onChange={refresh} />
+        </TabsContent>
+      </Tabs>
     </ConsoleShell>
+  )
+}
+
+function BackButton() {
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      aria-label="기관 목록으로 돌아가기"
+      nativeButton={false}
+      render={<Link to="/superadmin/orgs" />}
+      className="p-1.5"
+    >
+      <ArrowLeft className="size-5" />
+    </Button>
   )
 }

--- a/src/features/superadmin/orgs/OrgListScreen.tsx
+++ b/src/features/superadmin/orgs/OrgListScreen.tsx
@@ -35,7 +35,7 @@ import {
   PaginationItem,
   PaginationLink,
 } from '@/components/ui/Pagination'
-import { ORGS, type Org, type OrgStatus } from './mockData'
+import { ORGS, orgStatusBadge, type Org, type OrgStatus } from './mockData'
 import OrgMetrics from './components/OrgMetrics'
 import OrgCreateDialog from './components/OrgCreateDialog'
 import { cn } from '@/lib/utils/cn'
@@ -98,16 +98,11 @@ function compareOrgs(a: Org, b: Org, key: SortKey): number {
   }
 }
 
+// 배지 우선순위(삭제 대기 > 오퍼레이터 미배정 > 활성/정지)는 mockData.orgStatusBadge에
+// 있다 — SA-02 상세 헤더와 같은 판정을 공유해야 한다(mockData.ts SA-02 섹션 주석).
 function OrgStatusBadge({ org }: { org: Org }) {
-  // 오퍼레이터 미배정이 상태 배지를 덮는다 — 이 목록의 핵심 신호라 활성/정지보다 우선한다.
-  if (org.operators.length === 0) {
-    return <Badge variant="warning">오퍼레이터 미배정</Badge>
-  }
-  return org.status === 'ACTIVE' ? (
-    <Badge variant="success">활성</Badge>
-  ) : (
-    <Badge variant="neutral">정지</Badge>
-  )
+  const { variant, label } = orgStatusBadge(org)
+  return <Badge variant={variant}>{label}</Badge>
 }
 
 export default function OrgListScreen() {

--- a/src/features/superadmin/orgs/components/OrgMetrics.tsx
+++ b/src/features/superadmin/orgs/components/OrgMetrics.tsx
@@ -72,7 +72,7 @@ export default function OrgMetrics({ orgs }: { orgs: Org[] }) {
         */}
         <Progress
           value={budgetPct}
-          className="mt-2 gap-0 [&_[data-slot=progress-track]]:h-1.5 [&_[data-slot=progress-indicator]]:bg-warning"
+          className="mt-2 gap-0 [&_[data-slot=progress-track]]:h-1.5 [&_[data-slot=progress-track]]:bg-warning-soft [&_[data-slot=progress-indicator]]:bg-warning"
         />
       </MetricCard>
       <MetricCard

--- a/src/features/superadmin/orgs/components/detail/DeleteOrgDialog.tsx
+++ b/src/features/superadmin/orgs/components/detail/DeleteOrgDialog.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useState } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/Dialog'
+import { Field, FieldLabel, FieldDescription } from '@/components/ui/Field'
+import { Input } from '@/components/ui/Input'
+import { Button } from '@/components/ui/Button'
+import { Alert, AlertTitle, AlertDescription } from '@/components/ui/Alert'
+import { requestOrgDeletion, type Org } from '../../mockData'
+
+/*
+  SA-02 §7 "기관 삭제 — 즉시 파기가 아니다". 기관명을 정확히 입력해야 버튼이
+  풀린다 — 소속 오퍼레이터·매니저·교육생 전원이 로그인할 수 없게 되는 액션이라
+  버튼 한 번으로 끝나면 안 된다(정의서 "기관명 입력을 요구하는 이유").
+*/
+
+export default function DeleteOrgDialog({
+  open,
+  onOpenChange,
+  org,
+  retentionDays,
+  onDeleted,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  org: Org
+  retentionDays: number
+  onDeleted: () => void
+}) {
+  const [typed, setTyped] = useState('')
+
+  useEffect(() => {
+    if (open) setTyped('')
+  }, [open])
+
+  const matches = typed.trim() === org.name
+
+  function handleDelete() {
+    if (!matches) return
+    requestOrgDeletion(org.id)
+    onDeleted()
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="text-danger">{org.name}를 삭제할까요?</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4">
+          <Alert variant="danger">
+            <AlertTitle>지금 바로 지워지지 않습니다</AlertTitle>
+            <AlertDescription>
+              보존기간({retentionDays}일)이 지난 뒤 파기됩니다. 그전까지는 복구할 수 있습니다.
+            </AlertDescription>
+          </Alert>
+
+          <Field>
+            <FieldLabel htmlFor="delete-org-confirm">확인을 위해 기관명을 입력하세요</FieldLabel>
+            <Input
+              id="delete-org-confirm"
+              value={typed}
+              onChange={(e) => setTyped(e.target.value)}
+              placeholder={org.name}
+              autoComplete="off"
+            />
+            <FieldDescription>
+              삭제하면 소속 오퍼레이터 · 매니저 · 교육생이 모두 로그인할 수 없습니다
+            </FieldDescription>
+          </Field>
+        </div>
+
+        <DialogFooter className="-mx-4 -mb-4 mt-0">
+          <Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
+            취소
+          </Button>
+          <Button type="button" variant="danger" disabled={!matches} onClick={handleDelete}>
+            삭제
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/features/superadmin/orgs/components/detail/OperatorInviteDialog.tsx
+++ b/src/features/superadmin/orgs/components/detail/OperatorInviteDialog.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useState } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/Dialog'
+import { Field, FieldLabel, FieldDescription } from '@/components/ui/Field'
+import { Input } from '@/components/ui/Input'
+import { Button } from '@/components/ui/Button'
+import {
+  inviteOperator,
+  validateOperatorEmail,
+  type InviteFieldErrorCode,
+  type Operator,
+  type Org,
+} from '../../mockData'
+
+/*
+  SA-02 §3 "초대 모달" — 이메일 하나만 받는다(기수 배정 없음, 오퍼레이터는 기관
+  전체를 본다). 케이스 2·N1(형식·중복·도메인 밖)은 제출 전에 막는다 — 서버 왕복이
+  필요 없는 검사라 OrgCreateDialog의 실시간 중복 확인과 달리 입력마다 동기 검증만
+  한다(mockData.validateOperatorEmail).
+*/
+
+const ERROR_MESSAGE: Record<InviteFieldErrorCode, string> = {
+  INVALID_EMAIL: '올바른 이메일 형식이 아닙니다.',
+  ALREADY_INVITED: '이미 초대된 이메일입니다.',
+  DOMAIN_NOT_ALLOWED: '이 기관 도메인 밖의 주소는 초대할 수 없습니다.',
+}
+
+export default function OperatorInviteDialog({
+  open,
+  onOpenChange,
+  org,
+  existing,
+  onInvited,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  org: Org
+  existing: Operator[]
+  onInvited: (operator: Operator) => void
+}) {
+  const [email, setEmail] = useState('')
+  const [touched, setTouched] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+
+  useEffect(() => {
+    if (open) {
+      setEmail('')
+      setTouched(false)
+    }
+  }, [open])
+
+  const trimmed = email.trim()
+  const error = trimmed ? validateOperatorEmail(org.domain, existing, trimmed) : null
+  // 버튼은 "제출 가능한 상태"가 아니라 "누를 수 있는 상태"만 따진다 — 에러가 있어도
+  // 비활성으로 막으면 클릭 자체가 안 먹혀서 handleSubmit이 안 불리고(setTouched(true)도
+  // 안 됨), 결과적으로 입력칸에서 포커스가 빠져야만(onBlur) 에러가 보이는 문제가
+  // 생긴다. "초대 발송"을 눌렀을 때 바로 에러가 뜨려면 클릭이 항상 handleSubmit까지
+  // 도달해야 한다.
+  const canAttemptSubmit = trimmed.length > 0 && !submitting
+  const canSubmit = canAttemptSubmit && error === null
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setTouched(true)
+    if (!canSubmit) return
+    setSubmitting(true)
+    try {
+      const operator = await inviteOperator(org.id, trimmed)
+      onInvited(operator)
+      onOpenChange(false)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>오퍼레이터 초대 · {org.name}</DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} noValidate className="flex flex-col gap-4">
+          <Field data-invalid={touched && error !== null}>
+            <FieldLabel htmlFor="operator-email">이메일</FieldLabel>
+            <Input
+              id="operator-email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              onBlur={() => setTouched(true)}
+              placeholder={`example@${org.domain}`}
+              disabled={submitting}
+              aria-invalid={touched && error !== null}
+              autoComplete="off"
+            />
+            {touched && error ? (
+              <p className="text-danger text-xs font-medium">{ERROR_MESSAGE[error]}</p>
+            ) : (
+              <FieldDescription>
+                이 주소로 초대 메일이 갑니다 · {org.domain} 도메인만 가능
+              </FieldDescription>
+            )}
+          </Field>
+
+          <DialogFooter className="-mx-4 -mb-4 mt-0">
+            <Button
+              type="button"
+              variant="ghost"
+              disabled={submitting}
+              onClick={() => onOpenChange(false)}
+            >
+              취소
+            </Button>
+            <Button type="submit" disabled={!canAttemptSubmit}>
+              {submitting ? '보내는 중…' : '초대 발송'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/features/superadmin/orgs/components/detail/OperatorsTab.tsx
+++ b/src/features/superadmin/orgs/components/detail/OperatorsTab.tsx
@@ -1,0 +1,266 @@
+import { useState, type ReactNode } from 'react'
+import { PlusIcon, TriangleAlertIcon } from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import { Badge } from '@/components/ui/Badge'
+import { Alert, AlertTitle, AlertDescription } from '@/components/ui/Alert'
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from '@/components/ui/Table'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/Dialog'
+import { cn } from '@/lib/utils/cn'
+import {
+  cancelInvite,
+  reactivateOperator,
+  resendInvite,
+  suspendOperator,
+  type Operator,
+  type Org,
+  type OrgDetail,
+} from '../../mockData'
+import OperatorInviteDialog from './OperatorInviteDialog'
+
+/*
+  SA-02 §3 "오퍼레이터 탭" — 계정 관리이지 매니저 관리가 아니다(반 담당 매니저는
+  오퍼레이터가 기관 안에서 초대한다). 정지 액션은 항상 눌릴 수 있게 두고, 그게
+  마지막 활성 오퍼레이터일 때만 suspendOperator가 LAST_OPERATOR를 돌려줘서
+  차단 모달(N2)을 띄운다 — 미리 버튼을 숨기면 "왜 안 눌리지"를 설명할 곳이 없다.
+*/
+
+function ActionLink({
+  onClick,
+  tone = 'neutral',
+  children,
+  disabled,
+}: {
+  onClick: () => void
+  tone?: 'neutral' | 'danger' | 'primary'
+  children: ReactNode
+  disabled?: boolean
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={cn(
+        'text-xs font-semibold hover:underline disabled:cursor-not-allowed disabled:opacity-50 disabled:no-underline',
+        tone === 'danger' && 'text-danger',
+        tone === 'primary' && 'text-primary',
+        tone === 'neutral' && 'text-fg-muted',
+      )}
+    >
+      {children}
+    </button>
+  )
+}
+
+function OperatorStatusBadge({ status }: { status: Operator['status'] }) {
+  switch (status) {
+    case 'ACTIVE':
+      return <Badge variant="success">활성</Badge>
+    case 'INVITED':
+      return <Badge variant="warning">초대됨</Badge>
+    case 'MAIL_FAILED':
+      return <Badge variant="warning">메일 발송 실패</Badge>
+    case 'SUSPENDED':
+      return <Badge variant="neutral">정지</Badge>
+  }
+}
+
+export default function OperatorsTab({
+  org,
+  detail,
+  onChange,
+}: {
+  org: Org
+  detail: OrgDetail
+  onChange: () => void
+}) {
+  const [inviteOpen, setInviteOpen] = useState(false)
+  const [blockedOperator, setBlockedOperator] = useState<Operator | null>(null)
+  const [pendingId, setPendingId] = useState<string | null>(null)
+
+  async function handleSuspend(op: Operator) {
+    const result = suspendOperator(org.id, op.id)
+    if (!result.ok) {
+      setBlockedOperator(op)
+      return
+    }
+    onChange()
+  }
+
+  function handleReactivate(op: Operator) {
+    reactivateOperator(org.id, op.id)
+    onChange()
+  }
+
+  async function handleResend(op: Operator) {
+    setPendingId(op.id)
+    try {
+      await resendInvite(org.id, op.id)
+      onChange()
+    } finally {
+      setPendingId(null)
+    }
+  }
+
+  function handleCancel(op: Operator) {
+    cancelInvite(org.id, op.id)
+    onChange()
+  }
+
+  const hasMailFailure = detail.operators.some((o) => o.status === 'MAIL_FAILED')
+
+  return (
+    <div className="flex flex-col gap-4">
+      {hasMailFailure && (
+        <Alert variant="warning">
+          <TriangleAlertIcon />
+          <AlertTitle>오퍼레이터로 지정됐지만 초대 메일이 나가지 않았습니다</AlertTitle>
+          <AlertDescription>
+            계정 자리는 만들어졌고 링크만 실패했습니다. 재발송해 주세요.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <div className="flex items-center justify-between">
+        <p className="text-fg-subtle text-xs font-semibold">
+          이 기관의 오퍼레이터 계정 · {detail.operators.length}명
+        </p>
+        <Button onClick={() => setInviteOpen(true)}>
+          <PlusIcon /> 오퍼레이터 초대
+        </Button>
+      </div>
+
+      {detail.operators.length === 0 ? (
+        <p className="text-fg-subtle rounded-md border border-dashed border-border-strong bg-surface-2 p-8 text-center text-sm">
+          아직 오퍼레이터가 없습니다. 첫 오퍼레이터를 초대해 이 기관을 시작하세요.
+        </p>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow className="hover:bg-transparent">
+              <TableHead className="w-32">이름</TableHead>
+              <TableHead className="w-52">이메일</TableHead>
+              <TableHead className="w-32">상태</TableHead>
+              <TableHead className="w-28">초대일</TableHead>
+              <TableHead className="w-28">최근 로그인</TableHead>
+              <TableHead className="w-32" />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {detail.operators.map((op) => {
+              const suspended = op.status === 'SUSPENDED'
+              const mailFailed = op.status === 'MAIL_FAILED'
+              return (
+                <TableRow
+                  key={op.id}
+                  className={cn(suspended && 'opacity-60', mailFailed && 'bg-warning-soft')}
+                >
+                  <TableCell className={cn('font-bold', !op.name && 'text-fg-subtle font-normal')}>
+                    {op.name ?? '—'}
+                  </TableCell>
+                  <TableCell className="font-mono text-xs">{op.email}</TableCell>
+                  <TableCell>
+                    <OperatorStatusBadge status={op.status} />
+                  </TableCell>
+                  <TableCell className="text-fg-muted text-xs">{op.invitedAt}</TableCell>
+                  <TableCell className="text-fg-muted text-xs">
+                    {op.lastLoginAt ?? (op.status === 'INVITED' || mailFailed ? '대기 중' : '—')}
+                  </TableCell>
+                  <TableCell>
+                    <div className="flex items-center gap-3">
+                      {op.status === 'ACTIVE' && (
+                        <ActionLink tone="danger" onClick={() => handleSuspend(op)}>
+                          정지
+                        </ActionLink>
+                      )}
+                      {(op.status === 'INVITED' || mailFailed) && (
+                        <>
+                          <ActionLink
+                            tone="primary"
+                            disabled={pendingId === op.id}
+                            onClick={() => handleResend(op)}
+                          >
+                            재발송
+                          </ActionLink>
+                          <ActionLink tone="danger" onClick={() => handleCancel(op)}>
+                            취소
+                          </ActionLink>
+                        </>
+                      )}
+                      {suspended && (
+                        <ActionLink tone="primary" onClick={() => handleReactivate(op)}>
+                          재활성
+                        </ActionLink>
+                      )}
+                    </div>
+                  </TableCell>
+                </TableRow>
+              )
+            })}
+          </TableBody>
+        </Table>
+      )}
+
+      <OperatorInviteDialog
+        open={inviteOpen}
+        onOpenChange={setInviteOpen}
+        org={org}
+        existing={detail.operators}
+        onInvited={() => onChange()}
+      />
+
+      {/* N2 — 마지막 활성 오퍼레이터 정지 차단. 정의서 §6 "고아 기관 방지".
+          와이어 `.warnbox`(빨간 상자) + `.fhint`(상자 밖 잔글씨) 구조를 그대로 따른다 —
+          Dialog를 쓰는 이유는 AlertDialog엔 닫기 ✕가 없어서다(닫기 버튼이 이미 있어도
+          모달 우상단에 ✕가 있는 게 이 팀 모달의 기본형, DialogContent가 기본 제공한다). */}
+      <Dialog open={blockedOperator !== null} onOpenChange={(v) => !v && setBlockedOperator(null)}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>정지할 수 없습니다</DialogTitle>
+          </DialogHeader>
+
+          <div className="flex flex-col gap-3">
+            <Alert variant="danger">
+              <AlertTitle>이 기관의 마지막 오퍼레이터입니다</AlertTitle>
+              <AlertDescription>
+                정지하면 기관에 들어갈 수 있는 사람이 아무도 없어지고, 기수·명단·매니저를 손댈
+                방법이 사라집니다.
+              </AlertDescription>
+            </Alert>
+            <p className="text-fg-subtle text-xs">
+              새 오퍼레이터를 먼저 초대한 뒤에 정지할 수 있습니다
+            </p>
+          </div>
+
+          <DialogFooter className="-mx-4 -mb-4 mt-0">
+            <Button type="button" variant="ghost" onClick={() => setBlockedOperator(null)}>
+              닫기
+            </Button>
+            <Button
+              type="button"
+              onClick={() => {
+                setBlockedOperator(null)
+                setInviteOpen(true)
+              }}
+            >
+              오퍼레이터 초대
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/src/features/superadmin/orgs/components/detail/OverviewTab.tsx
+++ b/src/features/superadmin/orgs/components/detail/OverviewTab.tsx
@@ -1,0 +1,187 @@
+import type { ReactNode } from 'react'
+import { AlertTriangleIcon } from 'lucide-react'
+import { Card } from '@/components/ui/Card'
+import { Progress } from '@/components/ui/Progress'
+import { Alert, AlertTitle, AlertDescription } from '@/components/ui/Alert'
+import { Badge } from '@/components/ui/Badge'
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from '@/components/ui/Table'
+import { getOverviewSnapshot, type Org, type OrgDetail } from '../../mockData'
+
+/*
+  와이어프레임 `.metrics`(4카드) + `.oinfo`(기관 메타) + 기수 표(읽기전용).
+  오퍼레이터 0명(#noop)이면 상단에 경고 배너가 초대를 유도한다 — 정의서 §3
+  "이 목록의 핵심 신호"를 개요 탭에서도 그대로 이어간다.
+*/
+
+function MetricCard({
+  label,
+  value,
+  sub,
+  children,
+}: {
+  label: string
+  value: string
+  sub?: ReactNode
+  children?: ReactNode
+}) {
+  return (
+    <Card size="sm" className="gap-1.5 px-4">
+      <p className="text-fg-subtle text-xs font-semibold">{label}</p>
+      <p className="text-2xl font-bold tracking-[-0.02em] tabular-nums">{value}</p>
+      {sub && <p className="text-fg-subtle text-xs">{sub}</p>}
+      {children}
+    </Card>
+  )
+}
+
+export default function OverviewTab({ org, detail }: { org: Org; detail: OrgDetail }) {
+  const snapshot = getOverviewSnapshot(org)
+  const ongoingCount = detail.cohorts.filter((c) => c.status === 'ONGOING').length
+  const endedCount = detail.cohorts.filter((c) => c.status === 'ENDED').length
+  const activeOperatorNames = detail.operators
+    .filter((o) => o.status === 'ACTIVE')
+    .map((o) => o.name)
+    .filter((n): n is string => Boolean(n))
+  const unassigned = org.operators.length === 0
+
+  return (
+    <div className="flex flex-col gap-4">
+      {unassigned && (
+        <Alert variant="warning">
+          <AlertTriangleIcon />
+          <AlertTitle>오퍼레이터가 없어 이 기관은 아직 시작되지 않았습니다</AlertTitle>
+          <AlertDescription>
+            기수·반·명단을 만들 수 있는 사람이 없습니다. 첫 오퍼레이터를 초대하면 그 뒤부터는 기관
+            안에서 매니저를 직접 초대합니다. <b className="text-fg-muted">오퍼레이터</b> 탭에서
+            초대할 수 있습니다.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <div className="grid grid-cols-4 gap-4">
+        <MetricCard
+          label="기수"
+          value={`${detail.cohorts.length}`}
+          sub={
+            detail.cohorts.length === 0
+              ? '개설된 기수 없음'
+              : `진행 ${ongoingCount} · 종료 ${endedCount}`
+          }
+        />
+        <MetricCard
+          label="교육생"
+          value={org.traineeCount.toLocaleString()}
+          sub={
+            org.traineeCount === 0
+              ? '명단은 오퍼레이터가 등록'
+              : `활성 세션 ${snapshot.activeSessions}`
+          }
+        />
+        <MetricCard
+          label="이번 달 AI 비용"
+          value={`$${org.monthlyAiCostUsd.toLocaleString()}`}
+          sub={`예산 $${snapshot.budgetUsd.toLocaleString()} 대비 ${snapshot.budgetPct}%`}
+        >
+          {/* Progress는 Track·Indicator를 스스로 렌더한다 — children으로 또 넣지 않는다
+              (OrgMetrics.tsx의 같은 경고 참고). */}
+          <Progress
+            value={Math.min(snapshot.budgetPct, 100)}
+            className="mt-2 gap-0 [&_[data-slot=progress-track]]:h-1.5 [&_[data-slot=progress-track]]:bg-warning-soft [&_[data-slot=progress-indicator]]:bg-warning"
+          />
+        </MetricCard>
+        <MetricCard
+          label="저장량"
+          value={`${snapshot.storageGb} GB`}
+          sub={
+            snapshot.storageGb === 0
+              ? '—'
+              : snapshot.storageDeltaPct === null
+                ? undefined
+                : `전월 대비 +${snapshot.storageDeltaPct}%`
+          }
+        />
+      </div>
+
+      <dl className="grid grid-cols-3 gap-x-6 gap-y-3 rounded-md border border-border bg-surface p-4 text-sm">
+        <InfoRow k="org_id" v={<span className="font-mono text-xs">{org.id}</span>} />
+        <InfoRow
+          k="상태"
+          v={
+            <Badge variant={org.status === 'ACTIVE' ? 'success' : 'neutral'}>
+              {org.status === 'ACTIVE' ? '활성' : '정지'}
+            </Badge>
+          }
+        />
+        <InfoRow k="생성일" v={org.createdAt} />
+        <InfoRow
+          k="오퍼레이터"
+          v={
+            unassigned ? (
+              <span className="text-warning font-semibold">미배정</span>
+            ) : activeOperatorNames.length > 0 ? (
+              activeOperatorNames.join(' · ')
+            ) : (
+              <span className="text-fg-subtle">—</span>
+            )
+          }
+        />
+        <InfoRow k="데이터 보존기간" v={`${detail.settings.retentionDays}일`} />
+        <InfoRow k="공개 범위 기본값" v={detail.settings.defaultVisibility} />
+      </dl>
+
+      <div>
+        <p className="text-fg-muted mb-2 text-xs font-bold">
+          기수 <span className="text-fg-subtle font-normal">· 읽기전용</span>
+        </p>
+        {detail.cohorts.length === 0 ? (
+          <p className="text-fg-subtle rounded-md border border-dashed border-border-strong bg-surface-2 p-6 text-center text-sm">
+            아직 개설된 기수가 없습니다.
+          </p>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow className="hover:bg-transparent">
+                <TableHead className="w-32">기수</TableHead>
+                <TableHead className="w-28">상태</TableHead>
+                <TableHead className="w-20 text-right">반</TableHead>
+                <TableHead className="w-24 text-right">교육생</TableHead>
+                <TableHead>기간</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {detail.cohorts.map((c) => (
+                <TableRow key={c.id}>
+                  <TableCell className="font-bold">{c.label}</TableCell>
+                  <TableCell>
+                    <Badge variant={c.status === 'ONGOING' ? 'success' : 'neutral'}>
+                      {c.status === 'ONGOING' ? '진행 중' : '종료'}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-right tabular-nums">{c.classCount}</TableCell>
+                  <TableCell className="text-right tabular-nums">{c.traineeCount}</TableCell>
+                  <TableCell className="text-fg-muted text-xs">{c.period}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function InfoRow({ k, v }: { k: string; v: ReactNode }) {
+  return (
+    <div className="flex items-baseline gap-2">
+      <dt className="text-fg-subtle w-28 shrink-0 text-xs">{k}</dt>
+      <dd className="text-fg text-sm font-medium">{v}</dd>
+    </div>
+  )
+}

--- a/src/features/superadmin/orgs/components/detail/SettingsTab.tsx
+++ b/src/features/superadmin/orgs/components/detail/SettingsTab.tsx
@@ -1,0 +1,256 @@
+import { useState } from 'react'
+import type { ReactNode } from 'react'
+import { Button } from '@/components/ui/Button'
+import { Switch } from '@/components/ui/Switch'
+import { Alert, AlertTitle, AlertDescription } from '@/components/ui/Alert'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/Select'
+import {
+  cancelOrgDeletion,
+  updateOrgSettings,
+  updateOrgStatus,
+  type Org,
+  type OrgDetail,
+  type VisibilityDefault,
+} from '../../mockData'
+import DeleteOrgDialog from './DeleteOrgDialog'
+
+/*
+  SA-02 §3 "설정 탭" — 계약 한도 · 기능 토글 · 테넌트 정책. 각 행은 즉시 반영되는
+  단일 컨트롤이라(폼 제출 없음, 와이어프레임에 저장 버튼이 없다) 바꾸는 즉시
+  updateOrgSettings/updateOrgStatus를 부르고 onChange()로 화면을 새로 읽어온다.
+
+  토글 3개의 기본 on/off는 와이어(`.tgl` vs `.tgl off`)를 그대로 읽었다 — GitHub
+  조직 연동·ZIP 업로드는 기본 on, 빅프 기여도 분석만 명시적으로 off였다.
+*/
+
+const BUDGET_OPTIONS = [200, 300, 400, 600, 800, 1000] as const
+const TOKEN_LIMIT_OPTIONS = [50, 80, 100, 150, 200, 300] as const
+const RETENTION_OPTIONS = [90, 180, 365] as const
+const VISIBILITY_OPTIONS: VisibilityDefault[] = ['요약', '상세']
+
+function itemsOf<T extends string | number>(values: readonly T[], format: (v: T) => string) {
+  return Object.fromEntries(values.map((v) => [String(v), format(v)]))
+}
+
+function SettingRow({
+  title,
+  description,
+  children,
+  danger,
+}: {
+  title: string
+  description: string
+  children: ReactNode
+  danger?: boolean
+}) {
+  return (
+    <div className="flex items-center justify-between gap-6 border-b border-border py-4 last:border-0">
+      <div>
+        <p className={danger ? 'text-danger text-sm font-bold' : 'text-sm font-bold'}>{title}</p>
+        <p className="text-fg-subtle mt-0.5 text-xs">{description}</p>
+      </div>
+      <div className="shrink-0">{children}</div>
+    </div>
+  )
+}
+
+export default function SettingsTab({
+  org,
+  detail,
+  onChange,
+}: {
+  org: Org
+  detail: OrgDetail
+  onChange: () => void
+}) {
+  const [deleteOpen, setDeleteOpen] = useState(false)
+  const s = detail.settings
+
+  function patch<K extends keyof typeof s>(key: K, value: (typeof s)[K]) {
+    updateOrgSettings(org.id, { [key]: value })
+    onChange()
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {org.deletion && (
+        <Alert variant="danger">
+          <AlertTitle>삭제 대기 중입니다</AlertTitle>
+          <AlertDescription className="flex items-center justify-between gap-4">
+            <span>{org.deletion.purgeAt}에 파기됩니다. 그전까지는 복구할 수 있습니다.</span>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                cancelOrgDeletion(org.id)
+                onChange()
+              }}
+            >
+              복구
+            </Button>
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <div className="rounded-md border border-border bg-surface px-4">
+        <SettingRow
+          title="기관 상태"
+          description="정지하면 소속 계정의 로그인이 막힙니다. 데이터는 보존됩니다"
+        >
+          <Select
+            value={org.status}
+            onValueChange={(v) => {
+              updateOrgStatus(org.id, (v as Org['status']) ?? org.status)
+              onChange()
+            }}
+            items={{ ACTIVE: '활성', SUSPENDED: '정지' }}
+          >
+            <SelectTrigger className="w-28" aria-label="기관 상태">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="ACTIVE">활성</SelectItem>
+              <SelectItem value="SUSPENDED">정지</SelectItem>
+            </SelectContent>
+          </Select>
+        </SettingRow>
+
+        <SettingRow
+          title="AI 월 예산 상한"
+          description="넘으면 경고가 표시됩니다. 서비스는 중단되지 않습니다"
+        >
+          <Select
+            value={String(s.budgetUsd)}
+            onValueChange={(v) => patch('budgetUsd', Number(v ?? s.budgetUsd))}
+            items={itemsOf(BUDGET_OPTIONS, (v) => `$${v}`)}
+          >
+            <SelectTrigger className="w-28" aria-label="AI 월 예산 상한">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {BUDGET_OPTIONS.map((v) => (
+                <SelectItem key={v} value={String(v)}>
+                  ${v}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </SettingRow>
+
+        <SettingRow title="기관 · 월 토큰 한도" description="넘으면 새 세션이 열리지 않습니다">
+          <Select
+            value={String(s.tokenLimitM)}
+            onValueChange={(v) => patch('tokenLimitM', Number(v ?? s.tokenLimitM))}
+            items={itemsOf(TOKEN_LIMIT_OPTIONS, (v) => `${v}M`)}
+          >
+            <SelectTrigger className="w-28" aria-label="기관 · 월 토큰 한도">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {TOKEN_LIMIT_OPTIONS.map((v) => (
+                <SelectItem key={v} value={String(v)}>
+                  {v}M
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </SettingRow>
+
+        <SettingRow title="데이터 보존기간" description="종료 기수 데이터 보관 기간">
+          <Select
+            value={String(s.retentionDays)}
+            onValueChange={(v) => patch('retentionDays', Number(v ?? s.retentionDays))}
+            items={itemsOf(RETENTION_OPTIONS, (v) => `${v}일`)}
+          >
+            <SelectTrigger className="w-28" aria-label="데이터 보존기간">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {RETENTION_OPTIONS.map((v) => (
+                <SelectItem key={v} value={String(v)}>
+                  {v}일
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </SettingRow>
+
+        <SettingRow
+          title="신규 기수 공개 범위 기본값"
+          description="교육생에게 결과를 어디까지 공개할지의 기본값"
+        >
+          <Select
+            value={s.defaultVisibility}
+            onValueChange={(v) =>
+              patch('defaultVisibility', (v as VisibilityDefault) ?? s.defaultVisibility)
+            }
+            items={itemsOf(VISIBILITY_OPTIONS, (v) => v)}
+          >
+            <SelectTrigger className="w-28" aria-label="신규 기수 공개 범위 기본값">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {VISIBILITY_OPTIONS.map((v) => (
+                <SelectItem key={v} value={v}>
+                  {v}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </SettingRow>
+
+        <SettingRow title="GitHub 조직 연동" description="기관 저장소를 한 번에 연동합니다">
+          <Switch
+            checked={s.githubOrgSync}
+            onCheckedChange={(checked) => patch('githubOrgSync', checked)}
+            aria-label="GitHub 조직 연동"
+          />
+        </SettingRow>
+
+        <SettingRow
+          title="ZIP 업로드"
+          description="조직 밖 저장소를 내는 경로. 끄면 GitHub 연동만 남는다."
+        >
+          <Switch
+            checked={s.zipUpload}
+            onCheckedChange={(checked) => patch('zipUpload', checked)}
+            aria-label="ZIP 업로드"
+          />
+        </SettingRow>
+
+        <SettingRow title="빅프 기여도 분석" description="커밋 기준 기여도">
+          <Switch
+            checked={s.contributionAnalysis}
+            onCheckedChange={(checked) => patch('contributionAnalysis', checked)}
+            aria-label="빅프 기여도 분석"
+          />
+        </SettingRow>
+
+        <SettingRow title="기관 삭제" description="보존기간이 지난 뒤 파기됩니다" danger>
+          <Button
+            variant="ghost"
+            className="text-danger border-danger-border"
+            disabled={Boolean(org.deletion)}
+            onClick={() => setDeleteOpen(true)}
+          >
+            기관 삭제
+          </Button>
+        </SettingRow>
+      </div>
+
+      <DeleteOrgDialog
+        open={deleteOpen}
+        onOpenChange={setDeleteOpen}
+        org={org}
+        retentionDays={s.retentionDays}
+        onDeleted={onChange}
+      />
+    </div>
+  )
+}

--- a/src/features/superadmin/orgs/components/detail/UsageTab.tsx
+++ b/src/features/superadmin/orgs/components/detail/UsageTab.tsx
@@ -1,0 +1,263 @@
+import { useEffect, useState } from 'react'
+import { ClockIcon } from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import { Progress } from '@/components/ui/Progress'
+import { Empty, EmptyHeader, EmptyTitle, EmptyDescription, EmptyMedia } from '@/components/ui/Empty'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/Select'
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableRow,
+  TableHead,
+  TableCell,
+} from '@/components/ui/Table'
+import {
+  getOrgUsage,
+  USAGE_PERIOD_OPTIONS,
+  type Org,
+  type OrgUsage,
+  type UsagePeriod,
+} from '../../mockData'
+
+/*
+  SA-02 §3 "사용량 · AI 비용 탭" · 케이스 6(USAGE_UNAVAILABLE). getOrgUsage는
+  이 화면 하나만 감싼다 — 실패해도 다른 탭·기관 정보는 그대로 보여야 한다(§6
+  "이 영역만 막는다"). 그래서 이 컴포넌트는 로딩·실패·성공 3상태를 자체적으로
+  들고 있고, 부모(OrgDetailScreen)는 org만 넘긴다.
+
+  기간(와이어 `.filter` "기간 ▾")은 이 탭 안의 상태다 — 다른 탭에는 없는 이
+  탭 전용 컨트롤이라 OrgDetailScreen까지 끌어올리지 않는다. 옵션 구성 근거는
+  mockData.ts의 "사용량 · 기간" 섹션 주석에 있다(월 단위로 나눈 이유).
+
+  표시되는 비용 총액은 org.monthlyAiCostUsd(전역 "이번 달" 값)를 쓰지 않고
+  usage.models 합계로 직접 계산한다 — 기간을 지난 달·2개월 전으로 바꾸면
+  org.monthlyAiCostUsd는 더 이상 화면에 보이는 기간의 값이 아니게 된다.
+*/
+
+type State = { status: 'loading' } | { status: 'error' } | { status: 'ready'; usage: OrgUsage }
+
+function formatTokens(n: number): string {
+  if (n === 0) return '0'
+  return `${(n / 1_000_000).toFixed(1)}M`
+}
+
+export default function UsageTab({ org }: { org: Org }) {
+  const [period, setPeriod] = useState<UsagePeriod>('CURRENT')
+  const [state, setState] = useState<State>({ status: 'loading' })
+  const [attempt, setAttempt] = useState(0)
+
+  useEffect(() => {
+    setState({ status: 'loading' })
+    let cancelled = false
+    getOrgUsage(org.id, period).then(
+      (usage) => {
+        if (!cancelled) setState({ status: 'ready', usage })
+      },
+      () => {
+        if (!cancelled) setState({ status: 'error' })
+      },
+    )
+    return () => {
+      cancelled = true
+    }
+  }, [org.id, period, attempt])
+
+  const periodLabel = USAGE_PERIOD_OPTIONS.find((o) => o.value === period)?.label ?? '이번 달'
+
+  const periodSelect = (
+    <div className="mb-1 flex items-center justify-end gap-2">
+      <span className="text-fg-subtle text-xs">기간</span>
+      <Select
+        value={period}
+        onValueChange={(v) => setPeriod((v as UsagePeriod) ?? period)}
+        items={Object.fromEntries(USAGE_PERIOD_OPTIONS.map((o) => [o.value, o.label]))}
+      >
+        <SelectTrigger className="w-32" aria-label="기간">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {USAGE_PERIOD_OPTIONS.map((o) => (
+            <SelectItem key={o.value} value={o.value}>
+              {o.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  )
+
+  if (state.status === 'loading') {
+    return (
+      <div className="flex flex-col gap-4">
+        {periodSelect}
+        <p className="text-fg-subtle py-16 text-center text-sm">불러오는 중…</p>
+      </div>
+    )
+  }
+
+  if (state.status === 'error') {
+    return (
+      <div className="flex flex-col gap-4">
+        {periodSelect}
+        <Empty className="py-16">
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <ClockIcon />
+            </EmptyMedia>
+            <EmptyTitle>사용량을 불러오지 못했습니다</EmptyTitle>
+            <EmptyDescription>
+              잠시 후 다시 시도해 주세요.
+              <br />
+              저장량 · 사용 규모 · AI 비용은 지금 확인할 수 없습니다.
+            </EmptyDescription>
+          </EmptyHeader>
+          <Button variant="ghost" onClick={() => setAttempt((n) => n + 1)}>
+            다시 불러오기
+          </Button>
+        </Empty>
+      </div>
+    )
+  }
+
+  const { usage } = state
+  const totalCostUsd = usage.models.reduce((sum, m) => sum + m.costUsd, 0)
+  const budgetPct =
+    usage.monthBudgetUsd > 0 ? Math.round((totalCostUsd / usage.monthBudgetUsd) * 100) : 0
+  const totalTokens = usage.models.reduce(
+    (sum, m) => ({ in: sum.in + m.inputTokens, out: sum.out + m.outputTokens }),
+    { in: 0, out: 0 },
+  )
+  const totalCalls = usage.models.reduce((sum, m) => sum + m.calls, 0)
+
+  return (
+    <div className="flex flex-col gap-4">
+      {periodSelect}
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="rounded-md border border-border bg-surface p-4">
+          <div className="mb-3 flex items-baseline justify-between">
+            <h4 className="text-sm font-bold">저장량 구성</h4>
+            <span className="text-fg-subtle text-xs">총 {usage.totalStorageGb} GB</span>
+          </div>
+          {usage.storageBreakdown.length === 0 ? (
+            <p className="text-fg-subtle text-sm">저장된 데이터가 없습니다.</p>
+          ) : (
+            <div className="flex flex-col gap-2.5">
+              {usage.storageBreakdown.map((row) => (
+                <div key={row.label}>
+                  <div className="mb-1 flex items-baseline justify-between text-xs">
+                    <span className="text-fg-muted">{row.label}</span>
+                    <span className="tabular-nums font-medium">{row.gb} GB</span>
+                  </div>
+                  <Progress
+                    value={usage.totalStorageGb > 0 ? (row.gb / usage.totalStorageGb) * 100 : 0}
+                    className="gap-0 [&_[data-slot=progress-track]]:h-1.5"
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="rounded-md border border-border bg-surface p-4">
+          <div className="mb-3 flex items-baseline justify-between">
+            <h4 className="text-sm font-bold">사용 규모</h4>
+            <span className="text-fg-subtle text-xs">{periodLabel}</span>
+          </div>
+          <dl className="flex flex-col gap-2.5 text-sm">
+            <UsageRow k="활성 교육생" v={usage.activeTrainees.toLocaleString()} />
+            <UsageRow k="완료 세션" v={usage.completedSessions.toLocaleString()} />
+            <UsageRow k="채점 회차" v={usage.gradingRounds.toLocaleString()} />
+            <UsageRow k="발행 리포트" v={usage.publishedReports.toLocaleString()} />
+          </dl>
+        </div>
+      </div>
+
+      <div className="rounded-md border border-border bg-surface p-4">
+        <div className="mb-3 flex items-baseline justify-between">
+          <h4 className="text-sm font-bold">AI 비용 · 모델별</h4>
+          <span className="text-fg-subtle text-xs">
+            {periodLabel} ${totalCostUsd.toLocaleString()} / 예산 $
+            {usage.monthBudgetUsd.toLocaleString()}
+            {usage.costDeltaPct !== 0 && (
+              <span className="text-danger ml-1.5 font-bold">전월 +{usage.costDeltaPct}%</span>
+            )}
+          </span>
+        </div>
+        <Progress
+          value={Math.min(budgetPct, 100)}
+          className="mb-4 gap-0 [&_[data-slot=progress-track]]:h-1.5 [&_[data-slot=progress-track]]:bg-warning-soft [&_[data-slot=progress-indicator]]:bg-warning"
+        />
+        {/* 이 표는 이미 테두리·배경이 있는 패널(위 div) 안에 있다 — Table 자체의 면을
+            또 두면 이중 테두리가 된다(Table.tsx 주석 "카드 안에 이미 들어 있는 경우"
+            참고). 개요·오퍼레이터 탭의 표는 이런 바깥 패널이 없어 그대로(기본값) 둔다. */}
+        {usage.models.length === 0 ? (
+          <p className="text-fg-subtle text-center text-sm">{periodLabel} 사용 내역이 없습니다.</p>
+        ) : (
+          <Table className="border-0 bg-transparent">
+            <TableHeader>
+              <TableRow className="hover:bg-transparent">
+                <TableHead>용도 · 모델</TableHead>
+                <TableHead className="text-right">호출</TableHead>
+                <TableHead className="text-right">토큰(입력/출력)</TableHead>
+                <TableHead className="text-right">비용</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {usage.models.map((m) => (
+                <TableRow key={`${m.purpose}-${m.model}`}>
+                  <TableCell>
+                    {m.purpose}{' '}
+                    <span className="text-fg-subtle text-xs">
+                      {m.tierLabel} · <span className="font-mono">{m.model}</span>
+                    </span>
+                  </TableCell>
+                  <TableCell className="text-right tabular-nums">
+                    {m.calls.toLocaleString()}
+                  </TableCell>
+                  <TableCell className="text-right font-mono text-xs">
+                    {formatTokens(m.inputTokens)} / {formatTokens(m.outputTokens)}
+                  </TableCell>
+                  <TableCell className="text-right tabular-nums">
+                    ${m.costUsd.toLocaleString()}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+            <TableFooter>
+              <TableRow>
+                <TableCell>합계</TableCell>
+                <TableCell className="text-right tabular-nums">
+                  {totalCalls.toLocaleString()}
+                </TableCell>
+                <TableCell className="text-right font-mono text-xs">
+                  {formatTokens(totalTokens.in)} / {formatTokens(totalTokens.out)}
+                </TableCell>
+                <TableCell className="text-right tabular-nums">
+                  ${totalCostUsd.toLocaleString()}
+                </TableCell>
+              </TableRow>
+            </TableFooter>
+          </Table>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function UsageRow({ k, v }: { k: string; v: string }) {
+  return (
+    <div className="flex items-baseline justify-between">
+      <dt className="text-fg-subtle">{k}</dt>
+      <dd className="tabular-nums font-medium">{v}</dd>
+    </div>
+  )
+}

--- a/src/features/superadmin/orgs/mockData.ts
+++ b/src/features/superadmin/orgs/mockData.ts
@@ -18,6 +18,17 @@
 
 export type OrgStatus = 'ACTIVE' | 'SUSPENDED'
 
+/** 소프트 삭제 요청 — 즉시 파기가 아니라 보존기간이 지나야 파기된다(SA-02 §6·§7).
+ * `status`(정지)와 별개 축이라 Org에 직접 둔다 — 목록(SA-01)이 이 배지를 최우선으로
+ * 보여줘야 하는데, 상세(ORG_DETAILS)까지 가서 조회하게 하면 목록 화면이 상세 모듈에
+ * 의존하게 된다. */
+export type OrgDeletion = {
+  /** YYYY-MM-DD */
+  requestedAt: string
+  /** YYYY-MM-DD — requestedAt + 보존기간(설정 탭의 retentionDays) */
+  purgeAt: string
+}
+
 export type Org = {
   id: string
   name: string
@@ -31,6 +42,8 @@ export type Org = {
   operators: string[]
   /** YYYY-MM-DD */
   createdAt: string
+  /** 삭제 요청됨(파기 전) — 없으면(undefined) 정상. requestOrgDeletion이 채운다 */
+  deletion?: OrgDeletion
 }
 
 export const ORGS: Org[] = [
@@ -202,6 +215,20 @@ export const PLATFORM_SNAPSHOT = {
   storageDeltaPct: 6,
 }
 
+/** 상태 배지 우선순위 — 삭제 대기 > 오퍼레이터 미배정 > 활성/정지. SA-01 목록과
+ * SA-02 상세 헤더가 같은 배지를 보여줘야 해서(같은 기관, 다른 화면) 한 곳에 둔다 —
+ * 두 화면이 각자 판정하면 우선순위가 갈릴 위험이 있다. */
+export function orgStatusBadge(org: Org): {
+  variant: 'success' | 'warning' | 'neutral' | 'danger'
+  label: string
+} {
+  if (org.deletion) return { variant: 'danger', label: `삭제 대기 · ${org.deletion.purgeAt} 파기` }
+  if (org.operators.length === 0) return { variant: 'warning', label: '오퍼레이터 미배정' }
+  return org.status === 'ACTIVE'
+    ? { variant: 'success', label: '활성' }
+    : { variant: 'neutral', label: '정지' }
+}
+
 export type OrgApiErrorCode = 'ORG_NAME_TAKEN' | 'ORG_CREATE_FAILED'
 
 export interface OrgApiError {
@@ -273,4 +300,726 @@ export function createOrg(input: CreateOrgInput): Promise<Org> {
   // })
   // if (!res.ok) return Promise.reject(await res.json()) // { code }
   // return res.json()
+}
+
+/*
+  ══════════════════════════════ SA-02 기관 상세 ══════════════════════════════
+
+  정의서(SA-02-org-detail.md) · 와이어프레임(superadmin/console.html#page-overview
+  이하 — overview·noop·operators·invite·mailfail·lastblock·usage·usagefail·
+  settings·deleteconfirm)만 보고 짰다(v1 원본 없음, SA-01과 같은 사정).
+
+  데모를 3개 기관에 몰아둔다 — 상태를 기관마다 흩어두면 리뷰가 "이 케이스는 어느
+  기관에서 보나"를 매번 찾아야 한다:
+  - org-1(그린컴퍼니 부트캠프) — 정상 케이스의 무대. 오퍼레이터 4명이 활성·초대중·
+    메일실패는 아니고 정지·퇴사까지 이 화면에서 나오는 상태를 다 보여준다.
+  - org-4(블루아카데미) — 오퍼레이터가 1명뿐 → "마지막 오퍼레이터 정지 차단"(N2)의
+    무대. 와이어프레임 #lastblock도 이 기관 이름을 쓴다.
+  - org-5(파이널랩) — SA-01부터 오퍼레이터 0명(§3 핵심 신호). 기수도 0개라 개요 탭
+    상단 경고(#noop)가 여기서 뜬다.
+  - org-3(코드스쿨 A트랙) — 사용량 집계가 **항상** 실패한다(#usagefail 데모). 매번
+    같은 기관에서 재현돼야 "이 영역만 막힌다"를 리뷰가 검증하기 쉽다.
+
+  나머지 10개 기관은 ORG_DETAILS에 없다 — getOrgDetail이 fallback을 그 자리에서
+  만들어 최소 골격(SA-01의 operators 이름만 살리고, 기수·사용량은 traineeCount에서
+  파생)으로 진입은 항상 되게 한다. "목록의 아무 행이나 눌러도 상세가 뜬다"가
+  목적이라, 14개 기관 전부에 손으로 데이터를 채우는 비용을 들이지 않는다.
+*/
+
+export type CohortStatus = 'ONGOING' | 'ENDED'
+
+export interface Cohort {
+  id: string
+  label: string
+  status: CohortStatus
+  classCount: number
+  traineeCount: number
+  /** "2026-06 ~ 09" 같은 표시용 문구 */
+  period: string
+}
+
+export type OperatorStatus = 'ACTIVE' | 'INVITED' | 'MAIL_FAILED' | 'SUSPENDED'
+
+export interface Operator {
+  id: string
+  /** null = 초대만 됐고 아직 가입 전(표에 "—") */
+  name: string | null
+  email: string
+  status: OperatorStatus
+  /** YYYY-MM-DD 또는 "방금" */
+  invitedAt: string
+  /** null = 로그인 기록 없음 */
+  lastLoginAt: string | null
+}
+
+export interface ModelUsageRow {
+  purpose: string
+  tierLabel: string
+  model: string
+  calls: number
+  inputTokens: number
+  outputTokens: number
+  costUsd: number
+}
+
+export interface StorageBreakdownRow {
+  label: string
+  gb: number
+}
+
+export interface OrgUsage {
+  storageBreakdown: StorageBreakdownRow[]
+  totalStorageGb: number
+  activeTrainees: number
+  completedSessions: number
+  gradingRounds: number
+  publishedReports: number
+  monthBudgetUsd: number
+  costDeltaPct: number
+  models: ModelUsageRow[]
+}
+
+export type VisibilityDefault = '요약' | '상세'
+
+export interface OrgSettings {
+  budgetUsd: number
+  tokenLimitM: number
+  retentionDays: number
+  defaultVisibility: VisibilityDefault
+  githubOrgSync: boolean
+  zipUpload: boolean
+  contributionAnalysis: boolean
+}
+
+export interface OrgDetail {
+  cohorts: Cohort[]
+  operators: Operator[]
+  settings: OrgSettings
+}
+
+/** 손으로 채운 3개 기관 — 위 주석의 데모 배정 그대로 */
+const ORG_DETAILS: Record<string, OrgDetail> = {
+  'org-1': {
+    cohorts: [
+      {
+        id: 'c-8',
+        label: '8기',
+        status: 'ONGOING',
+        classCount: 10,
+        traineeCount: 52,
+        period: '2026-06 ~ 09',
+      },
+      {
+        id: 'c-7',
+        label: '7기',
+        status: 'ONGOING',
+        classCount: 9,
+        traineeCount: 48,
+        period: '2026-05 ~ 08',
+      },
+      {
+        id: 'c-6',
+        label: '6기',
+        status: 'ENDED',
+        classCount: 9,
+        traineeCount: 48,
+        period: '2026-02 ~ 05',
+      },
+    ],
+    operators: [
+      {
+        id: 'op-1',
+        name: '박지현',
+        email: 'jihyun@green.com',
+        status: 'ACTIVE',
+        invitedAt: '2026-03-02',
+        lastLoginAt: '2026-07-28',
+      },
+      {
+        id: 'op-2',
+        name: '한도윤',
+        email: 'doyun@green.com',
+        status: 'ACTIVE',
+        invitedAt: '2026-05-11',
+        lastLoginAt: '2026-07-27',
+      },
+      // 지정은 됐지만 아직 가입 전 — mailfail과 구분: 여긴 메일이 정상 발송된 케이스
+      {
+        id: 'op-3',
+        name: null,
+        email: 'newop@green.com',
+        status: 'INVITED',
+        invitedAt: '2026-07-27',
+        lastLoginAt: null,
+      },
+      // 정지·퇴사 — 재활성 가능한 상태를 보여주는 데모
+      {
+        id: 'op-4',
+        name: '최상현',
+        email: 'sanghyun@green.com',
+        status: 'SUSPENDED',
+        invitedAt: '2025-11-02',
+        lastLoginAt: '2026-05-02',
+      },
+    ],
+    settings: {
+      budgetUsd: 600,
+      tokenLimitM: 200,
+      retentionDays: 180,
+      defaultVisibility: '요약',
+      githubOrgSync: true,
+      zipUpload: true,
+      contributionAnalysis: false,
+    },
+  },
+  'org-4': {
+    cohorts: [
+      {
+        id: 'c-b1',
+        label: '1기',
+        status: 'ENDED',
+        classCount: 2,
+        traineeCount: 40,
+        period: '2025-10 ~ 2026-01',
+      },
+    ],
+    // 딱 1명 — "정지" 눌러도 LAST_OPERATOR로 막혀야 한다(N2, #lastblock)
+    operators: [
+      {
+        id: 'op-5',
+        name: '정민호',
+        email: 'minho@blueac.io',
+        status: 'ACTIVE',
+        invitedAt: '2026-01-15',
+        lastLoginAt: '2026-07-20',
+      },
+    ],
+    settings: {
+      budgetUsd: 200,
+      tokenLimitM: 80,
+      retentionDays: 180,
+      defaultVisibility: '요약',
+      githubOrgSync: false,
+      zipUpload: true,
+      contributionAnalysis: false,
+    },
+  },
+  'org-5': {
+    // 오퍼레이터 0명 → 기수도 0개(#noop) — SA-01부터 이어지는 같은 기관
+    cohorts: [],
+    operators: [],
+    settings: {
+      budgetUsd: 400,
+      tokenLimitM: 100,
+      retentionDays: 180,
+      defaultVisibility: '요약',
+      githubOrgSync: false,
+      zipUpload: true,
+      contributionAnalysis: false,
+    },
+  },
+}
+
+const DEFAULT_SETTINGS: OrgSettings = {
+  budgetUsd: 400,
+  tokenLimitM: 100,
+  retentionDays: 180,
+  defaultVisibility: '요약',
+  githubOrgSync: false,
+  zipUpload: true,
+  contributionAnalysis: false,
+}
+
+/** 손으로 안 채운 기관의 최소 골격 — SA-01의 operators 이름만 살리고 나머지는
+ * traineeCount·cohortCount에서 파생한다. 실 데이터가 아니라 "진입이 죽지 않는다"가
+ * 목적이므로 정밀도는 필요 없다. */
+function fallbackDetail(org: Org): OrgDetail {
+  const perCohort = org.cohortCount > 0 ? Math.round(org.traineeCount / org.cohortCount) : 0
+  const cohorts: Cohort[] = Array.from({ length: org.cohortCount }, (_, i) => ({
+    id: `${org.id}-c-${i + 1}`,
+    label: `${i + 1}기`,
+    status: i === org.cohortCount - 1 && org.status === 'ACTIVE' ? 'ONGOING' : 'ENDED',
+    classCount: Math.max(1, Math.round(perCohort / 5)),
+    traineeCount: perCohort,
+    period: '—',
+  }))
+  const operators: Operator[] = org.operators.map((name, i) => ({
+    id: `${org.id}-op-${i + 1}`,
+    name,
+    email: `operator${i + 1}@${org.domain}`,
+    status: org.status === 'SUSPENDED' ? 'SUSPENDED' : 'ACTIVE',
+    invitedAt: org.createdAt,
+    lastLoginAt: null,
+  }))
+  return { cohorts, operators, settings: { ...DEFAULT_SETTINGS } }
+}
+
+/** 화면·mock API가 실제로 읽고 쓰는 저장소. ORG_DETAILS(손으로 채운 3곳)를 시드로
+ * 쓰고, 나머지는 처음 조회될 때 fallbackDetail로 채운다 — SA-01의 ORGS와 같은
+ * 관례(함수가 직접 mutate)로, 초대·정지 같은 액션이 화면을 벗어났다 돌아와도
+ * 유지된다. */
+const detailStore: Record<string, OrgDetail> = {}
+
+function getOrCreateDetail(orgId: string): OrgDetail {
+  if (!detailStore[orgId]) {
+    const org = ORGS.find((o) => o.id === orgId)
+    detailStore[orgId] = ORG_DETAILS[orgId] ?? (org ? fallbackDetail(org) : { ...emptyDetail() })
+  }
+  return detailStore[orgId]
+}
+
+function emptyDetail(): OrgDetail {
+  return { cohorts: [], operators: [], settings: { ...DEFAULT_SETTINGS } }
+}
+
+/** GET /admin/orgs/{id} — 기관 메타 + 상세. 기관이 없으면 null(잘못된 주소) */
+export function getOrgDetail(orgId: string): { org: Org; detail: OrgDetail } | null {
+  const org = ORGS.find((o) => o.id === orgId)
+  if (!org) return null
+  return { org, detail: getOrCreateDetail(orgId) }
+}
+
+// ───────────────────────── 오퍼레이터 초대·정지 ─────────────────────────
+
+export type InviteFieldErrorCode = 'INVALID_EMAIL' | 'ALREADY_INVITED' | 'DOMAIN_NOT_ALLOWED'
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+/** 케이스 2·N1 — 제출 전 필드 검증(정의서 §3 "모달 필드 하단"). 서버 왕복이 필요
+ * 없는 형식·중복·도메인 검사라 OrgCreateDialog의 실시간 중복 확인과 달리 동기로 둔다. */
+export function validateOperatorEmail(
+  orgDomain: string,
+  existing: Operator[],
+  email: string,
+): InviteFieldErrorCode | null {
+  const trimmed = email.trim()
+  if (!EMAIL_RE.test(trimmed)) return 'INVALID_EMAIL'
+  const domain = trimmed.slice(trimmed.indexOf('@') + 1).toLowerCase()
+  if (domain !== orgDomain.toLowerCase()) return 'DOMAIN_NOT_ALLOWED'
+  if (existing.some((o) => o.email.toLowerCase() === trimmed.toLowerCase()))
+    return 'ALREADY_INVITED'
+  return null
+}
+
+// ===== Mock 전용 (백엔드 연동 시 이 블록 삭제) =====
+/** 로컬파트에 이 문자열이 있으면 "지정됐지만 메일이 안 나감"으로 응답한다(케이스
+ * 4·5 합침 — 정의서 §6 "서버 사정이 다를 뿐 사용자가 할 일은 재발송 하나"). 이메일
+ * *형식*은 여전히 유효해야 하니 로컬파트에 섞는다(도메인에 넣으면 검증부터 막힌다). */
+const INVITE_MAIL_FAIL_TRIGGER = 'fail'
+// ====================================================
+
+/** POST /admin/orgs/{id}/operators — 초대. 메일 실패해도 계정 자리는 남는다(§6). */
+export function inviteOperator(orgId: string, email: string): Promise<Operator> {
+  // ===== Mock 버전 (현재 활성) =====
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      const detail = getOrCreateDetail(orgId)
+      const trimmed = email.trim()
+      const mailFailed = trimmed.toLowerCase().split('@')[0]?.includes(INVITE_MAIL_FAIL_TRIGGER)
+      const operator: Operator = {
+        id: `op-${Date.now()}`,
+        name: null,
+        email: trimmed,
+        status: mailFailed ? 'MAIL_FAILED' : 'INVITED',
+        invitedAt: '방금',
+        lastLoginAt: null,
+      }
+      detail.operators = [operator, ...detail.operators]
+      syncOrgOperatorNames(orgId) // 초대 자체는 ACTIVE가 아니라 목록엔 안 잡힌다 —
+      // 그래도 다른 액션과 같은 자리에서 항상 불러 "언제 부르는지"를 고민 안 하게 한다.
+      resolve(operator)
+    }, 500)
+  })
+
+  // ===== 실제 백엔드 버전 =====
+  // const res = await fetch(`/admin/orgs/${orgId}/operators`, {
+  //   method: 'POST',
+  //   headers: { 'Content-Type': 'application/json' },
+  //   body: JSON.stringify({ email }),
+  // })
+  // return res.json()
+}
+
+/** POST /admin/orgs/{id}/operators/{opId}/resend — 재발송. 자리를 지우지 않고
+ * 상태만 되돌린다(§6). */
+export function resendInvite(orgId: string, operatorId: string): Promise<Operator> {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      const detail = getOrCreateDetail(orgId)
+      const op = detail.operators.find((o) => o.id === operatorId)
+      if (!op) {
+        reject(new Error('operator not found'))
+        return
+      }
+      op.status = 'INVITED'
+      op.invitedAt = '방금'
+      resolve(op)
+    }, 500)
+  })
+}
+
+/** DELETE /admin/orgs/{id}/operators/{opId} — 아직 가입 전인 초대 자리 취소.
+ * 가입 완료된 계정(활성·정지)엔 쓰지 않는다 — 그건 정지/재활성이 맡는다. */
+export function cancelInvite(orgId: string, operatorId: string): void {
+  const detail = getOrCreateDetail(orgId)
+  detail.operators = detail.operators.filter((o) => o.id !== operatorId)
+  syncOrgOperatorNames(orgId)
+}
+
+/** SA-01 `Org.operators`(이름 배열)를 SA-02 `OrgDetail.operators`(상세 레코드)의
+ * 활성 인원으로 다시 맞춘다. 두 필드가 서로 다른 화면(SA-01 목록·SA-02 상세)의
+ * 서로 다른 저장소에 있어서, 상세에서 초대·정지·재활성을 해도 자동으로는 안
+ * 맞춰진다 — 안 부르면 SA-01 목록의 "오퍼레이터 미배정" 배지·오퍼레이터 이름이
+ * 상세에서 방금 정지·재활성한 것과 안 맞게 뒤쳐진다. 초대(INVITED)는 아직
+ * 로그인한 적 없는 사람이라 여기 안 들어간다(§6, suspendOperator 주석과 같은 이유). */
+function syncOrgOperatorNames(orgId: string): void {
+  const org = ORGS.find((o) => o.id === orgId)
+  if (!org) return
+  const detail = getOrCreateDetail(orgId)
+  org.operators = detail.operators
+    .filter((o) => o.status === 'ACTIVE')
+    .map((o) => o.name)
+    .filter((n): n is string => Boolean(n))
+}
+
+export const LAST_OPERATOR_ERROR = 'LAST_OPERATOR' as const
+
+/** PATCH /admin/orgs/{id}/operators/{opId} — 정지. 활성(ACTIVE) 오퍼레이터가 이 한
+ * 명뿐이면 막는다(N2, §6 "고아 기관 방지"). **초대중(INVITED)·메일발송실패는 세지
+ * 않는다** — 아직 로그인한 적 없는 계정이라 그 초대가 실제로 받아들여질지
+ * 보장이 안 된다(메일이 스팸함에 묻히거나, 받는 사람이 그냥 무시할 수도 있다).
+ * 받지도 않은 초대를 "커버"로 치고 마지막 활성 계정을 정지시키면, 그 초대가
+ * 영영 안 열릴 경우 기관이 그대로 고아가 된다 — 정지는 그 사람이 실제로 들어와서
+ * ACTIVE가 된 뒤에만 풀린다. */
+export function suspendOperator(
+  orgId: string,
+  operatorId: string,
+): { ok: true } | { ok: false; code: typeof LAST_OPERATOR_ERROR } {
+  const detail = getOrCreateDetail(orgId)
+  const target = detail.operators.find((o) => o.id === operatorId)
+  if (!target) return { ok: false, code: LAST_OPERATOR_ERROR }
+  const activeCount = detail.operators.filter((o) => o.status === 'ACTIVE').length
+  if (target.status === 'ACTIVE' && activeCount <= 1) {
+    return { ok: false, code: LAST_OPERATOR_ERROR }
+  }
+  target.status = 'SUSPENDED'
+  syncOrgOperatorNames(orgId)
+  return { ok: true }
+}
+
+/** PATCH /admin/orgs/{id}/operators/{opId} — 재활성. 마지막 1인 제약이 없다(정지에만 있다). */
+export function reactivateOperator(orgId: string, operatorId: string): void {
+  const detail = getOrCreateDetail(orgId)
+  const op = detail.operators.find((o) => o.id === operatorId)
+  if (op) op.status = 'ACTIVE'
+  syncOrgOperatorNames(orgId)
+}
+
+// ───────────────────────── 사용량 · 비용 ─────────────────────────
+
+export type UsageApiErrorCode = 'USAGE_UNAVAILABLE'
+
+export interface UsageApiError {
+  code: UsageApiErrorCode
+}
+
+/** 손으로 채운 사용량 — org-1만. 합계($412 = 286+104+22)가 SA-01 목록의
+ * monthlyAiCostUsd와 맞아야 한다(같은 기관을 두 화면에서 본다). */
+const USAGE_BY_ORG: Record<string, OrgUsage> = {
+  'org-1': {
+    storageBreakdown: [
+      { label: '코드 제출물 (레포·ZIP)', gb: 4.8 },
+      { label: '문답 원문', gb: 2.1 },
+      { label: '채점 근거 (evidence)', gb: 1.6 },
+      { label: '리포트 · 내보내기 PDF', gb: 0.9 },
+    ],
+    totalStorageGb: 9.4,
+    activeTrainees: 148,
+    completedSessions: 612,
+    gradingRounds: 1840,
+    publishedReports: 96,
+    monthBudgetUsd: 600,
+    costDeltaPct: 12,
+    models: [
+      {
+        purpose: '채점',
+        tierLabel: '플랫폼 고정',
+        model: 'claude-opus-5',
+        calls: 3120,
+        inputTokens: 18_400_000,
+        outputTokens: 2_100_000,
+        costUsd: 286,
+      },
+      {
+        purpose: '질문 생성',
+        tierLabel: '균형 티어',
+        model: 'claude-sonnet-5',
+        calls: 1540,
+        inputTokens: 9_200_000,
+        outputTokens: 3_400_000,
+        costUsd: 104,
+      },
+      {
+        purpose: '요약',
+        tierLabel: '비용 우선 티어',
+        model: 'claude-haiku-4-5',
+        calls: 420,
+        inputTokens: 2_100_000,
+        outputTokens: 600_000,
+        costUsd: 22,
+      },
+    ],
+  },
+}
+
+/** org-1 예시의 항목별 비중 — 저장량 4종·모델 3종. 손으로 안 채운 13개 기관도
+ * "저장량 구성이 여러 막대로 어떻게 쪼개지는지", "모델별 비용 표가 실제로 어떻게
+ * 채워지는지"를 바로 볼 수 있어야 한다(막대 1개·행 1개짜리 자리표시로는 이 탭을
+ * 평가할 수 없다). 항목 이름(코드 제출물·문답 원문 등, 채점·질문 생성·요약)은
+ * 실제 데이터 스키마이지 org-1만의 특징이 아니라서 그대로 재사용하고, org마다
+ * 다른 건 규모(비중을 그 기관의 storageGb·monthlyAiCostUsd에 곱한 값)뿐이다. */
+const STORAGE_SHARE = [
+  { label: '코드 제출물 (레포·ZIP)', share: 4.8 / 9.4 },
+  { label: '문답 원문', share: 2.1 / 9.4 },
+  { label: '채점 근거 (evidence)', share: 1.6 / 9.4 },
+  { label: '리포트 · 내보내기 PDF', share: 0.9 / 9.4 },
+] as const
+
+const MODEL_SHARE = [
+  {
+    purpose: '채점',
+    tierLabel: '플랫폼 고정',
+    model: 'claude-opus-5',
+    costShare: 286 / 412,
+    callShare: 3120 / 5080,
+    inputShare: 18_400_000 / 29_700_000,
+    outputShare: 2_100_000 / 6_100_000,
+  },
+  {
+    purpose: '질문 생성',
+    tierLabel: '균형 티어',
+    model: 'claude-sonnet-5',
+    costShare: 104 / 412,
+    callShare: 1540 / 5080,
+    inputShare: 9_200_000 / 29_700_000,
+    outputShare: 3_400_000 / 6_100_000,
+  },
+  {
+    purpose: '요약',
+    tierLabel: '비용 우선 티어',
+    model: 'claude-haiku-4-5',
+    costShare: 22 / 412,
+    callShare: 420 / 5080,
+    inputShare: 2_100_000 / 29_700_000,
+    outputShare: 600_000 / 6_100_000,
+  },
+] as const
+
+/** 손으로 안 채운 기관의 사용량 — org-1 비중을 이 기관의 규모로 스케일한다.
+ * 비용 합계는 마지막 행에 나머지를 몰아서 org.monthlyAiCostUsd와 정확히
+ * 맞춘다(표 합계 행과 상단 요약 숫자가 반올림 때문에 어긋나면 안 된다). */
+function fallbackUsage(org: Org): OrgUsage {
+  const storageGb = Math.round(org.traineeCount * 0.0635 * 10) / 10
+  const storageBreakdown: StorageBreakdownRow[] =
+    storageGb > 0
+      ? STORAGE_SHARE.map((row) => ({
+          label: row.label,
+          gb: Math.round(storageGb * row.share * 10) / 10,
+        }))
+      : []
+
+  const totalCalls = org.monthlyAiCostUsd * (5080 / 412)
+  const totalInputTokens = org.monthlyAiCostUsd * (29_700_000 / 412)
+  const totalOutputTokens = org.monthlyAiCostUsd * (6_100_000 / 412)
+  let costRemaining = org.monthlyAiCostUsd
+  const models: ModelUsageRow[] =
+    org.monthlyAiCostUsd > 0
+      ? MODEL_SHARE.map((row, i) => {
+          const isLast = i === MODEL_SHARE.length - 1
+          const costUsd = isLast ? costRemaining : Math.round(org.monthlyAiCostUsd * row.costShare)
+          costRemaining -= costUsd
+          return {
+            purpose: row.purpose,
+            tierLabel: row.tierLabel,
+            model: row.model,
+            calls: Math.round(totalCalls * row.callShare),
+            inputTokens: Math.round(totalInputTokens * row.inputShare),
+            outputTokens: Math.round(totalOutputTokens * row.outputShare),
+            costUsd,
+          }
+        })
+      : []
+
+  return {
+    storageBreakdown,
+    totalStorageGb: storageGb,
+    activeTrainees: Math.round(org.traineeCount * 0.04),
+    completedSessions: org.traineeCount * 2,
+    gradingRounds: org.traineeCount * 6,
+    publishedReports: Math.round(org.traineeCount * 0.3),
+    monthBudgetUsd: getOrCreateDetail(org.id).settings.budgetUsd,
+    costDeltaPct: org.monthlyAiCostUsd > 0 ? 12 : 0,
+    models,
+  }
+}
+
+/** 이 기관은 사용량 조회가 **항상** 실패한다(#usagefail 고정 데모 — 위 파일
+ * 머리말 참고). 재조회를 눌러도 다시 실패해야 "이 영역만 막힌다"(§6)가 매번
+ * 같은 모습으로 재현된다. */
+const USAGE_ALWAYS_FAIL_ORG_ID = 'org-3'
+
+// ───────────────────────── 사용량 · 기간 ─────────────────────────
+
+/*
+  와이어프레임(#page-usage `.filter`)에 "기간 ▾" 셀렉트가 있지만 구현이 빠져
+  있었다. 무엇을 단위로 나눌지 판단: 이 화면의 1급 지표("이번 달 AI 비용")와
+  설정 탭의 "AI 월 예산 상한"이 전부 **달** 단위 계약값이고, 정의서 §4 데이터
+  목록도 "모델별 호출·토큰·단가 · 월 추이"라고 못 박아 월 단위임을 명시한다 —
+  그래서 기간 옵션도 "지난 3개월"류 합계 구간이 아니라 **개별 달**로 나눈다(합계
+  구간을 넣으면 "호출 수" 같은 개별 지표의 의미가 "그 달"에서 "그 구간 합"으로
+  바뀌어 표 헤더까지 다시 정의해야 한다).
+
+  과거 달의 실측값이 없는 mock이라, 이 기관의 월간 성장률(costDeltaPct = "전월
+  대비 +N%")이 매달 일정했다고 가정하고 되감는다. 부트캠프가 성장하는 동안은
+  교육생·저장량·세션·비용이 같이 늘어나는 게 자연스러운 상관관계라, 필드마다
+  다른 임의의 과거 숫자를 지어내는 것보다 이 방식이 근거가 있다.
+*/
+export type UsagePeriod = 'CURRENT' | 'LAST_MONTH' | 'TWO_MONTHS_AGO'
+
+export const USAGE_PERIOD_OPTIONS: { value: UsagePeriod; label: string }[] = [
+  { value: 'CURRENT', label: '이번 달' },
+  { value: 'LAST_MONTH', label: '지난 달' },
+  { value: 'TWO_MONTHS_AGO', label: '2개월 전' },
+]
+
+const USAGE_PERIOD_STEPS_BACK: Record<UsagePeriod, number> = {
+  CURRENT: 0,
+  LAST_MONTH: 1,
+  TWO_MONTHS_AGO: 2,
+}
+
+function scaleUsageForPeriod(usage: OrgUsage, period: UsagePeriod): OrgUsage {
+  const stepsBack = USAGE_PERIOD_STEPS_BACK[period]
+  if (stepsBack === 0) return usage
+  // 등락이 0%거나 음수면(성장률 데이터가 없거나 이미 줄고 있는 기관) 억지로
+  // 되감지 않는다 — 나눗셈이 오히려 과거를 더 크게 만들거나 발산한다.
+  const growth = 1 + usage.costDeltaPct / 100
+  const factor = growth > 0 ? growth ** -stepsBack : 1
+  const scaleInt = (n: number) => Math.round(n * factor)
+  const scale1 = (n: number) => Math.round(n * factor * 10) / 10
+  return {
+    storageBreakdown: usage.storageBreakdown.map((row) => ({ ...row, gb: scale1(row.gb) })),
+    totalStorageGb: scale1(usage.totalStorageGb),
+    activeTrainees: scaleInt(usage.activeTrainees),
+    completedSessions: scaleInt(usage.completedSessions),
+    gradingRounds: scaleInt(usage.gradingRounds),
+    publishedReports: scaleInt(usage.publishedReports),
+    monthBudgetUsd: usage.monthBudgetUsd, // 예산 한도는 계약값 — 시점과 무관하게 그대로
+    costDeltaPct: usage.costDeltaPct,
+    models: usage.models.map((m) => ({
+      ...m,
+      calls: scaleInt(m.calls),
+      inputTokens: scaleInt(m.inputTokens),
+      outputTokens: scaleInt(m.outputTokens),
+      costUsd: scaleInt(m.costUsd),
+    })),
+  }
+}
+
+/** GET /admin/orgs/{id}/usage?period= — 케이스 6. 실패해도 기관 정보·다른 탭은
+ * 그대로다(§6 "이 영역만 막는다") — 그래서 이 함수는 화면 전체가 아니라
+ * 사용량 탭 컴포넌트 하나만 감싼다. */
+export function getOrgUsage(orgId: string, period: UsagePeriod = 'CURRENT'): Promise<OrgUsage> {
+  // ===== Mock 버전 (현재 활성) =====
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      if (orgId === USAGE_ALWAYS_FAIL_ORG_ID) {
+        reject({ code: 'USAGE_UNAVAILABLE' } satisfies UsageApiError)
+        return
+      }
+      const org = ORGS.find((o) => o.id === orgId)
+      const current = USAGE_BY_ORG[orgId] ?? fallbackUsage(org!)
+      resolve(scaleUsageForPeriod(current, period))
+    }, 500)
+  })
+
+  // ===== 실제 백엔드 버전 =====
+  // const res = await fetch(`/admin/orgs/${orgId}/usage?period=${period}`)
+  // if (!res.ok) return Promise.reject(await res.json()) // { code: 'USAGE_UNAVAILABLE' }
+  // return res.json()
+}
+
+// ───────────────────────── 개요 탭 지표 ─────────────────────────
+
+/** 개요 탭의 지표 카드는 항상 즉시 그려진다 — getOrgUsage()(사용량 탭, 실패 가능)와
+ * 의도적으로 분리한다(§6 "이 영역만 막는다"의 반대편: 개요는 사용량 집계 실패에
+ * 물들면 안 된다). USAGE_BY_ORG에 손으로 채운 값이 있으면 그 값을 쓰고(org-1은
+ * 이 값이 사용량 탭과 일치해야 한다), 없으면 fallbackUsage와 같은 파생식을 쓴다. */
+export function getOverviewSnapshot(org: Org): {
+  storageGb: number
+  /** null = 전월 대비를 말할 수 없는 경우(저장량 0·정지 기관) */
+  storageDeltaPct: number | null
+  activeSessions: number
+  budgetUsd: number
+  budgetPct: number
+} {
+  const settings = getOrCreateDetail(org.id).settings
+  const usage = USAGE_BY_ORG[org.id]
+  const storageGb = usage ? usage.totalStorageGb : Math.round(org.traineeCount * 0.0635 * 10) / 10
+  const activeSessions = usage
+    ? Math.round(usage.activeTrainees * 0.04)
+    : Math.round(org.traineeCount * 0.04)
+  const budgetPct =
+    settings.budgetUsd > 0 ? Math.round((org.monthlyAiCostUsd / settings.budgetUsd) * 100) : 0
+  // 저장량 증가율 — 실측 과거 데이터가 없는 mock이라 org-1의 실측값(+8%, 와이어
+  // #page-overview)을 "활성 기관은 매달 이만큼씩 쌓인다"는 공통 가정으로 쓴다
+  // (usage 탭 fallbackUsage의 costDeltaPct=12%와 같은 방식 — 저장량은 AI 비용과
+  // 다른 지표라 값도 다르다). 저장량이 0(오퍼레이터 미배정이라 아직 아무것도 안
+  // 쌓인 기관)이거나 기관이 정지 상태(로그인이 막혀 있어 새 데이터가 안 쌓인다)면
+  // "전월 대비"를 말할 근거가 없어 null로 둔다.
+  const storageDeltaPct = org.status === 'ACTIVE' && storageGb > 0 ? 8 : null
+  return {
+    storageGb,
+    storageDeltaPct,
+    activeSessions,
+    budgetUsd: settings.budgetUsd,
+    budgetPct,
+  }
+}
+
+// ───────────────────────── 설정 · 삭제 ─────────────────────────
+
+/** PATCH /admin/orgs/{id}/settings */
+export function updateOrgSettings(orgId: string, patch: Partial<OrgSettings>): OrgSettings {
+  const detail = getOrCreateDetail(orgId)
+  detail.settings = { ...detail.settings, ...patch }
+  return detail.settings
+}
+
+/** PATCH /admin/orgs/{id} — 기관 상태(활성/정지). 소속 전원 로그인 차단, 데이터는
+ * 보존(§6) — 삭제(soft-delete)와는 다른 축이라 org.deletion을 건드리지 않는다. */
+export function updateOrgStatus(orgId: string, status: OrgStatus): void {
+  const org = ORGS.find((o) => o.id === orgId)
+  if (org) org.status = status
+}
+
+/** DELETE /admin/orgs/{id} — 케이스 7. 즉시 파기가 아니라 soft-delete + 보존기간이다
+ * (§7 "기관 삭제 — 즉시 파기가 아니다"). purgeAt은 지금 설정된 retentionDays 기준. */
+export function requestOrgDeletion(orgId: string): OrgDeletion {
+  const org = ORGS.find((o) => o.id === orgId)
+  if (!org) throw new Error('org not found')
+  const detail = getOrCreateDetail(orgId)
+  const requestedAt = new Date().toISOString().slice(0, 10)
+  const purge = new Date()
+  purge.setDate(purge.getDate() + detail.settings.retentionDays)
+  const deletion: OrgDeletion = { requestedAt, purgeAt: purge.toISOString().slice(0, 10) }
+  org.deletion = deletion
+  return deletion
+}
+
+/** 보존기간 안에는 복구할 수 있다(§7) — 파기 후 복구 경로는 없다(케이스8은 화면
+ * 자체가 없음, 정의서 §6 "그림 없음"). */
+export function cancelOrgDeletion(orgId: string): void {
+  const org = ORGS.find((o) => o.id === orgId)
+  if (org) org.deletion = undefined
 }


### PR DESCRIPTION
## 작업 내용

기관 상세 화면(개요·오퍼레이터·사용량 · 비용·설정 4탭) 신규 구현.
정의서(SA-02-org-detail.md)·와이어프레임(superadmin/console.html#page-overview
이하)만 보고 짰다(v1 원본 없음, SA-01과 같은 사정).

* 개요 — 지표 4카드 + 기관 메타 + 기수 표(읽기전용) + 오퍼레이터 0명 경고 배너
* 오퍼레이터 — 계정 표(활성/초대됨/메일발송실패/정지) + 초대 모달(이메일 형식·중복·
  도메인 밖 검증) + 재발송/취소/정지/재활성 + 마지막 오퍼레이터 정지 차단(LAST_OPERATOR)
* 사용량 · 비용 — 저장량 구성 + 사용 규모 + 모델별 비용 표, 집계 실패
  (USAGE_UNAVAILABLE) 시 이 영역만 막고 재조회, 기간(이번 달/지난 달/2개월 전) 선택
* 설정 — 기관 상태·AI 예산·토큰 한도·보존기간·공개범위 기본값·기능 토글 3종 + 위험존
  기관 삭제(기관명 입력 확인, soft-delete + 보존기간)
* mockData.ts에 SA-02 데이터 모델·mock API 전체 추가(기수/오퍼레이터/사용량/설정/삭제)
* OrgListScreen 상태 배지 판정을 mockData.orgStatusBadge로 통합(SA-01·SA-02가 같은
  우선순위를 공유하도록)
* (부수) OrgMetrics.tsx 예산 진행바 트랙 색 대비 개선 — 같은 브랜치에서 발견한 작은
  버그라 별도 커밋으로만 분리하고 이 PR에 같이 실었다

## 리뷰 포인트

* mockData.ts가 크다(SA-02 섹션 전체) — 실 백엔드 연동 시 걷어낼 자리는 각 함수의
  `// ===== Mock 버전 =====` / `// ===== 실제 백엔드 버전 =====` 블록으로 이미 표시해 둠
* LAST_OPERATOR 차단 로직(`suspendOperator`) — 초대중(INVITED) 인원은 활성 인원 수에
  안 센다는 판단이 맞는지(주석에 근거 적어둠)
* 사용량 탭 "기간" 선택 — 과거 달 실측치가 없어 매달 성장률(costDeltaPct)을 그대로
  되감아 파생시켰다(mockData.ts "사용량 · 기간" 섹션 주석)
* `Org.operators`(SA-01 목록용)와 `OrgDetail.operators`(SA-02 상세용) 동기화
  (`syncOrgOperatorNames`) — 두 저장소를 나눈 판단이 맞는지

## 완료 조건

* [x] tsc -b · vite build · oxlint(0 errors) · prettier · doc:design · doc:components ·
  check:design 전부 통과
* [x] npm run dev로 4탭 렌더·액션(초대/정지/재발송/삭제/기간 선택) 확인
* [x] 기존 기능(SA-01 목록)에 문제 없음 확인

closes #71