### PR TITLE
build: auto-format staged files in pre-commit hook (#81)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -81,6 +81,32 @@ for old in $(git diff --cached --name-only --diff-filter=ACMR -- 'src/components
   echo "ℹ src/components/ui 파일명 규칙: $base → $new_stem.$ext (자동 수정, import 경로도 갱신됨)" >&2
 done
 
+# 포맷 — 파일명 교정과 같은 이유로 "차단" 대신 "자동 수정"한다.
+# prettier 결과는 기계가 정하는 것이라 사람이 판단할 여지가 없고, 되돌리기 비용도 0이다.
+#
+# 왜 붙였나: 포맷 한 줄 때문에 CI가 빨개지고 `style: apply prettier ...` 커밋이 하나 더
+# 붙는 일이 실제로 있었다. CI(`npm run format:check`)와 **같은 도구·같은 설정**을 쓴다.
+#
+# ⚠ 대상 파일에 unstaged 변경이 있으면 그것도 함께 올라간다 — 위 import 경로 갱신과
+#   같은 판단(포맷이 깨진 채 커밋되는 것보다 낫다).
+# 타입 검사(tsc)는 여기 없다: 4초가 걸리고, 편집기와 CI가 이미 잡는다.
+fmt=$(git diff --cached --name-only --diff-filter=ACMR \
+  | grep -E '\.(ts|tsx|js|jsx|mjs|mts|css|json|md|ya?ml)$' || true)
+
+if [ -n "$fmt" ]; then
+  # 지워진 파일은 건너뛴다(--diff-filter로 걸러지지만 rename 직후를 대비)
+  exists=$(printf '%s\n' "$fmt" | while IFS= read -r f; do [ -f "$f" ] && printf '%s\n' "$f"; done)
+  if [ -n "$exists" ]; then
+    before=$(printf '%s\n' "$exists" | xargs npx prettier --list-different 2>/dev/null || true)
+    if [ -n "$before" ]; then
+      printf '%s\n' "$before" | xargs npx prettier --write >/dev/null 2>&1
+      printf '%s\n' "$before" | xargs git add --
+      echo "ℹ 포맷을 자동으로 고쳐 다시 스테이징했습니다:" >&2
+      printf '%s\n' "$before" | sed 's/^/    /' >&2
+    fi
+  fi
+fi
+
 # 이슈 연결 안내(차단 아님 — 오타·포맷팅은 이슈 없이 커밋하는 게 규약 §3)
 if [ -z "$(git config --get "branch.$branch.issue" 2>/dev/null)" ]; then
   echo "ℹ 이 브랜치에 이슈 번호가 없습니다. 연결하면 (#N)이 자동으로 붙습니다:" >&2


### PR DESCRIPTION
Closes #81

`.githooks/pre-commit`에 **포맷 자동 수정**을 붙인다. 파일 하나, 26줄 추가.

## 왜

포맷 안 맞은 파일이 커밋되면 CI가 `Format`에서 빨개지고 `style: apply prettier ...` 커밋이 하나 더 붙는다 — PR #79에서 실제로 그랬다. 공백·줄바꿈만 다른 것이라 **사람이 판단할 여지가 없는** 변경이었다.

## 왜 차단이 아니라 자동 수정인가

이 훅이 이미 쓰고 있는 원칙을 그대로 따랐다.

> UI 컴포넌트 파일명 교정은 예외적으로 "차단" 대신 "자동 수정"한다 — 대소문자/구분자 규칙은 **되돌리기 비용이 0이라 사람이 판단할 이유가 없다.**

prettier 결과도 기계가 정하는 값이라 같은 성격이다. 대신 **무엇을 고쳤는지 항상 출력한다** — 커밋 내용이 모르는 사이에 바뀌면 안 되므로.

## 동작

```
ℹ 포맷을 자동으로 고쳐 다시 스테이징했습니다:
    src/features/operator/admin/roster/RosterTab.tsx
```

- CI(`npm run format:check`)와 **같은 도구·같은 설정** — 여기서만 통과하는 검사는 의미가 없다
- 스테이징된 파일 중 **실제로 어긋난 것만** 고친다. 없으면 아무 일도 안 한다(대부분의 커밋에서 비용 ≈ 0)
- 지워진 파일은 건너뛴다

## 안 넣은 것 — 타입 검사

실측했다.

| | |
|---|---|
| prettier(파일 1개) | 690ms |
| lint | 177ms |
| check:design | 137ms |
| **tsc** | **4221ms** |

커밋마다 4초를 더 내는 것보다 편집기와 CI가 잡는 편이 낫다. 나머지 셋은 합쳐 1초라 넣어도 됐지만, 이번 PR은 **실제로 CI를 깨뜨린 것 하나**만 다룬다.

## 알려진 제약

- **작업 트리 기준으로 검사한다.** staged 내용만 떼어 보려면 stash가 필요한데 이 레포는 여러 세션이 폴더를 공유해서 stash가 위험하다(`.claude/guard-worktree.sh`). `git add -p`로 일부만 올린 경우, 대상 파일의 unstaged 변경도 함께 올라간다 — 바로 위 파일명 교정 로직이 이미 같은 판단을 하고 있다
- 건너뛰려면 `git commit --no-verify`

## 검증

일부러 어긋난 파일(`export const x   =    1`)을 만들어 커밋 → 자동 수정 후 커밋된 내용이 `export const x = 1`인 것을 확인. 어긋난 파일이 없을 때 아무 출력도 없는 것까지 확인했다.
