### PR TITLE
[Feat] Add SA-03 Platform Settings Screen

### DIFF
--- a/src/features/superadmin/settings/PlatformSettingsScreen.tsx
+++ b/src/features/superadmin/settings/PlatformSettingsScreen.tsx
@@ -1,11 +1,45 @@
+import { useState } from 'react'
 import ConsoleShell from '@/shells/ConsoleShell'
-import PlaceholderScreen from '@/app/PlaceholderScreen'
+import PageHeader from '@/components/common/PageHeader'
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/Tabs'
+import { getPlatformSettings } from './mockData'
+import ModelPricingTab from './components/ModelPricingTab'
+import SuperadminAccountsTab from './components/SuperadminAccountsTab'
 
-/** SA-03 플랫폼 설정 — 화면 이식 전 자리표시. 실제 화면이 들어오면 이 파일 내용만 바뀐다. */
+/*
+  SA-03 플랫폼 설정 — 탭 2(모델·단가 · 슈퍼어드민 계정). 정의서
+  (SA-03-platform-settings.md) · 와이어프레임(superadmin/console.html#page-model
+  이하)만 보고 새로 짰다(v1 원본 없음, SA-01·SA-02와 같은 사정). 진입점은 네비가
+  아니라 Header.tsx 우상단 톱니다(정의서 §2 "화면이라기보다 설정 항목").
+
+  탭들이 mockData.ts를 직접 mutate하는 mock API를 쓰기 때문에, SA-02
+  OrgDetailScreen과 같은 패턴으로 React state 대신 "다시 읽어오기"로 반영한다.
+*/
+
 export default function PlatformSettingsScreen() {
+  const [snapshot, setSnapshot] = useState(() => getPlatformSettings())
+
+  function refresh() {
+    setSnapshot(getPlatformSettings())
+  }
+
   return (
     <ConsoleShell role="superadmin">
-      <PlaceholderScreen code="SA-03" title="플랫폼 설정" />
+      <PageHeader title="플랫폼 설정" />
+
+      <Tabs defaultValue="model">
+        <TabsList className="mb-4">
+          <TabsTrigger value="model">모델 · 단가</TabsTrigger>
+          <TabsTrigger value="accounts">슈퍼어드민 계정</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="model">
+          <ModelPricingTab snapshot={snapshot} onChange={refresh} />
+        </TabsContent>
+        <TabsContent value="accounts">
+          <SuperadminAccountsTab accounts={snapshot.accounts} onChange={refresh} />
+        </TabsContent>
+      </Tabs>
     </ConsoleShell>
   )
 }

--- a/src/features/superadmin/settings/components/ModelChangeDialog.tsx
+++ b/src/features/superadmin/settings/components/ModelChangeDialog.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useState } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/Dialog'
+import { Field, FieldLabel } from '@/components/ui/Field'
+import { Alert, AlertTitle, AlertDescription } from '@/components/ui/Alert'
+import { Button } from '@/components/ui/Button'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/Select'
+import { AVAILABLE_MODELS, changeGradingModel, type ModelId } from '../mockData'
+
+/*
+  SA-03 §6 "채점 모델 변경은 되돌릴 수 없다고 먼저 말한다" — 와이어 #modelchange.
+  확정 전에 전 기관 재캘리브레이션 경고를 빨간 Alert(§3 규약 그대로, OperatorsTab의
+  마지막 오퍼레이터 차단 모달과 같은 `.warnbox` 구조 재사용)로 보여주고, 확정 버튼도
+  danger로 눌러야 실제 위험을 담는다.
+*/
+
+export default function ModelChangeDialog({
+  open,
+  onOpenChange,
+  currentModel,
+  orgCount,
+  onChanged,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  currentModel: ModelId
+  orgCount: number
+  onChanged: () => void
+}) {
+  const [model, setModel] = useState<ModelId>(currentModel)
+  const [submitting, setSubmitting] = useState(false)
+
+  useEffect(() => {
+    if (open) setModel(currentModel)
+  }, [open, currentModel])
+
+  const canSubmit = model !== currentModel && !submitting
+
+  function handleConfirm() {
+    if (!canSubmit) return
+    setSubmitting(true)
+    try {
+      changeGradingModel(model)
+      onChanged()
+      onOpenChange(false)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>채점 모델 변경</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4">
+          <Field>
+            <FieldLabel htmlFor="grading-model-select">모델</FieldLabel>
+            <Select
+              value={model}
+              onValueChange={(v) => setModel((v as ModelId) ?? currentModel)}
+              items={Object.fromEntries(AVAILABLE_MODELS.map((m) => [m, m]))}
+            >
+              <SelectTrigger
+                id="grading-model-select"
+                className="w-full font-mono text-xs"
+                aria-label="채점 모델"
+              >
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {AVAILABLE_MODELS.map((m) => (
+                  <SelectItem key={m} value={m} className="font-mono text-xs">
+                    {m}
+                    {m === currentModel && ' (현재)'}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </Field>
+
+          <div className="flex flex-col gap-2">
+            <Alert variant="danger">
+              <AlertTitle>{orgCount}개 기관 전체가 재캘리브레이션 대기 상태가 됩니다</AlertTitle>
+              <AlertDescription>
+                끝나기 전까지 이전 버전으로 채점된 결과와는 비교할 수 없습니다.
+              </AlertDescription>
+            </Alert>
+            <p className="text-fg-subtle text-xs">진행 중인 세션은 기존 모델로 끝까지 채점됩니다</p>
+          </div>
+        </div>
+
+        <DialogFooter className="-mx-4 -mb-4 mt-0">
+          <Button
+            type="button"
+            variant="ghost"
+            disabled={submitting}
+            onClick={() => onOpenChange(false)}
+          >
+            취소
+          </Button>
+          <Button type="button" variant="danger" disabled={!canSubmit} onClick={handleConfirm}>
+            변경하고 재캘리브레이션 시작
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/features/superadmin/settings/components/ModelPricingTab.tsx
+++ b/src/features/superadmin/settings/components/ModelPricingTab.tsx
@@ -1,0 +1,231 @@
+import { useState, type ReactNode } from 'react'
+import { TriangleAlertIcon } from 'lucide-react'
+import { Badge } from '@/components/ui/Badge'
+import { Button } from '@/components/ui/Button'
+import { Alert, AlertTitle, AlertDescription } from '@/components/ui/Alert'
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from '@/components/ui/Table'
+import {
+  getPlatformSettings,
+  getUnpricedModelsInUse,
+  type ModelId,
+  type ModelPricing,
+  type TierMapping,
+} from '../mockData'
+import ModelChangeDialog from './ModelChangeDialog'
+import TierModelDialog from './TierModelDialog'
+import PricingDialog from './PricingDialog'
+
+/*
+  SA-03 §3 "모델 · 단가" 탭. 와이어 #page-model의 `.setrow`(채점 모델·캘리브레이션
+  버전)는 SA-02 SettingsTab의 SettingRow와 같은 모양이라 그 패턴을 그대로 옮겼다
+  (좌: 제목+설명, 우: 컨트롤, 구분선). 티어 매핑·단가는 표 형태라 OperatorsTab의
+  bare Table 관례를 따른다.
+*/
+
+function SettingRow({
+  title,
+  description,
+  badge,
+  children,
+}: {
+  title: string
+  description: string
+  badge?: string
+  children: ReactNode
+}) {
+  return (
+    <div className="flex items-center justify-between gap-6 border-b border-border py-4 last:border-0">
+      <div>
+        <p className="flex items-center gap-1.5 text-sm font-bold">
+          {title}
+          {badge && (
+            <Badge variant="info" className="text-[10px]">
+              {badge}
+            </Badge>
+          )}
+        </p>
+        <p className="text-fg-subtle mt-0.5 text-xs">{description}</p>
+      </div>
+      <div className="shrink-0">{children}</div>
+    </div>
+  )
+}
+
+type Snapshot = ReturnType<typeof getPlatformSettings>
+
+export default function ModelPricingTab({
+  snapshot,
+  onChange,
+}: {
+  snapshot: Snapshot
+  onChange: () => void
+}) {
+  const [modelChangeOpen, setModelChangeOpen] = useState(false)
+  const [tierDialogTarget, setTierDialogTarget] = useState<TierMapping | null>(null)
+  const [pricingDialogTarget, setPricingDialogTarget] = useState<ModelId | null>(null)
+
+  const { gradingModel, tierMappings, pricing, orgCountSnapshot } = snapshot
+  const unpriced = getUnpricedModelsInUse()
+  const pricedModels = Object.keys(pricing) as ModelId[]
+  // 단가 표에 보여줄 모델 — 이미 단가가 있는 것 + 지금 실제로 쓰이는데 아직 없는 것
+  // (예: 채점 모델을 opus-6으로 바꾼 직후). 순서는 채점 모델·티어 매핑에 쓰이는
+  // 순서를 앞에 두고 나머지를 뒤에 붙인다.
+  const inUseOrder: ModelId[] = [gradingModel.model, ...tierMappings.map((t) => t.model)]
+  const rowModels = [...new Set([...inUseOrder, ...pricedModels])]
+
+  return (
+    <div className="flex flex-col gap-4">
+      {unpriced.length > 0 && (
+        <Alert variant="warning">
+          <TriangleAlertIcon />
+          <AlertTitle>
+            <span className="font-mono">{unpriced.join(', ')}</span> 단가가 입력되지 않았습니다
+          </AlertTitle>
+          <AlertDescription>
+            이 모델이 쓰인 만큼은 비용 화면에서 단가 미설정으로 표시되고 금액에 합산되지 않습니다.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <div className="rounded-md border border-border bg-surface px-4">
+        <SettingRow
+          title="채점 모델"
+          description="기관이 바꿀 수 없다. 바뀌면 전 기관 재캘리브레이션이 필요합니다"
+          badge="전 기관 공통"
+        >
+          <div className="flex items-center gap-3">
+            <span className="font-mono text-xs">{gradingModel.model}</span>
+            <Button variant="ghost" size="sm" onClick={() => setModelChangeOpen(true)}>
+              변경
+            </Button>
+          </div>
+        </SettingRow>
+
+        <SettingRow
+          title="캘리브레이션 버전"
+          description={`${gradingModel.appliedAt} 적용 · 이후 모든 채점 결과에 이 버전이 붙는다.`}
+        >
+          <span className="font-mono text-xs">{gradingModel.calibrationVersion}</span>
+        </SettingRow>
+      </div>
+
+      <div>
+        <p className="text-fg-subtle mb-2 text-xs font-semibold">
+          티어 매핑 <span className="text-fg-subtle font-normal">· 질문 생성 · 요약</span>
+        </p>
+        <Table>
+          <TableHeader>
+            <TableRow className="hover:bg-transparent">
+              <TableHead className="w-32">티어</TableHead>
+              <TableHead className="w-48">모델</TableHead>
+              <TableHead>쓰이는 곳</TableHead>
+              <TableHead className="w-20" />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {tierMappings.map((t) => (
+              <TableRow key={t.tier}>
+                <TableCell className="font-bold">{t.label}</TableCell>
+                <TableCell className="font-mono text-xs">{t.model}</TableCell>
+                <TableCell className="text-fg-muted text-xs">{t.usedFor}</TableCell>
+                <TableCell>
+                  <button
+                    type="button"
+                    onClick={() => setTierDialogTarget(t)}
+                    className="text-primary text-xs font-semibold hover:underline"
+                  >
+                    변경
+                  </button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      <div>
+        <p className="text-fg-subtle mb-0.5 text-xs font-semibold">
+          단가 <span className="text-fg-subtle font-normal">· 100만 토큰당</span>
+        </p>
+        <p className="text-fg-subtle mb-2 text-xs">
+          미설정으로 되돌리려면 입력·출력에 0을 입력하세요.
+        </p>
+        <Table>
+          <TableHeader>
+            <TableRow className="hover:bg-transparent">
+              <TableHead className="w-40">모델</TableHead>
+              <TableHead className="w-28">입력</TableHead>
+              <TableHead className="w-28">출력</TableHead>
+              <TableHead className="w-28">적용일</TableHead>
+              <TableHead className="w-20" />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rowModels.map((m) => {
+              const row: ModelPricing | undefined = pricing[m]
+              return (
+                <TableRow key={m} className={!row ? 'bg-warning-soft' : undefined}>
+                  <TableCell className="font-mono text-xs">{m}</TableCell>
+                  <TableCell className="text-xs">
+                    {row ? (
+                      `$${row.inputUsdPerM.toFixed(2)}`
+                    ) : (
+                      <span className="text-warning font-semibold">미설정</span>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-xs">
+                    {row ? (
+                      `$${row.outputUsdPerM.toFixed(2)}`
+                    ) : (
+                      <span className="text-warning font-semibold">미설정</span>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-fg-muted text-xs">{row?.appliedAt ?? '—'}</TableCell>
+                  <TableCell>
+                    <button
+                      type="button"
+                      onClick={() => setPricingDialogTarget(m)}
+                      className="text-primary text-xs font-semibold hover:underline"
+                    >
+                      {row ? '수정' : '입력'}
+                    </button>
+                  </TableCell>
+                </TableRow>
+              )
+            })}
+          </TableBody>
+        </Table>
+      </div>
+
+      <ModelChangeDialog
+        open={modelChangeOpen}
+        onOpenChange={setModelChangeOpen}
+        currentModel={gradingModel.model}
+        orgCount={orgCountSnapshot}
+        onChanged={onChange}
+      />
+
+      <TierModelDialog
+        open={tierDialogTarget !== null}
+        onOpenChange={(v) => !v && setTierDialogTarget(null)}
+        tierMapping={tierDialogTarget}
+        onChanged={onChange}
+      />
+
+      <PricingDialog
+        open={pricingDialogTarget !== null}
+        onOpenChange={(v) => !v && setPricingDialogTarget(null)}
+        model={pricingDialogTarget}
+        current={pricingDialogTarget ? pricing[pricingDialogTarget] : undefined}
+        onChanged={onChange}
+      />
+    </div>
+  )
+}

--- a/src/features/superadmin/settings/components/PricingDialog.tsx
+++ b/src/features/superadmin/settings/components/PricingDialog.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useState } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/Dialog'
+import { Field, FieldLabel, FieldDescription } from '@/components/ui/Field'
+import { Input } from '@/components/ui/Input'
+import { Button } from '@/components/ui/Button'
+import { updatePricing, type ModelId, type ModelPricing } from '../mockData'
+
+/*
+  SA-03 §5 "단가 수정" — 매핑 변경과 달리 확인 모달이 명시돼 있지 않다(정의서 §5
+  목록에 "매핑 변경(확인 모달)"만 괄호가 붙어 있고 단가 수정엔 없다). 그래서 이
+  다이얼로그는 확인 문구 없이 바로 입력·저장한다.
+
+  100만 토큰당 달러 단위(와이어 "· 100만 토큰당") — 소수점 둘째 자리까지 받는다.
+
+  0·0 = 미설정 — 두 값을 다 0으로 저장하면 mockData.updatePricing이 이 모델의
+  단가 항목 자체를 지운다(§6 "0으로 계산하지 않는다"). 값을 막지 않고 되돌리는
+  쪽으로 둔 이유: 입력을 막으면 "이미 있는 단가를 미설정으로 되돌리고 싶을 때"
+  취소 말고는 방법이 없다 — 0을 그 의도의 입력으로 받아주는 편이 자연스럽다.
+*/
+
+export default function PricingDialog({
+  open,
+  onOpenChange,
+  model,
+  current,
+  onChanged,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  model: ModelId | null
+  current: ModelPricing | undefined
+  onChanged: () => void
+}) {
+  const [inputUsd, setInputUsd] = useState('')
+  const [outputUsd, setOutputUsd] = useState('')
+  const [touched, setTouched] = useState(false)
+
+  useEffect(() => {
+    if (open) {
+      setInputUsd(current ? String(current.inputUsdPerM) : '')
+      setOutputUsd(current ? String(current.outputUsdPerM) : '')
+      setTouched(false)
+    }
+  }, [open, current])
+
+  if (!model) return null
+
+  const inputNum = Number(inputUsd)
+  const outputNum = Number(outputUsd)
+  const inputValid = inputUsd.trim() !== '' && Number.isFinite(inputNum) && inputNum >= 0
+  const outputValid = outputUsd.trim() !== '' && Number.isFinite(outputNum) && outputNum >= 0
+  const canAttemptSubmit = inputUsd.trim() !== '' && outputUsd.trim() !== ''
+  const canSubmit = canAttemptSubmit && inputValid && outputValid
+  const willClear = canSubmit && inputNum === 0 && outputNum === 0
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setTouched(true)
+    if (!model || !canSubmit) return
+    updatePricing(model, inputNum, outputNum)
+    onChanged()
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            단가 {current ? '수정' : '입력'} · {model}
+          </DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} noValidate className="flex flex-col gap-4">
+          <p className="text-fg-subtle text-xs">
+            미설정으로 되돌리려면 입력·출력 둘 다 0을 입력하세요.
+          </p>
+
+          <Field data-invalid={touched && !inputValid}>
+            <FieldLabel htmlFor="price-input">입력 토큰 단가 (USD)</FieldLabel>
+            <Input
+              id="price-input"
+              inputMode="decimal"
+              value={inputUsd}
+              onChange={(e) => setInputUsd(e.target.value)}
+              placeholder="0.00"
+              aria-invalid={touched && !inputValid}
+            />
+            {touched && !inputValid ? (
+              <p className="text-danger text-xs font-medium">0 이상의 숫자를 입력하세요.</p>
+            ) : (
+              <FieldDescription>100만 토큰당</FieldDescription>
+            )}
+          </Field>
+
+          <Field data-invalid={touched && !outputValid}>
+            <FieldLabel htmlFor="price-output">출력 토큰 단가 (USD)</FieldLabel>
+            <Input
+              id="price-output"
+              inputMode="decimal"
+              value={outputUsd}
+              onChange={(e) => setOutputUsd(e.target.value)}
+              placeholder="0.00"
+              aria-invalid={touched && !outputValid}
+            />
+            {touched && !outputValid ? (
+              <p className="text-danger text-xs font-medium">0 이상의 숫자를 입력하세요.</p>
+            ) : (
+              <FieldDescription>100만 토큰당</FieldDescription>
+            )}
+          </Field>
+
+          {willClear && (
+            <p className="text-warning text-xs font-medium">
+              저장하면 이 모델은 단가 미설정으로 바뀝니다.
+            </p>
+          )}
+
+          <DialogFooter className="-mx-4 -mb-4 mt-0">
+            <Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
+              취소
+            </Button>
+            <Button type="submit" disabled={!canAttemptSubmit}>
+              {willClear ? '미설정으로 저장' : '저장'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/features/superadmin/settings/components/SuperadminAccountsTab.tsx
+++ b/src/features/superadmin/settings/components/SuperadminAccountsTab.tsx
@@ -1,0 +1,203 @@
+import { useState } from 'react'
+import { PlusIcon } from 'lucide-react'
+import { Badge } from '@/components/ui/Badge'
+import { Button } from '@/components/ui/Button'
+import { Alert, AlertTitle, AlertDescription } from '@/components/ui/Alert'
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from '@/components/ui/Table'
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+} from '@/components/ui/Pagination'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/Dialog'
+import { cancelSuperadminInvite, suspendSuperadmin, type SuperadminAccount } from '../mockData'
+import SuperadminInviteDialog from './SuperadminInviteDialog'
+
+/*
+  SA-03 §3 "슈퍼어드민 계정" — 목록 · 초대 · 정지(재활성 없음, mockData.ts 파일
+  머리말 판단 근거). 초대는 SA-02 오퍼레이터와 같이 INVITED로 시작해 실제 로그인
+  전까지 활성으로 치지 않는다(mockData.ts 판단 근거) — 그래서 액션도 상태별로
+  갈린다: ACTIVE는 정지, INVITED는 초대 취소(아직 아무도 아니라 "정지"가 성립하지
+  않는다), SUSPENDED는 없음. 표는 SA-02 OperatorsTab의 bare Table 관례를 따르고,
+  "마지막 슈퍼어드민 정지 차단"은 OperatorsTab의 LAST_OPERATOR 차단 모달과 같은
+  구조(Dialog + 빨간 Alert, AlertDialog가 아닌 이유도 동일 — 닫기 ✕가 있어야 한다)를
+  재사용한다. 와이어 #page-accounts의 하단 범위·페이지네이션도 그대로 둔다(SA-01
+  목록과 같은 1쪽 고정 표기 — 실제 다중 페이지 로직은 아직 없다).
+*/
+
+export default function SuperadminAccountsTab({
+  accounts,
+  onChange,
+}: {
+  accounts: SuperadminAccount[]
+  onChange: () => void
+}) {
+  const [inviteOpen, setInviteOpen] = useState(false)
+  const [blocked, setBlocked] = useState<SuperadminAccount | null>(null)
+
+  function handleSuspend(account: SuperadminAccount) {
+    const result = suspendSuperadmin(account.id)
+    if (!result.ok) {
+      setBlocked(account)
+      return
+    }
+    onChange()
+  }
+
+  function handleCancelInvite(account: SuperadminAccount) {
+    cancelSuperadminInvite(account.id)
+    onChange()
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <p className="text-fg-subtle text-xs font-semibold">
+          슈퍼어드민 계정 · {accounts.length}명
+        </p>
+        <Button onClick={() => setInviteOpen(true)}>
+          <PlusIcon /> 계정 초대
+        </Button>
+      </div>
+
+      <Table>
+        <TableHeader>
+          <TableRow className="hover:bg-transparent">
+            <TableHead className="w-40">이름</TableHead>
+            <TableHead className="w-52">이메일</TableHead>
+            <TableHead className="w-28">상태</TableHead>
+            <TableHead className="w-28">최근 로그인</TableHead>
+            <TableHead className="w-20" />
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {accounts.map((a) => {
+            const suspended = a.status === 'SUSPENDED'
+            const invited = a.status === 'INVITED'
+            return (
+              <TableRow key={a.id} className={suspended ? 'opacity-60' : undefined}>
+                <TableCell className={a.name ? 'font-bold' : 'text-fg-subtle font-normal'}>
+                  <span className="flex items-center gap-1.5">
+                    {a.name}
+                    {a.isSelf && (
+                      <Badge variant="neutral" className="text-[10px]">
+                        나
+                      </Badge>
+                    )}
+                  </span>
+                </TableCell>
+                <TableCell className="font-mono text-xs">{a.email}</TableCell>
+                <TableCell>
+                  {suspended ? (
+                    <Badge variant="neutral">정지</Badge>
+                  ) : invited ? (
+                    <Badge variant="warning">초대됨</Badge>
+                  ) : (
+                    <Badge variant="success">활성</Badge>
+                  )}
+                </TableCell>
+                <TableCell className="text-fg-muted text-xs">
+                  {a.lastLoginAt ?? (invited ? '대기 중' : '—')}
+                </TableCell>
+                <TableCell>
+                  {a.status === 'ACTIVE' && (
+                    <button
+                      type="button"
+                      onClick={() => handleSuspend(a)}
+                      className="text-danger text-xs font-semibold hover:underline"
+                    >
+                      정지
+                    </button>
+                  )}
+                  {invited && (
+                    <button
+                      type="button"
+                      onClick={() => handleCancelInvite(a)}
+                      className="text-danger text-xs font-semibold hover:underline"
+                    >
+                      초대 취소
+                    </button>
+                  )}
+                </TableCell>
+              </TableRow>
+            )
+          })}
+        </TableBody>
+      </Table>
+
+      <div className="grid grid-cols-3 items-center">
+        <p className="text-fg-subtle text-xs">{`1–${accounts.length} / ${accounts.length}개`}</p>
+        <div className="flex justify-center">
+          <Pagination className="mx-0 w-auto">
+            <PaginationContent>
+              <PaginationItem>
+                <PaginationLink isActive aria-label="1쪽">
+                  1
+                </PaginationLink>
+              </PaginationItem>
+            </PaginationContent>
+          </Pagination>
+        </div>
+        <div />
+      </div>
+
+      <SuperadminInviteDialog
+        open={inviteOpen}
+        onOpenChange={setInviteOpen}
+        onInvited={() => onChange()}
+      />
+
+      {/* 마지막 슈퍼어드민 정지 차단 — OperatorsTab의 LAST_OPERATOR 모달과 같은 구조.
+          닫기 ✕가 필요해 AlertDialog가 아니라 Dialog를 쓴다. */}
+      <Dialog open={blocked !== null} onOpenChange={(v) => !v && setBlocked(null)}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>정지할 수 없습니다</DialogTitle>
+          </DialogHeader>
+
+          <div className="flex flex-col gap-3">
+            <Alert variant="danger">
+              <AlertTitle>마지막 슈퍼어드민 계정입니다</AlertTitle>
+              <AlertDescription>
+                정지하면 플랫폼 콘솔에 들어갈 수 있는 사람이 아무도 없어집니다. 풀어 줄 상위 권한이
+                없어 되돌릴 방법도 없습니다.
+              </AlertDescription>
+            </Alert>
+            <p className="text-fg-subtle text-xs">
+              새 슈퍼어드민을 먼저 초대한 뒤에 정지할 수 있습니다
+            </p>
+          </div>
+
+          <DialogFooter className="-mx-4 -mb-4 mt-0">
+            <Button type="button" variant="ghost" onClick={() => setBlocked(null)}>
+              닫기
+            </Button>
+            <Button
+              type="button"
+              onClick={() => {
+                setBlocked(null)
+                setInviteOpen(true)
+              }}
+            >
+              계정 초대
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/src/features/superadmin/settings/components/SuperadminInviteDialog.tsx
+++ b/src/features/superadmin/settings/components/SuperadminInviteDialog.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useState } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/Dialog'
+import { Field, FieldLabel, FieldDescription } from '@/components/ui/Field'
+import { Input } from '@/components/ui/Input'
+import { Button } from '@/components/ui/Button'
+import {
+  inviteSuperadmin,
+  validateSuperadminInvite,
+  type SuperadminAccount,
+  type SuperadminInviteErrorCode,
+} from '../mockData'
+
+/*
+  SA-03 §3 "슈퍼어드민 계정" — 목록 · 초대 · 정지. 이메일만 받는 오퍼레이터 초대와
+  달리 이름도 함께 받는다(초대 즉시 활성 계정을 만들기 때문 — mockData.ts 파일
+  머리말 판단 근거). 검증 타이밍은 OperatorInviteDialog와 같은 패턴: 버튼은 항상
+  handleSubmit까지 도달하게 두고(disabled는 "누를 수 있는 상태"만 따짐), 제출
+  시점에 touched를 세워 에러를 보여준다.
+*/
+
+const ERROR_MESSAGE: Record<SuperadminInviteErrorCode, string> = {
+  NAME_REQUIRED: '이름을 입력하세요.',
+  INVALID_EMAIL: '올바른 이메일 형식이 아닙니다.',
+  ALREADY_EXISTS: '이미 등록된 이메일입니다.',
+}
+
+export default function SuperadminInviteDialog({
+  open,
+  onOpenChange,
+  onInvited,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onInvited: (account: SuperadminAccount) => void
+}) {
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const [touched, setTouched] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+
+  useEffect(() => {
+    if (open) {
+      setName('')
+      setEmail('')
+      setTouched(false)
+    }
+  }, [open])
+
+  const trimmedName = name.trim()
+  const trimmedEmail = email.trim()
+  const error =
+    trimmedName || trimmedEmail ? validateSuperadminInvite(trimmedName, trimmedEmail) : null
+  const canAttemptSubmit = trimmedName.length > 0 && trimmedEmail.length > 0 && !submitting
+  const canSubmit = canAttemptSubmit && error === null
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setTouched(true)
+    if (!canSubmit) return
+    setSubmitting(true)
+    try {
+      const account = inviteSuperadmin(trimmedName, trimmedEmail)
+      onInvited(account)
+      onOpenChange(false)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>슈퍼어드민 계정 초대</DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} noValidate className="flex flex-col gap-4">
+          <Field data-invalid={touched && error === 'NAME_REQUIRED'}>
+            <FieldLabel htmlFor="superadmin-name">이름</FieldLabel>
+            <Input
+              id="superadmin-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              onBlur={() => setTouched(true)}
+              disabled={submitting}
+              autoComplete="off"
+            />
+            {touched && error === 'NAME_REQUIRED' && (
+              <p className="text-danger text-xs font-medium">{ERROR_MESSAGE.NAME_REQUIRED}</p>
+            )}
+          </Field>
+
+          <Field
+            data-invalid={touched && (error === 'INVALID_EMAIL' || error === 'ALREADY_EXISTS')}
+          >
+            <FieldLabel htmlFor="superadmin-email">이메일</FieldLabel>
+            <Input
+              id="superadmin-email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              onBlur={() => setTouched(true)}
+              placeholder="example@iz-get.com"
+              disabled={submitting}
+              aria-invalid={touched && (error === 'INVALID_EMAIL' || error === 'ALREADY_EXISTS')}
+              autoComplete="off"
+            />
+            {touched && (error === 'INVALID_EMAIL' || error === 'ALREADY_EXISTS') ? (
+              <p className="text-danger text-xs font-medium">{ERROR_MESSAGE[error]}</p>
+            ) : (
+              <FieldDescription>플랫폼 콘솔에 로그인할 수 있는 계정입니다</FieldDescription>
+            )}
+          </Field>
+
+          <DialogFooter className="-mx-4 -mb-4 mt-0">
+            <Button
+              type="button"
+              variant="ghost"
+              disabled={submitting}
+              onClick={() => onOpenChange(false)}
+            >
+              취소
+            </Button>
+            <Button type="submit" disabled={!canAttemptSubmit}>
+              {submitting ? '초대하는 중…' : '계정 초대'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/features/superadmin/settings/components/TierModelDialog.tsx
+++ b/src/features/superadmin/settings/components/TierModelDialog.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useState } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/Dialog'
+import { Field, FieldLabel, FieldDescription } from '@/components/ui/Field'
+import { Button } from '@/components/ui/Button'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/Select'
+import { AVAILABLE_MODELS, updateTierMapping, type ModelId, type TierMapping } from '../mockData'
+
+/*
+  SA-03 §5 "매핑 변경(확인 모달)". 채점 모델 변경(ModelChangeDialog)과 달리
+  재캘리브레이션이 걸리지 않는다 — 질문 생성·요약 전용이라 채점 결과 비교와
+  무관하다(mockData.ts updateTierMapping 주석). 그래서 확인은 가볍게, 위험
+  경고 없이 "정말 바꿀지"만 확인한다.
+*/
+
+export default function TierModelDialog({
+  open,
+  onOpenChange,
+  tierMapping,
+  onChanged,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  tierMapping: TierMapping | null
+  onChanged: () => void
+}) {
+  const [model, setModel] = useState<ModelId>(tierMapping?.model ?? 'claude-opus-5')
+
+  useEffect(() => {
+    if (open && tierMapping) setModel(tierMapping.model)
+  }, [open, tierMapping])
+
+  if (!tierMapping) return null
+
+  const canSubmit = model !== tierMapping.model
+
+  function handleConfirm() {
+    if (!tierMapping || !canSubmit) return
+    updateTierMapping(tierMapping.tier, model)
+    onChanged()
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>티어 모델 변경 · {tierMapping.label}</DialogTitle>
+        </DialogHeader>
+
+        <Field>
+          <FieldLabel htmlFor="tier-model-select">모델</FieldLabel>
+          <Select
+            value={model}
+            onValueChange={(v) => setModel((v as ModelId) ?? tierMapping.model)}
+            items={Object.fromEntries(AVAILABLE_MODELS.map((m) => [m, m]))}
+          >
+            <SelectTrigger
+              id="tier-model-select"
+              className="w-full font-mono text-xs"
+              aria-label="모델"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {AVAILABLE_MODELS.map((m) => (
+                <SelectItem key={m} value={m} className="font-mono text-xs">
+                  {m}
+                  {m === tierMapping.model && ' (현재)'}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <FieldDescription>{tierMapping.usedFor}에 쓰입니다</FieldDescription>
+        </Field>
+
+        <DialogFooter className="-mx-4 -mb-4 mt-0">
+          <Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
+            취소
+          </Button>
+          <Button type="button" disabled={!canSubmit} onClick={handleConfirm}>
+            변경
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/features/superadmin/settings/mockData.ts
+++ b/src/features/superadmin/settings/mockData.ts
@@ -1,0 +1,292 @@
+/*
+  SA-03 플랫폼 설정 목업 데이터 + mock API. 정의서(SA-03-platform-settings.md) ·
+  와이어프레임(superadmin/console.html#page-model 이하 — model·modelchange·
+  nopricing·accounts·cases-sa03)만 보고 짰다(v1 원본 없음, SA-01·SA-02와 같은 사정).
+
+  API 격리는 orgs/mockData.ts와 같은 관례 — 모듈 스코프 저장소를 함수가 직접
+  mutate하고, 화면은 getPlatformSettings()로 "다시 읽어오기" 한다.
+
+  판단 근거(정의서·와이어프레임 밖에서 이 세션이 정한 것):
+
+  - **재캘리브레이션 경고 문구의 "N개 기관"** — 와이어 #modelchange가 "14개 기관"이라고
+    못 박아 뒀다. orgs 기능의 ORGS.length를 그대로 가져오면 두 기능(superadmin/orgs ·
+    superadmin/settings)이 서로 import하게 되는데, 지금 이 레포에 그런 교차참조 관례가
+    없어(각 기능 폴더가 자기 mockData만 쓴다) 새로 만들지 않는다. 대신 이 파일 안에
+    같은 숫자(14)를 상수로 박아둔다 — 실제 백엔드에서는 어차피 이 화면이 직접 조회할
+    값이라 mock 단계에서 두 파일을 묶을 이유가 약하다.
+  - **슈퍼어드민 계정 재활성 없음** — 정의서 §3·§5가 "목록 · 초대 · 정지" 셋만
+    명시한다(SA-02 오퍼레이터는 정지/재활성 둘 다 명시돼 있어 달랐다). 정지된 계정을
+    되돌리는 액션은 만들지 않는다 — 필요해지면 팀장님과 별도 판단.
+  - **계정 초대는 SA-02 오퍼레이터와 같이 INVITED로 시작한다** — 처음엔 케이스
+    계약(#cases-sa03)에 메일 실패·초대중 상태가 없다는 이유로 즉시 ACTIVE를
+    만들었는데, 다시 보니 두 가지가 안 맞았다: (1) "활성"인데 `lastLoginAt`이
+    없다(로그인한 적이 없다는 뜻)는 게 그 자체로 모순이고, (2) 슈퍼어드민은
+    플랫폼에서 가장 강한 권한이라(§6 "풀어 줄 상위 권한이 아예 없다") 본인이
+    실제로 로그인하기 전까지 활성으로 치면 안 된다 — 오퍼레이터보다 더 엄격해야
+    할 자리가 오히려 검증이 없는 건 앞뒤가 바뀌었다. INVITED는 오퍼레이터와
+    같은 이유로 "마지막 슈퍼어드민" 집계에서 빠진다(아직 로그인한 적 없는
+    계정은 커버로 치지 않는다).
+  - **단가 미입력 데모** — claude-opus-6을 "채점 모델 변경" 선택지에는 있지만 단가
+    표에는 없는 모델로 시드해 둔다. 실제로 채점 모델을 opus-6으로 바꾸면 그 즉시
+    단가 미입력 경고(#nopricing)가 뜬다 — 와이어가 #modelchange → #nopricing으로
+    이어지는 흐름과 같다.
+*/
+
+export type ModelId = 'claude-opus-5' | 'claude-opus-6' | 'claude-sonnet-5' | 'claude-haiku-4-5'
+
+/** 채점 모델 변경 시 고를 수 있는 후보. claude-opus-6은 아직 단가가 없다(위 주석) */
+export const AVAILABLE_MODELS: ModelId[] = [
+  'claude-opus-5',
+  'claude-opus-6',
+  'claude-sonnet-5',
+  'claude-haiku-4-5',
+]
+
+/** 재캘리브레이션 경고에 쓰는 기관 수 — 와이어 #modelchange 문구("14개 기관")와 맞춘
+ * 고정값이다(파일 머리말 판단 근거 참고). */
+const ORG_COUNT_SNAPSHOT = 14
+
+export interface GradingModelState {
+  model: ModelId
+  calibrationVersion: string
+  /** YYYY-MM-DD — 이 캘리브레이션 버전이 적용된 날 */
+  appliedAt: string
+}
+
+const GRADING_MODEL: GradingModelState = {
+  model: 'claude-opus-5',
+  calibrationVersion: 'cal-2026-04',
+  appliedAt: '2026-04-11',
+}
+
+export type Tier = 'ACCURACY' | 'BALANCED' | 'COST'
+
+export interface TierMapping {
+  tier: Tier
+  label: string
+  model: ModelId
+  /** "쓰이는 곳" 표시용 문구 */
+  usedFor: string
+}
+
+const TIER_MAPPINGS: Record<Tier, TierMapping> = {
+  ACCURACY: {
+    tier: 'ACCURACY',
+    label: '정확도 우선',
+    model: 'claude-opus-5',
+    usedFor: '질문 생성',
+  },
+  BALANCED: {
+    tier: 'BALANCED',
+    label: '균형',
+    model: 'claude-sonnet-5',
+    usedFor: '질문 생성 · 요약',
+  },
+  COST: {
+    tier: 'COST',
+    label: '비용 우선',
+    model: 'claude-haiku-4-5',
+    usedFor: '요약',
+  },
+}
+
+export const TIER_ORDER: Tier[] = ['ACCURACY', 'BALANCED', 'COST']
+
+export interface ModelPricing {
+  model: ModelId
+  inputUsdPerM: number
+  outputUsdPerM: number
+  /** YYYY-MM-DD */
+  appliedAt: string
+}
+
+/** undefined = 단가 미설정(§6 "0으로 계산하지 않는다") */
+const PRICING: Partial<Record<ModelId, ModelPricing>> = {
+  'claude-opus-5': {
+    model: 'claude-opus-5',
+    inputUsdPerM: 6.0,
+    outputUsdPerM: 30.0,
+    appliedAt: '2026-04-01',
+  },
+  'claude-sonnet-5': {
+    model: 'claude-sonnet-5',
+    inputUsdPerM: 3.2,
+    outputUsdPerM: 16.0,
+    appliedAt: '2026-04-01',
+  },
+  'claude-haiku-4-5': {
+    model: 'claude-haiku-4-5',
+    inputUsdPerM: 1.0,
+    outputUsdPerM: 5.0,
+    appliedAt: '2026-04-01',
+  },
+  // claude-opus-6: 아직 미설정 — #nopricing 데모
+}
+
+export type SuperadminStatus = 'ACTIVE' | 'INVITED' | 'SUSPENDED'
+
+export interface SuperadminAccount {
+  id: string
+  name: string
+  email: string
+  status: SuperadminStatus
+  /** "지금" 또는 YYYY-MM-DD, null = 로그인 기록 없음(INVITED 상태의 자연스러운 값) */
+  lastLoginAt: string | null
+  /** 지금 로그인한 계정 — 목록에 "나" 배지 */
+  isSelf?: boolean
+}
+
+const SUPERADMIN_ACCOUNTS: SuperadminAccount[] = [
+  {
+    id: 'sa-1',
+    name: '김운영',
+    email: 'kim@iz-get.com',
+    status: 'ACTIVE',
+    lastLoginAt: '지금',
+    isSelf: true,
+  },
+  {
+    id: 'sa-2',
+    name: '오세라',
+    email: 'sera@iz-get.com',
+    status: 'ACTIVE',
+    lastLoginAt: '2026-07-28',
+  },
+]
+
+function today(): string {
+  return new Date().toISOString().slice(0, 10)
+}
+
+/** GET /admin/settings — 화면이 매번 이 스냅샷을 다시 읽어 "다시 읽어오기" 패턴을
+ * 따른다(orgs/mockData.ts getOrgDetail과 같은 관례). */
+export function getPlatformSettings(): {
+  gradingModel: GradingModelState
+  tierMappings: TierMapping[]
+  pricing: Partial<Record<ModelId, ModelPricing>>
+  accounts: SuperadminAccount[]
+  orgCountSnapshot: number
+} {
+  return {
+    gradingModel: { ...GRADING_MODEL },
+    tierMappings: TIER_ORDER.map((t) => TIER_MAPPINGS[t]),
+    pricing: { ...PRICING },
+    accounts: [...SUPERADMIN_ACCOUNTS],
+    orgCountSnapshot: ORG_COUNT_SNAPSHOT,
+  }
+}
+
+// ───────────────────────── 채점 모델 · 캘리브레이션 ─────────────────────────
+
+/** PATCH /admin/settings/grading-model — 케이스 "채점 모델 변경"(#modelchange).
+ * 확인 모달(전 기관 재캘리브레이션 경고)은 화면이 맡는다 — 이 함수는 확정된 뒤에만
+ * 불린다. 캘리브레이션 버전은 오늘 날짜로 새로 발급한다. */
+export function changeGradingModel(model: ModelId): GradingModelState {
+  GRADING_MODEL.model = model
+  GRADING_MODEL.calibrationVersion = `cal-${today()}`
+  GRADING_MODEL.appliedAt = today()
+  return { ...GRADING_MODEL }
+}
+
+// ───────────────────────── 티어 매핑 ─────────────────────────
+
+/** PATCH /admin/settings/tiers/{tier} — §5 "매핑 변경(확인 모달)". 채점 모델과 달리
+ * 재캘리브레이션이 필요 없다(질문 생성·요약 전용, 채점 결과 비교와 무관) — 화면의
+ * 확인 모달은 "정말 바꿀지"만 묻는 가벼운 확인이다. */
+export function updateTierMapping(tier: Tier, model: ModelId): TierMapping {
+  TIER_MAPPINGS[tier] = { ...TIER_MAPPINGS[tier], model }
+  return { ...TIER_MAPPINGS[tier] }
+}
+
+// ───────────────────────── 단가 ─────────────────────────
+
+/** 지금 실제로 쓰이는 모델(채점 + 3티어) 중 단가가 없는 것 — 있으면 화면이 경고
+ * 배너(#nopricing)를 띄운다. §6 "단가 미입력을 0으로 계산하지 않는다". */
+export function getUnpricedModelsInUse(): ModelId[] {
+  const inUse = new Set<ModelId>([
+    GRADING_MODEL.model,
+    ...TIER_ORDER.map((t) => TIER_MAPPINGS[t].model),
+  ])
+  return [...inUse].filter((m) => !PRICING[m])
+}
+
+/** PUT /admin/settings/pricing/{model} — 단가 입력·수정. 0·0을 입력하면 "미설정"으로
+ * 되돌린다(둘 다 0일 때만 — 한쪽만 0이면 그 모델은 정말 그 방향만 무료라는 뜻일 수
+ * 있어 그대로 저장한다). 그래서 화면에 "0으로 계산되는 단가"가 남는 경우가 아예
+ * 없다 — 있으면 미설정이고, 없으면 실제 값이다(§6 "0으로 계산하지 않는다"). 서버
+ * 왕복이 필요 없는 로컬 상태 변경이라 동기로 둔다(orgs/mockData.ts의
+ * updateOrgSettings와 같은 결). */
+export function updatePricing(
+  model: ModelId,
+  inputUsdPerM: number,
+  outputUsdPerM: number,
+): ModelPricing | undefined {
+  if (inputUsdPerM === 0 && outputUsdPerM === 0) {
+    delete PRICING[model]
+    return undefined
+  }
+  const pricing: ModelPricing = { model, inputUsdPerM, outputUsdPerM, appliedAt: today() }
+  PRICING[model] = pricing
+  return pricing
+}
+
+// ───────────────────────── 슈퍼어드민 계정 ─────────────────────────
+
+export type SuperadminInviteErrorCode = 'INVALID_EMAIL' | 'ALREADY_EXISTS' | 'NAME_REQUIRED'
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+/** 제출 전 필드 검증 — 서버 왕복이 필요 없는 형식·중복 검사라 orgs의
+ * validateOperatorEmail과 같은 결로 동기로 둔다. */
+export function validateSuperadminInvite(
+  name: string,
+  email: string,
+): SuperadminInviteErrorCode | null {
+  if (!name.trim()) return 'NAME_REQUIRED'
+  const trimmed = email.trim()
+  if (!EMAIL_RE.test(trimmed)) return 'INVALID_EMAIL'
+  if (SUPERADMIN_ACCOUNTS.some((a) => a.email.toLowerCase() === trimmed.toLowerCase()))
+    return 'ALREADY_EXISTS'
+  return null
+}
+
+/** POST /admin/settings/accounts — 초대. SA-02 오퍼레이터와 같이 INVITED로
+ * 시작한다(파일 머리말 판단 근거) — 본인이 실제로 로그인해야 ACTIVE가 된다. */
+export function inviteSuperadmin(name: string, email: string): SuperadminAccount {
+  const account: SuperadminAccount = {
+    id: `sa-${Date.now()}`,
+    name: name.trim(),
+    email: email.trim(),
+    status: 'INVITED',
+    lastLoginAt: null,
+  }
+  SUPERADMIN_ACCOUNTS.unshift(account)
+  return account
+}
+
+/** DELETE /admin/settings/accounts/{id} — 아직 로그인 전인 초대 자리 취소.
+ * SA-02 cancelInvite와 같은 이유로 ACTIVE·SUSPENDED 계정엔 쓰지 않는다. */
+export function cancelSuperadminInvite(id: string): void {
+  const idx = SUPERADMIN_ACCOUNTS.findIndex((a) => a.id === id && a.status === 'INVITED')
+  if (idx !== -1) SUPERADMIN_ACCOUNTS.splice(idx, 1)
+}
+
+export const LAST_SUPERADMIN_ERROR = 'LAST_SUPERADMIN' as const
+
+/** PATCH /admin/settings/accounts/{id} — 정지. 활성 슈퍼어드민이 이 한 명뿐이면
+ * 막는다(§6 "풀어 줄 상위 권한이 아예 없다" — SA-02 LAST_OPERATOR보다 더 치명적).
+ * INVITED(아직 로그인한 적 없음)는 커버로 세지 않는다 — SA-02 LAST_OPERATOR와
+ * 같은 이유(받아들여질지 보장 안 된 초대로 마지막 활성 계정을 정지시키면 고아가
+ * 될 수 있다). */
+export function suspendSuperadmin(
+  id: string,
+): { ok: true } | { ok: false; code: typeof LAST_SUPERADMIN_ERROR } {
+  const target = SUPERADMIN_ACCOUNTS.find((a) => a.id === id)
+  if (!target) return { ok: false, code: LAST_SUPERADMIN_ERROR }
+  const activeCount = SUPERADMIN_ACCOUNTS.filter((a) => a.status === 'ACTIVE').length
+  if (target.status === 'ACTIVE' && activeCount <= 1) {
+    return { ok: false, code: LAST_SUPERADMIN_ERROR }
+  }
+  target.status = 'SUSPENDED'
+  return { ok: true }
+}

--- a/src/shells/ConsoleShell.tsx
+++ b/src/shells/ConsoleShell.tsx
@@ -75,7 +75,7 @@ export default function ConsoleShell({
         본문으로 건너뛰기
       </a>
 
-      <Header user={user} scope={scope} />
+      <Header user={user} scope={scope} role={role} />
 
       <div className="flex min-h-0 min-w-0 flex-1">
         <Sidebar sidebar={sidebar} />

--- a/src/shells/Header.tsx
+++ b/src/shells/Header.tsx
@@ -1,4 +1,6 @@
 import { useState } from 'react'
+import { Link, useLocation } from 'react-router'
+import { SettingsIcon } from 'lucide-react'
 import { Avatar, AvatarFallback } from '@/components/ui/Avatar'
 import {
   Select,
@@ -8,6 +10,8 @@ import {
   SelectValue,
 } from '@/components/ui/Select'
 import Wordmark from '@/components/common/Wordmark'
+import { cn } from '@/lib/utils/cn'
+import type { Role } from './sidebarConfig'
 
 /*
   상단바 — 브랜드 + 스코프 선택기 + 사용자. 54px 고정 높이(목업 `.topbar{height:54px}`
@@ -22,14 +26,23 @@ import Wordmark from '@/components/common/Wordmark'
   scope — 역할마다 스코프가 다르므로(슈퍼어드민은 없음 · 오퍼레이터/매니저는
   기수 · 교육생은 자기 자신) 없으면 자리 자체를 렌더하지 않는다. 지금은 옵션이
   현재 값 하나뿐이다 — 실제 기수 목록은 화면 이식 때 API에서 받는다.
+
+  우상단 톱니(⚙) — SA-03(플랫폼 설정) 진입점. 정의서 "네비 자리를 주지 않는다 —
+  화면이라기보다 설정 항목이다"(SA-03-platform-settings.md §2)를 그대로 따라 네비가
+  아니라 여기 둔다. superadmin 역할일 때만 렌더하고(다른 역할엔 이 설정 자체가
+  없다), 현재 경로가 /superadmin/settings 아래면 활성 색(primary)을 준다 — 와이어
+  `.gear.on`과 같은 신호다.
 */
 type Props = {
   user: { name: string; role: string }
   scope?: { label: string; value: string }
+  role: Role
 }
 
-export default function Header({ user, scope }: Props) {
+export default function Header({ user, scope, role }: Props) {
   const [value, setValue] = useState(scope?.value)
+  const location = useLocation()
+  const isSettingsActive = location.pathname.startsWith('/superadmin/settings')
 
   return (
     <header className="bg-surface border-border flex h-[54px] w-full shrink-0 items-center justify-between overflow-x-auto border-b px-6">
@@ -52,7 +65,19 @@ export default function Header({ user, scope }: Props) {
         )}
       </div>
 
-      <div className="text-fg-muted flex shrink-0 items-center gap-2 text-sm">
+      <div className="text-fg-muted flex shrink-0 items-center gap-3 text-sm">
+        {role === 'superadmin' && (
+          <Link
+            to="/superadmin/settings"
+            aria-label="플랫폼 설정"
+            className={cn(
+              'rounded-md p-1.5 text-fg-subtle transition-colors hover:bg-surface-2 hover:text-fg',
+              isSettingsActive && 'text-primary hover:text-primary',
+            )}
+          >
+            <SettingsIcon className="size-4" aria-hidden="true" />
+          </Link>
+        )}
         <span className="hidden sm:inline">
           {user.name} · {user.role}
         </span>


### PR DESCRIPTION
## 작업 내용

* 모델·단가 탭 — 채점 모델(전 기관 공통, 변경 시 확인 모달 + 재캘리브레이션 경고), 캘리브레이션 버전, 티어 매핑 표, 단가 표(단가 미입력 상태 처리)
* 슈퍼어드민 계정 탭 — 목록·초대·정지, 마지막 한 명 정지 차단
* `mockData.ts` 신규 — 모델·단가·티어 매핑·계정 데이터 모델 + mock API
* `Header.tsx` 우상단 톱니 추가 — superadmin role일 때만 노출, `/superadmin/settings` 진입 + 활성 표시

## 리뷰 포인트

* `Header.tsx`·`ConsoleShell.tsx`는 공용(팀장님) 파일 — 톱니 진입점 추가(role 분기 + prop 전달)만 했고 기존 로직은 안 건드렸습니다. 확인 부탁드립니다.
* 채점 모델을 `claude-opus-6`으로 바꾸면 단가 미입력 경고 배너가 바로 재현됩니다(#nopricing 데모).
* 슈퍼어드민 계정에 재활성 액션이 없습니다 — 정의서 §3·§5가 "목록·초대·정지" 셋만 명시해서 만들지 않았습니다(`mockData.ts` 파일 머리말 주석). 필요하면 말씀해주세요.

closes #73