### PR TITLE
[Feat] Add Manager Project List Screen

### DIFF
--- a/src/features/manager/projects/ProjectListScreen.tsx
+++ b/src/features/manager/projects/ProjectListScreen.tsx
@@ -1,11 +1,220 @@
+import { useCallback, useState } from 'react'
+import { Link, useNavigate } from 'react-router'
 import ConsoleShell from '@/shells/ConsoleShell'
-import PlaceholderScreen from '@/app/PlaceholderScreen'
+import PageHeader from '@/components/common/PageHeader'
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from '@/components/ui/Table'
+import { Empty, EmptyHeader, EmptyTitle, EmptyDescription } from '@/components/ui/Empty'
+import { Button } from '@/components/ui/Button'
+import { Spinner } from '@/components/ui/Spinner'
+import { useAsync } from '@/lib/useAsync'
+import {
+  KIND_LABEL,
+  MANAGED_CLASSES,
+  COHORT_NAME,
+  CURRICULUM_OPTIONS,
+  listManagerProjects,
+  scopeLabel,
+  type ClassName,
+  type ProjectKind,
+  type ProjectStatus,
+} from './mockData'
+import { ALL, INITIAL_FILTERS, isNarrowed, type FilterValues } from './filterState'
+import ProjectStatusBadge from './components/ProjectStatusBadge'
+import ProjectFilters from './components/ProjectFilters'
+import {
+  ProjectNameCell,
+  ClassesCell,
+  CurriculumCell,
+  ConceptCell,
+  PeriodCell,
+  ProgressColCell,
+  ActionColCell,
+} from './components/ProjectRowCells'
 
-/** MG-07 프로젝트 목록 — 화면 이식 전 자리표시. 실제 화면이 들어오면 이 파일 내용만 바뀐다. */
+/*
+  MG-07 프로젝트 목록 — "내 반이 어디까지 왔고 무엇이 밀렸나"에 답한다. 오퍼레이터
+  OP-03과 표는 닮았지만 시간 방향이 반대라(정의서 "OP-03과 통일하지 않은 것") 조립을
+  그대로 베끼지 않았다 — 열 구성·정렬·조치 단위가 전부 이 화면 자체 계약이다.
+
+  이 파일은 조립만 한다. 셀 분기는 `ProjectRowCells`가, 툴바는 `ProjectFilters`가,
+  진행·조치 파생값은 `mockData`(rules 역할)가 갖는다.
+
+  **생성 버튼이 없다.** 프로젝트는 오퍼레이터가 만든다(OP-03) — 매니저 화면에
+  생성 유도를 넣으면 할 수 없는 일을 권하는 것이다(정의서 §"생성 유도를 넣지 않는다").
+*/
+
+const CLASS_NAMES = MANAGED_CLASSES.map((c) => c.name)
+const CLASS_TOTAL: Record<ClassName, number> = Object.fromEntries(
+  MANAGED_CLASSES.map((c) => [c.name, c.total]),
+) as Record<ClassName, number>
+
+const detailPath = (id: string) => `/manager/projects/${id}`
+
 export default function ProjectListScreen() {
+  const navigate = useNavigate()
+  const [filters, setFilters] = useState<FilterValues>(INITIAL_FILTERS)
+
+  const loadProjects = useCallback(
+    () =>
+      listManagerProjects({
+        search: filters.search || undefined,
+        classFilter: filters.classFilter === ALL ? undefined : (filters.classFilter as ClassName),
+        curriculum: filters.curriculum === ALL ? undefined : filters.curriculum,
+        kind: filters.kind === ALL ? undefined : (filters.kind as ProjectKind),
+        status: filters.status === ALL ? undefined : (filters.status as ProjectStatus),
+        sort: filters.sort,
+      }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [filters],
+  )
+  const page = useAsync(loadProjects)
+  const narrowed = isNarrowed(filters)
+
+  // 스코프 문구 — 헤더는 필터와 무관하게 항상 담당 반 전체 합계를 보여준다
+  const scopeText = scopeLabel(CLASS_NAMES, CLASS_TOTAL)
+
   return (
     <ConsoleShell role="manager">
-      <PlaceholderScreen code="MG-07" title="프로젝트 목록" />
+      <PageHeader
+        breadcrumb={`프로젝트 › ${COHORT_NAME} › 담당 반`}
+        title="프로젝트"
+        count={page.data ? `${page.data.total}개` : undefined}
+        breakdown={
+          <span className="text-fg-subtle">
+            담당 <b className="text-fg-muted font-bold">{scopeText}</b>
+          </span>
+        }
+      />
+
+      <ProjectFilters
+        {...filters}
+        classes={CLASS_NAMES}
+        curricula={CURRICULUM_OPTIONS}
+        counts={page.data?.counts}
+        onChange={(patch) => setFilters((f) => ({ ...f, ...patch }))}
+      />
+
+      {page.loading ? (
+        <div className="flex justify-center py-16">
+          <Spinner className="size-6" aria-label="목록을 불러오는 중" />
+        </div>
+      ) : page.failed ? (
+        <Empty>
+          <EmptyHeader>
+            <EmptyTitle>목록을 불러오지 못했습니다</EmptyTitle>
+            <EmptyDescription>잠시 후 다시 시도해 주세요.</EmptyDescription>
+          </EmptyHeader>
+          <Button variant="ghost" onClick={page.reload}>
+            다시 시도
+          </Button>
+        </Empty>
+      ) : page.data?.items.length === 0 ? (
+        narrowed ? (
+          <Empty>
+            <EmptyHeader>
+              <EmptyTitle>
+                {filters.search
+                  ? `"${filters.search}"와 맞는 회차가 없습니다`
+                  : '조건에 맞는 회차가 없습니다'}
+              </EmptyTitle>
+            </EmptyHeader>
+          </Empty>
+        ) : (
+          // 생성 유도를 넣지 않는다 — 프로젝트는 오퍼레이터가 만든다(정의서 §7)
+          <Empty className="border-dashed bg-surface-2">
+            <EmptyHeader>
+              <EmptyTitle>이 기수에 등록된 프로젝트가 없습니다</EmptyTitle>
+              <EmptyDescription>회차가 만들어지면 여기에 나타납니다.</EmptyDescription>
+            </EmptyHeader>
+          </Empty>
+        )
+      ) : (
+        page.data && (
+          <>
+            <Table className="table-fixed">
+              <TableHeader>
+                <TableRow className="hover:bg-transparent">
+                  {/*
+                    열 순서를 팀장님의 실제 OP-03 렌더 화면(프로젝트·유형·상태·기간·
+                    교안·검증개념3건)에 맞추되, OP-03에 없는 반 열을 상태·기간 사이에
+                    넣었다(사용자 지시, 4차 반영). OP-03에 없는 이 화면만의 열(진행·
+                    조치 — "무엇이 밀렸는지"에 답하는 핵심)은 뒤에 이어 붙인다.
+                  */}
+                  <TableHead className="w-28">프로젝트</TableHead>
+                  <TableHead className="w-16">유형</TableHead>
+                  <TableHead className="w-24">상태</TableHead>
+                  <TableHead className="w-28">반</TableHead>
+                  <TableHead className="w-40">프로젝트 기간</TableHead>
+                  <TableHead className="w-36">교안</TableHead>
+                  <TableHead className="w-56">검증 개념 3건</TableHead>
+                  <TableHead className="w-28">진행</TableHead>
+                  <TableHead className="w-40">조치</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {page.data.items.map(({ project, progress, actions }) => (
+                  <TableRow
+                    key={project.id}
+                    className="hover:bg-surface-2 cursor-pointer"
+                    onClick={() => navigate(detailPath(project.id))}
+                  >
+                    <TableCell>
+                      {/* 행 전체가 클릭되지만 키보드 접근을 위해 실제 링크를 하나 둔다(완료 정의 §6) */}
+                      <Link
+                        to={detailPath(project.id)}
+                        className="hover:underline"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        <ProjectNameCell project={project} />
+                      </Link>
+                    </TableCell>
+                    <TableCell className="text-fg-muted text-xs">
+                      {KIND_LABEL[project.kind]}
+                    </TableCell>
+                    <TableCell>
+                      <ProjectStatusBadge status={project.status} />
+                    </TableCell>
+                    <TableCell>
+                      <ClassesCell classes={project.classes} />
+                    </TableCell>
+                    <TableCell>
+                      <PeriodCell startAt={project.startAt} dueAt={project.dueAt} />
+                    </TableCell>
+                    <TableCell>
+                      <CurriculumCell project={project} />
+                    </TableCell>
+                    <TableCell>
+                      <ConceptCell project={project} />
+                    </TableCell>
+                    <TableCell>
+                      <ProgressColCell cell={progress} />
+                    </TableCell>
+                    <TableCell>
+                      <ActionColCell items={actions} />
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+
+            {/* 페이지가 하나뿐이라 페이저를 그리지 않는다(E7 — 누를 수 없는 컨트롤은 장식) */}
+            <div className="mt-3 grid grid-cols-3 items-center">
+              <p className="text-fg-subtle text-xs">
+                {`1–${page.data.items.length} / ${page.data.total}개`}
+              </p>
+              <div />
+              <div />
+            </div>
+          </>
+        )
+      )}
     </ConsoleShell>
   )
 }

--- a/src/features/manager/projects/components/ProjectFilters.tsx
+++ b/src/features/manager/projects/components/ProjectFilters.tsx
@@ -1,0 +1,196 @@
+import { SearchIcon, XIcon } from 'lucide-react'
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from '@/components/ui/InputGroup'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/Select'
+import {
+  KIND_LABEL,
+  STATUS_LABEL,
+  type ClassName,
+  type ProjectKind,
+  type ProjectSort,
+  type ProjectStatus,
+} from '../mockData'
+import { ALL, type FilterValues } from '../filterState'
+
+/*
+  목록 툴바 — 검색·상태·반·유형·교안·정렬. 순서·구성을 팀장님의 실제 OP-03 화면
+  (검색→상태→유형→교안→|→정렬)에 맞추되, OP-03에 없는 매니저 전용 축(반)을
+  **상태와 유형 사이**에 넣는다(사용자 지시, 4차 반영 — 3차에서 뺐다가 되돌렸다).
+
+  **정렬을 2종으로 줄였다**(프로젝트 시작 순 · 마감 임박 순) — "준비 필요 순"은
+  매니저에게 뜻이 없어서(확정 권한이 없다) 사용자가 직접 뺐다.
+
+  **상태 옵션에 개수를 싣는다**(`전체 (6)`) — OP-03과 같은 이유(고르기 전에 분포를
+  아는 것, 고르는 자리에 있어야 한다).
+
+  **트리거 폭을 전부 고정한다**(`min-w-*`가 아니라 `w-*`). `SelectTrigger`
+  기본 클래스가 `w-fit`이라, 폭을 최소값만 주면(`min-w-*`) 그 최소값보다 긴 값이
+  선택됐을 땐 트리거가 늘어났다가 짧은 값을 고르면 다시 줄어든다 — 클릭할 때마다
+  칸 크기 자체가 바뀌는 문제(사용자 지시로 5차 반영). 게다가 `SelectContent`가
+  트리거 폭(`--anchor-width`)에 맞춰 열리는 공용 컴포넌트라, 트리거가 짧아진
+  채로 열리면 긴 옵션(`Streamlit 실습 v1`)이 목록에서 잘리기도 했다(교안 필터,
+  4차 반영 당시 발견). `w-*` 고정폭을 각 필터의 최장 옵션 기준으로 넉넉히 주면
+  두 문제가 한 번에 없어진다 — 공용 `Select` 자체는 고치지 않는다(앱 전체 영향
+  회피, 4차 반영과 같은 판단).
+*/
+
+const items = (prefix: string, options: { value: string; label: string }[]) =>
+  Object.fromEntries(options.map((o) => [o.value, `${prefix} · ${o.label}`]))
+
+type Props = FilterValues & {
+  classes: ClassName[]
+  /** 이 기수에서 실제로 쓰이는 교안 — 교안 필터 선택지(`CURRICULUM_OPTIONS`) */
+  curricula: string[]
+  /** 상태별 개수 — 필터와 무관한 전체 모집단 기준(`ProjectListResult.counts`) */
+  counts?: Record<ProjectStatus, number>
+  onChange: (patch: Partial<FilterValues>) => void
+}
+
+const sum = (c: Record<ProjectStatus, number>) => Object.values(c).reduce((a, b) => a + b, 0)
+
+const SORT_OPTIONS: { value: ProjectSort; label: string }[] = [
+  { value: 'START', label: '프로젝트 시작 순' },
+  { value: 'DUE', label: '마감 임박 순' },
+]
+
+export default function ProjectFilters({
+  search,
+  status,
+  classFilter,
+  kind,
+  curriculum,
+  sort,
+  classes,
+  curricula,
+  counts,
+  onChange,
+}: Props) {
+  const statusOptions = [
+    { value: ALL, label: counts ? `전체 (${sum(counts)})` : '전체' },
+    ...(Object.keys(STATUS_LABEL) as ProjectStatus[]).map((s) => ({
+      value: s,
+      label: counts ? `${STATUS_LABEL[s]} (${counts[s]})` : STATUS_LABEL[s],
+    })),
+  ]
+  const classOptions = [
+    { value: ALL, label: '전체' },
+    ...classes.map((c) => ({ value: c, label: c })),
+  ]
+  const kindOptions = [
+    { value: ALL, label: '전체' },
+    ...(Object.keys(KIND_LABEL) as ProjectKind[]).map((k) => ({ value: k, label: KIND_LABEL[k] })),
+  ]
+  const curriculumOptions = [
+    { value: ALL, label: '전체' },
+    ...curricula.map((c) => ({ value: c, label: c })),
+  ]
+
+  return (
+    <div className="mb-3 flex flex-wrap items-center gap-2">
+      <InputGroup className="h-9 w-60">
+        <InputGroupAddon>
+          <SearchIcon />
+        </InputGroupAddon>
+        <InputGroupInput
+          value={search}
+          onChange={(e) => onChange({ search: e.target.value })}
+          placeholder="프로젝트명 검색"
+          aria-label="프로젝트 검색"
+        />
+        {search && (
+          <InputGroupAddon align="inline-end">
+            <InputGroupButton
+              size="icon-xs"
+              aria-label="검색어 지우기"
+              onClick={() => onChange({ search: '' })}
+            >
+              <XIcon />
+            </InputGroupButton>
+          </InputGroupAddon>
+        )}
+      </InputGroup>
+
+      <FilterSelect
+        label="상태"
+        value={status}
+        options={statusOptions}
+        onChange={(v) => onChange({ status: v })}
+        className="w-44"
+      />
+      <FilterSelect
+        label="반"
+        value={classFilter}
+        options={classOptions}
+        onChange={(v) => onChange({ classFilter: v })}
+        className="w-32"
+      />
+      <FilterSelect
+        label="유형"
+        value={kind}
+        options={kindOptions}
+        onChange={(v) => onChange({ kind: v })}
+        className="w-44"
+      />
+      <FilterSelect
+        label="교안"
+        value={curriculum}
+        options={curriculumOptions}
+        onChange={(v) => onChange({ curriculum: v })}
+        className="w-56"
+      />
+
+      <span className="bg-border mx-1 h-5 w-px" />
+
+      <FilterSelect
+        label="정렬"
+        value={sort}
+        options={SORT_OPTIONS}
+        onChange={(v) => onChange({ sort: v as ProjectSort })}
+        className="w-48"
+      />
+    </div>
+  )
+}
+
+function FilterSelect({
+  label,
+  value,
+  options,
+  onChange,
+  className = 'w-28',
+}: {
+  label: string
+  value: string
+  options: { value: string; label: string }[]
+  onChange: (value: string) => void
+  className?: string
+}) {
+  return (
+    <Select
+      value={value}
+      onValueChange={(v) => onChange(v ?? options[0].value)}
+      items={items(label, options)}
+    >
+      <SelectTrigger className={`h-9 ${className}`} aria-label={`${label} 필터`}>
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {options.map((o) => (
+          <SelectItem key={o.value} value={o.value}>
+            {label} · {o.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}

--- a/src/features/manager/projects/components/ProjectRowCells.tsx
+++ b/src/features/manager/projects/components/ProjectRowCells.tsx
@@ -1,0 +1,174 @@
+import { TriangleAlertIcon } from 'lucide-react'
+import Badge from '@/components/ui/Badge'
+import { cn } from '@/lib/utils/cn'
+import {
+  attendanceReachLevel,
+  dueLabel,
+  formatDue,
+  type ActionItem,
+  type ClassProgress,
+  type Project,
+  type ProgressCell,
+} from '../mockData'
+
+/*
+  목록 표의 셀 셋 — 화면 파일에서 뺀 이유는 OP-03 ProjectRowCells와 같다: 이 셋은
+  전부 "값이 없을 때 무엇을 대신 말하나"를 정하는 분기라, 화면 파일에 두면 표의
+  골격이 안 읽힌다. **목록 전용이다** — MG-08 상세는 같은 데이터를 다른 방식으로
+  그린다(반별 표로 편다).
+*/
+
+/**
+ * 교안 — OP-03 `CurriculumSummary`와 같은 세로 나열. 빅프는 구조적으로
+ * "해당 없음"(회색), 미프인데 아직 교안이 안 붙었으면 "교안 연결 안 됨"(경고색) —
+ * OP-03과 같은 톤이다(4차 반영, 정의서의 "경고 안 띄운다" 판단을 뒤집었다).
+ */
+export function CurriculumCell({ project }: { project: Project }) {
+  if (project.kind === 'BIG') return <span className="text-fg-subtle text-xs">해당 없음</span>
+  if (project.curricula.length === 0) {
+    return <span className="text-warning text-xs font-semibold">교안 연결 안 됨</span>
+  }
+  return (
+    <div className="flex flex-col gap-0.5 text-xs">
+      {project.curricula.map((c) => (
+        <span key={c}>{c}</span>
+      ))}
+    </div>
+  )
+}
+
+/**
+ * 검증 개념 3건 — 확정 칩 3개 · 미확정(⚠ + 후보 건수) · 교안 미연결 · 빅프의
+ * 본인 커밋 영역. OP-03 `ConceptSummary`와 같은 4분기로 맞췄다(4차 반영).
+ */
+export function ConceptCell({ project }: { project: Project }) {
+  if (project.kind === 'BIG') {
+    return <span className="text-fg-subtle text-xs">본인 커밋 영역 — 사람마다 다름</span>
+  }
+  if (project.curricula.length === 0) {
+    return <span className="text-fg-subtle text-xs">교안을 먼저 연결해야 후보가 나옵니다</span>
+  }
+  if (project.concepts === null) {
+    return (
+      <span className="text-warning flex items-center gap-1 text-xs font-semibold">
+        <TriangleAlertIcon className="size-3.5" />
+        미확정 · 후보 {project.conceptCandidateCount}건에서 3건
+      </span>
+    )
+  }
+  return (
+    <div className="flex flex-wrap gap-1">
+      {project.concepts.map((c) => (
+        // kchip = Badge + 테두리(OP-03 ConceptSummary와 같은 조합)
+        <Badge key={c} className="border-border-strong bg-surface-2 text-fg-muted border">
+          {c}
+        </Badge>
+      ))}
+    </div>
+  )
+}
+
+/** 빅프는 회차 번호가 없다 — 이름 아래 "총 3회 · 첫 동작 · +2주 · 마감"을 함께 쓴다 */
+export function ProjectNameCell({ project }: { project: Project }) {
+  return (
+    <div>
+      <span className="text-fg font-semibold">{project.name}</span>
+      {project.note && <p className="text-fg-subtle mt-0.5 text-2xs">{project.note}</p>}
+    </div>
+  )
+}
+
+/**
+ * 반 — 이 회차에 실제로 반별 데이터가 있으면 그 반 이름을(A반·B반·C반), 아직
+ * 없으면(예정 회차) "—"(4차 반영, 사용자 지시로 새로 추가한 열).
+ */
+export function ClassesCell({ classes }: { classes: ClassProgress[] }) {
+  if (classes.length === 0) return <span className="text-fg-subtle text-xs">—</span>
+  return <span className="text-xs">{classes.map((c) => c.className).join(' · ')}</span>
+}
+
+/**
+ * 프로젝트 기간 — 시작~마감 전체 범위 + 남은 일수(OP-03 `PeriodCell`과 같은 모양,
+ * 4차 반영 — "제출 마감" 단일 날짜에서 바뀌었다). 마감이 임박했을 때만 빨간
+ * 굵은 글씨, 아니면 옅은 회색 — 색만으로 구분하지 않고 글자도 같이 바뀐다(F4).
+ * 시작·마감이 둘 다 없으면 "미설정"(경고색). 시작·마감 둘 다 날짜+시간까지 보여준다
+ * (5차 반영 — 시작일은 원래 시간을 잘라 날짜만 보였는데, 마감과 같은 정밀도로 맞췄다).
+ * 남은 일수 줄은 위 날짜 범위 줄보다 짧아 눈에 안 맞아 보였다 — 가운데 정렬한다.
+ */
+export function PeriodCell({ startAt, dueAt }: { startAt: string | null; dueAt: string | null }) {
+  if (!startAt && !dueAt) {
+    return <span className="text-warning text-xs font-semibold">미설정</span>
+  }
+  const due = dueAt ? dueLabel(dueAt) : null
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="text-fg-muted text-xs tabular-nums">
+        {startAt ? formatDue(startAt) : '—'}
+        <span className="text-fg-subtle"> ~ </span>
+        {dueAt ? formatDue(dueAt) : '—'}
+      </span>
+      {due && (
+        <span
+          className={cn(
+            'text-center text-2xs',
+            due.urgent ? 'text-danger font-bold' : 'text-fg-subtle',
+          )}
+        >
+          {due.text}
+        </span>
+      )}
+    </div>
+  )
+}
+
+/** 응시 실수 분자(`58`)의 강조 색 — 0/25/50/75/100% 경계로 reach 5단(사용자 지시) */
+const REACH_TEXT: Record<0 | 1 | 2 | 3 | 4, string> = {
+  0: 'text-reach-0',
+  1: 'text-reach-1',
+  2: 'text-reach-2',
+  3: 'text-reach-3',
+  4: 'text-reach-4',
+}
+
+/** 진행 — 파이프라인 현재 단계 하나(정의서 §3). 예정 회차는 아직 아무 일도 없다 */
+export function ProgressColCell({ cell }: { cell: ProgressCell | null }) {
+  if (!cell) return <span className="text-fg-subtle text-sm">—</span>
+  if (cell.kind === 'DONE') {
+    return (
+      <div className="text-sm">
+        <span className="text-fg-subtle block text-2xs font-bold tracking-wide">리포트</span>
+        <span className="text-success font-bold">발행 완료</span>
+      </div>
+    )
+  }
+  const level = attendanceReachLevel(cell.attended, cell.attendable)
+  return (
+    <div className="text-sm">
+      <span className="text-fg-subtle block text-2xs font-bold tracking-wide">응시</span>
+      <span className="tabular-nums">
+        <span className={cn('font-bold', REACH_TEXT[level])}>{cell.attended}</span>
+        <span className="text-fg-muted">/{cell.attendable}</span>
+      </span>
+    </div>
+  )
+}
+
+const ACTION_TONE_CLASS: Record<ActionItem['tone'], string> = {
+  warning: 'text-warning font-semibold',
+  danger: 'text-danger font-semibold',
+  todo: 'text-primary font-semibold',
+}
+
+/** 조치 — 이 화면의 질문("무엇이 밀렸는지")에 직접 답한다. 비면 "—"(축하 문구 없음) */
+export function ActionColCell({ items }: { items: ActionItem[] }) {
+  if (items.length === 0) return <span className="text-fg-subtle text-xs">—</span>
+  return (
+    <div className="flex flex-col gap-0.5 text-xs">
+      {items.map((a, i) => (
+        <span key={i} className={ACTION_TONE_CLASS[a.tone]}>
+          {a.text}
+        </span>
+      ))}
+    </div>
+  )
+}

--- a/src/features/manager/projects/components/ProjectStatusBadge.tsx
+++ b/src/features/manager/projects/components/ProjectStatusBadge.tsx
@@ -1,0 +1,17 @@
+import Badge from '@/components/ui/Badge'
+import { STATUS_LABEL, type ProjectStatus } from '../mockData'
+
+/*
+  목업 `.st.plan`(회색) · `.st.run`(파랑) · `.st.done`(초록)을 그대로 옮긴다.
+  OP-03 ProjectStatusBadge와 색을 맞추되(같은 의미는 같은 색) `준비 중`·`준비됨`
+  구분이 없어 매핑이 더 단순하다.
+*/
+const VARIANT: Record<ProjectStatus, 'neutral' | 'info' | 'success'> = {
+  PLANNED: 'neutral',
+  RUNNING: 'info',
+  DONE: 'success',
+}
+
+export default function ProjectStatusBadge({ status }: { status: ProjectStatus }) {
+  return <Badge variant={VARIANT[status]}>{STATUS_LABEL[status]}</Badge>
+}

--- a/src/features/manager/projects/filterState.ts
+++ b/src/features/manager/projects/filterState.ts
@@ -1,0 +1,39 @@
+import type { ProjectSort } from './mockData'
+
+/*
+  목록 필터의 값. UI(`components/ProjectFilters.tsx`)와 파일을 가른 이유는 OP-03
+  filterState.ts(D20)와 같다 — 한 파일이 컴포넌트와 값을 같이 export하면 React Fast
+  Refresh가 그 파일에 상태 보존 핫리로드를 못 해준다(react/only-export-components).
+*/
+
+export const ALL = 'ALL'
+
+export type FilterValues = {
+  search: string
+  classFilter: string
+  curriculum: string
+  kind: string
+  status: string
+  sort: ProjectSort
+}
+
+/** 기본값 — 정렬만 기본이 있다. 매니저는 마감이 급한 회차부터 본다(OP-03과 같은 이유) */
+export const INITIAL_FILTERS: FilterValues = {
+  search: '',
+  classFilter: ALL,
+  curriculum: ALL,
+  kind: ALL,
+  status: ALL,
+  sort: 'DUE',
+}
+
+/** 빈 결과가 "아직 없음"인지 "필터에 안 걸림"인지 — 문구가 갈린다(OP-03 isNarrowed와 같은 이유) */
+export function isNarrowed(f: FilterValues): boolean {
+  return (
+    f.search !== '' ||
+    f.classFilter !== ALL ||
+    f.curriculum !== ALL ||
+    f.kind !== ALL ||
+    f.status !== ALL
+  )
+}

--- a/src/features/manager/projects/mockData.ts
+++ b/src/features/manager/projects/mockData.ts
@@ -1,0 +1,523 @@
+/*
+  MG-07 프로젝트 목록 · MG-08 프로젝트 상세(매니저) — 공유 목업 데이터.
+
+  값은 목업 docs/plan/v2/wireframe/manager/projects.html에서 그대로 옮긴다. OP-03
+  (operator/projects)과 표는 닮았지만 **답하는 질문이 다르다**(정의서 "OP-03과
+  통일하지 않은 것") — 상태(예정/진행 중/종료 3종, OP의 PREP·READY 구분 없음) ·
+  진행 열(파이프라인 현재 단계 하나) · 조치 열(반 이름 + 미제출·분석 실패·면담)이
+  전부 이 화면 자체 계약이라 OP-03 타입을 재사용하지 않는다 — 이 레포에 역할 간
+  mock cross-import 전례가 없다(auth 제외, auth는 신원이라 예외).
+
+  ⚠ 판단 기록 — 이 파일이 정한 것 (기획 문서에 없음)
+  · 담당 반 인원: A반 26 · B반 26 · C반 23 = 75명(목업 "담당 A·B·C반 · 75명" ·
+    "C반만 · 23명" 두 장면에서 역산). 나머지 분배는 프론트가 정했다.
+  · 미프 3차 반별 응시 실수: 위 인원 분배로 **합계 58/71**이 정확히 나오도록
+    맞췄다(목업 장면 숫자와 일치).
+  · **미프 5차를 추가했다.** 목업 `#notready` 장면(다음 회차 미준비 · 6개)은 기본
+    `#list` 장면(5개)과 항목 수가 다르다 — 손그림 와이어는 장면마다 따로 그려도
+    되지만 실제 화면은 **하나의 데이터셋**이어야 필터 결과가 항상 맞는다. 미프 5차
+    (교안조차 안 붙은 예정 회차)를 데이터셋에 넣어 상태 필터 `예정`이 실제로 3건
+    (빅프·미프5차·미프4차)을 돌려주게 했다 — 기본 목록 개수는 6개가 된다(목업 5개
+    표기와 다름, 의도적 이탈).
+  · 조치 열의 "팀" 단위(`A반 미제출 2팀`)는 목업 문구를 그대로 따랐다 — 미프가
+    개인 제출인지 팀 제출인지는 정의서에 없다(OP-04 쪽 `totalTeams`도 같은 사정,
+    "이 숫자는 기획에 없다"). 제출/분석/응시 실수와 조치 문구를 같은 필드로
+    역산하지 않고 **독립된 값**으로 둔다 — 실제 서버라면 서로 다른 집계 쿼리라
+    산수가 딱 맞물릴 필요가 없다.
+
+  ⚠ 2차 반영 — 팀장님이 새로 짠 OP-03 렌더 화면(컬럼: 프로젝트·유형·상태·기간·
+  교안·검증개념3건 / 필터: 검색·상태·유형·교안·|·정렬)에 맞춰 컬럼·필터 순서를
+  다시 맞췄다.
+
+  ⚠ 3차 반영 — 사용자 지시로 OP-03과 마저 맞췄다. 유형 라벨을 전체 이름(미니
+  프로젝트/빅 프로젝트)으로. 정렬·반 필터는 4차에서 다시 한 번 바뀐다(아래).
+
+  ⚠ 4차 반영 — 사용자 피드백(렌더 확인 후).
+  · **반 필터가 되돌아왔다.** "프로젝트에 포함된 반을 표시"하는 열(상태·기간 사이)
+    + 필터(상태·유형 사이)로. 3차에서 뺐던 걸 다시 넣은 것 — 이번엔 목록을 좁히는
+    용도가 아니라 **그 회차에 실제로 반 데이터가 있는지**(예정 회차는 아직 없다)를
+    보여주는 열이라 `project.classes`를 그대로 읽는다.
+  · **"제출 마감" → "프로젝트 기간".** 시작~마감 전체 범위 + 남은 일수(OP-03
+    `PeriodCell`과 같은 모양 — `dueLabel`도 그대로 들여왔다). **빅프도 이제 날짜를
+    보여준다** — 전엔 "학생마다 진행이 다르다"는 이유로 이 셀만 "—"로 가렸는데,
+    사용자가 준 참고 화면이 빅프 행에도 실제 기간(72일 남음 등)을 그리고 있어 그
+    쪽을 따랐다. `startAt`은 이제 정렬만이 아니라 **화면에도 나온다.**
+  · **응시 진행의 "뒤처진 반" 보조문구(`C반이 12/23`)를 없앴다** — 사용자가
+    불필요하다고 판단. `progressCell`의 반환 모양도 그만큼 단순해졌다.
+  · **응시 실수(`58/71`)의 분자에 5단 색을 입힌다** — 0/25/50/75/100% 경계로 색이
+    바뀐다. 새 색 토큰을 만들지 않고 **이미 있는 `reach-0~4`**(MG-05 개념 도달
+    5단 스케일)를 재사용했다 — 뜻은 다르지만(개념 도달 단계 vs 응시율) 시각적으로
+    똑같은 "5단 그라데이션"이 필요해서다. 새 토큰을 추가하면 `doc:design` 갱신이
+    또 필요해진다.
+  · **"교안 연결 안 됨"·"미설정"을 경고색으로.** OP-03 톤을 그대로 따랐다 — 3차
+    반영 때 "확정 권한이 없으면 경고를 안 띄운다"던 정의서 판단을 이번에도
+    뒤집는다(사용자가 명시적으로 OP-03 스타일을 요구). **검증 개념 미확정도
+    OP-03처럼 `⚠ 미확정 · 후보 N건에서 3건`으로** — `conceptCandidateCount`를
+    새로 추가했다(OP-03 `Project.conceptCandidateCount`와 같은 자리, 값은 그
+    교안이 실제로 가르치는 항목 수를 손으로 맞췄다).
+  · **정렬 3종 → 2종.** "준비 필요 순"·"시작 임박 순"을 없애고 **프로젝트 시작
+    순 · 마감 임박 순**만 남겼다. "마감 임박 순"은 **아직 안 지난 회차를 마감
+    이른 순으로 먼저 보여주고, 이미 지난 회차는 뒤에 시작 순으로 이어붙인다** —
+    사용자가 명시한 순서라 `compareProjects`에 그 규칙 그대로 넣었다(`isOverdue`
+    분기 참고). "지났다"의 기준일은 `MOCK_TODAY`(미프 3차가 마감 직후·응시 창
+    진행 중이 되는 시점으로 잡았다 — 그래야 RUNNING 회차의 마감이 "지남"으로
+    보이는 게 자연스럽다).
+  · **교안 필터 드롭다운 폭 버그.** `SelectContent`가 트리거 폭(`--anchor-width`)에
+    맞춰 열려서, "전체"처럼 짧은 값이 선택된 채로 열면 긴 옵션(`Streamlit 실습
+    v1`)이 잘렸다. 공용 `Select` 컴포넌트를 고치면 앱 전체 셀렉트에 영향이 가므로
+    건드리지 않고, 이 필터의 트리거 최소 폭만 넉넉하게 늘렸다(`ProjectFilters.tsx`).
+
+  ⚠ 5차 반영 — 필터 트리거 전부 고정폭으로(`ProjectFilters.tsx`, `min-w-*` →
+  `w-*`, 트리거 기본 클래스가 `w-fit`이라 최소폭만 주면 선택값 길이에 따라 칸
+  자체가 커졌다 줄었다 했다).
+
+  ⚠ 6차 반영 — **프로젝트 기간의 시작일에도 시간을 더했다** — OP-03 `PeriodCell`은
+  시작일을 `.slice(0, 5)`로 잘라 날짜만 보여주지만(마감만 시:분까지), 사용자가
+  시작일도 마감과 같은 정밀도로 보길 원해 그 자름을 없앴다(`ProjectRowCells.tsx`).
+  OP-03과 다시 갈라지는 지점이라 여기 남긴다. 표 헤더 폭도 늘어난 글자 수만큼
+  넓혔다(`w-32` → `w-40`, `ProjectListScreen.tsx`). 남은 일수("N일 남음"/"지남")
+  줄도 위 날짜 범위보다 짧아 어긋나 보여 가운데 정렬했다(`ProjectRowCells.tsx`).
+*/
+
+export type ProjectKind = 'MINI' | 'BIG'
+
+/** 매니저에게는 예정/진행 중/종료 3종만 있다 — 준비 상태(PREP·READY)는 OP-03 소관 */
+export type ProjectStatus = 'PLANNED' | 'RUNNING' | 'DONE'
+
+export type ClassName = 'A반' | 'B반' | 'C반'
+
+/** 반별 원자 값 — MG-08 제출 현황 탭이 이 레코드를 그대로 반별 표로 편다 */
+export type ClassProgress = {
+  className: ClassName
+  /** 그 반 인원 */
+  total: number
+  attendable: number
+  attended: number
+  /** 진행 중 회차 — 미제출 "팀" 수. 0이면 조치에 안 나타난다 */
+  unsubmittedTeams: number
+  /** 진행 중 회차 — 분석 실패 "팀" 수 */
+  analysisFailedTeams: number
+  /** 종료된 회차 — 면담 대기·진행 인원 */
+  interviewCount: number
+}
+
+export type Project = {
+  id: string
+  name: string
+  kind: ProjectKind
+  status: ProjectStatus
+  /**
+   * 연결 교안 — "이름 버전" 문자열 목록(OP-03 CurriculumSummary와 같은 세로 나열).
+   * 빈 배열 = 교안 없음. 빅프는 구조적으로 항상 빈 배열(개념 자체가 없다), 미프가
+   * 빈 배열이면 "아직 안 붙었다"는 뜻이라 다른 문구가 붙는다(§notready 케이스).
+   */
+  curricula: string[]
+  /** 검증 개념 3건. null = 미확정(빅프는 개념 자체가 없어 빈 배열) */
+  concepts: string[] | null
+  /**
+   * 연결한 교안이 가르치는 항목 수(OP-03 `conceptCandidateCount`와 같은 자리) —
+   * 미확정일 때 "후보 N건에서 3건"에 쓴다. 교안이 없거나 빅프면 0.
+   */
+  conceptCandidateCount: number
+  /** 시작 ISO. 미설정이면 null(§notready 케이스 · 미프 5차) */
+  startAt: string | null
+  /** 제출 마감 ISO. 미설정이면 null */
+  dueAt: string | null
+  /** 빅프 전용 부가문구 */
+  note?: string
+  /** 담당 반 스코프의 반별 데이터. 예정 회차는 빈 배열(아직 아무 일도 없다) */
+  classes: ClassProgress[]
+}
+
+/**
+ * 유형 라벨 — OP-03 `KIND_LABEL`과 동일한 전체 이름(사용자 지시, 3차 반영). 원래는
+ * 목업 표기(미프/빅프 약어)를 따랐으나 OP-03과 화면 어휘를 맞추는 쪽으로 바뀌었다.
+ */
+export const KIND_LABEL: Record<ProjectKind, string> = { MINI: '미니 프로젝트', BIG: '빅 프로젝트' }
+
+/** 매니저는 3종만 본다 — 준비 중/준비됨 구분은 확정 권한이 있는 OP-03 쪽 개념이다 */
+export const STATUS_LABEL: Record<ProjectStatus, string> = {
+  PLANNED: '예정',
+  RUNNING: '진행 중',
+  DONE: '종료',
+}
+
+/** 담당 반 스코프 — 매니저 박지현, 7기 A·B·C반 */
+export const MANAGED_CLASSES: { name: ClassName; total: number }[] = [
+  { name: 'A반', total: 26 },
+  { name: 'B반', total: 26 },
+  { name: 'C반', total: 23 },
+]
+export const SCOPE_TOTAL = MANAGED_CLASSES.reduce((n, c) => n + c.total, 0)
+export const COHORT_NAME = '7기'
+
+export const PROJECTS: Project[] = [
+  {
+    id: 'bigp',
+    name: '빅프',
+    kind: 'BIG',
+    status: 'PLANNED',
+    curricula: [],
+    concepts: [],
+    conceptCandidateCount: 0,
+    startAt: '2026-08-01T09:00',
+    dueAt: '2026-09-26T23:59',
+    note: '총 3회 · 첫 동작 · +2주 · 마감',
+    classes: [],
+  },
+  {
+    // 다음 회차 미준비 케이스 전용 — 교안조차 안 붙었다(§notready)
+    id: 'mif-5',
+    name: '미프 5차',
+    kind: 'MINI',
+    status: 'PLANNED',
+    curricula: [],
+    concepts: null,
+    conceptCandidateCount: 0,
+    startAt: null,
+    dueAt: null,
+    classes: [],
+  },
+  {
+    id: 'mif-4',
+    name: '미프 4차',
+    kind: 'MINI',
+    status: 'PLANNED',
+    curricula: ['AI_LLMOps v2'],
+    concepts: null,
+    // AI_LLMOps v2가 실제로 가르치는 항목 5건(HITL 흐름·정의·Supervisor·Critic·Snapshot) 중 3건 확정 대기
+    conceptCandidateCount: 5,
+    startAt: '2026-07-17T09:00',
+    dueAt: '2026-07-23T18:00',
+    classes: [],
+  },
+  {
+    id: 'mif-3',
+    name: '미프 3차',
+    kind: 'MINI',
+    status: 'RUNNING',
+    curricula: ['AI_LLMOps v2', 'Streamlit 실습 v1'],
+    concepts: ['HITL Trigger', 'Graph 구성', 'State 관리'],
+    conceptCandidateCount: 6,
+    startAt: '2026-07-02T09:00',
+    dueAt: '2026-07-16T18:00',
+    classes: [
+      {
+        className: 'A반',
+        total: 26,
+        attendable: 26,
+        attended: 26,
+        unsubmittedTeams: 2,
+        analysisFailedTeams: 0,
+        interviewCount: 0,
+      },
+      {
+        className: 'B반',
+        total: 26,
+        attendable: 22,
+        attended: 20,
+        unsubmittedTeams: 0,
+        analysisFailedTeams: 0,
+        interviewCount: 0,
+      },
+      {
+        className: 'C반',
+        total: 23,
+        attendable: 23,
+        attended: 12,
+        unsubmittedTeams: 0,
+        analysisFailedTeams: 1,
+        interviewCount: 0,
+      },
+    ],
+  },
+  {
+    id: 'mif-2',
+    name: '미프 2차',
+    kind: 'MINI',
+    status: 'DONE',
+    curricula: ['AI_LLMOps v2'],
+    concepts: ['인증 흐름', '트랜잭션', '캐시 전략'],
+    conceptCandidateCount: 5,
+    startAt: '2026-06-04T09:00',
+    dueAt: '2026-06-18T18:00',
+    classes: [
+      {
+        className: 'A반',
+        total: 26,
+        attendable: 26,
+        attended: 26,
+        unsubmittedTeams: 0,
+        analysisFailedTeams: 0,
+        interviewCount: 2,
+      },
+      {
+        className: 'B반',
+        total: 26,
+        attendable: 26,
+        attended: 26,
+        unsubmittedTeams: 0,
+        analysisFailedTeams: 0,
+        interviewCount: 0,
+      },
+      {
+        className: 'C반',
+        total: 23,
+        attendable: 23,
+        attended: 23,
+        unsubmittedTeams: 0,
+        analysisFailedTeams: 0,
+        interviewCount: 2,
+      },
+    ],
+  },
+  {
+    id: 'mif-1',
+    name: '미프 1차',
+    kind: 'MINI',
+    status: 'DONE',
+    curricula: ['AI_LLMOps v2'],
+    concepts: ['REST 설계', '예외 처리', 'DTO 분리'],
+    conceptCandidateCount: 5,
+    startAt: '2026-05-07T09:00',
+    dueAt: '2026-05-21T18:00',
+    classes: [
+      {
+        className: 'A반',
+        total: 26,
+        attendable: 26,
+        attended: 26,
+        unsubmittedTeams: 0,
+        analysisFailedTeams: 0,
+        interviewCount: 0,
+      },
+      {
+        className: 'B반',
+        total: 26,
+        attendable: 26,
+        attended: 26,
+        unsubmittedTeams: 0,
+        analysisFailedTeams: 0,
+        interviewCount: 0,
+      },
+      {
+        className: 'C반',
+        total: 23,
+        attendable: 23,
+        attended: 23,
+        unsubmittedTeams: 0,
+        analysisFailedTeams: 0,
+        interviewCount: 0,
+      },
+    ],
+  },
+]
+
+/** 이 기수에서 실제로 쓰이는 교안 목록 — 교안 필터 선택지(값은 PROJECTS에서 파생) */
+export const CURRICULUM_OPTIONS: string[] = [...new Set(PROJECTS.flatMap((p) => p.curricula))]
+
+// ── 표시 파생값 ──────────────────────────────────────────────
+
+/** 표시용 "07-16 18:00". 저장은 ISO, 화면에서만 자른다(OP-03 formatDue와 같은 방식) */
+export function formatDue(iso: string): string {
+  return `${iso.slice(5, 10)} ${iso.slice(11, 16)}`
+}
+
+/*
+  목업이 그려진 기준일. 미프 3차(RUNNING)가 마감 직후·응시 창 진행 중이 되는
+  시점으로 잡았다(마감 07-16이 "지남"으로 보이면서도 응시 데이터는 이미 있어야
+  RUNNING이 자연스럽다) — OP-03 `MOCK_TODAY`와 같은 방식(실제 `new Date()`를 쓰면
+  값이 매일 달라져 대조가 안 된다).
+*/
+export const MOCK_TODAY = '2026-07-18'
+
+/** 마감 임박 경고 기준(일). 기획에 없다 — OP-03 `DUE_SOON_DAYS`와 같은 값 */
+export const DUE_SOON_DAYS = 7
+
+const DAY_MS = 86_400_000
+const dateOnly = (iso: string) => new Date(iso.slice(0, 10)).getTime()
+
+export type DueLabel = { text: string; overdue: boolean; urgent: boolean }
+
+/** 마감까지 남은 일수 — "5일 남음"·"지남"(OP-03 `dueLabel`을 그대로 들여옴) */
+export function dueLabel(dueAt: string | null, now: string = MOCK_TODAY): DueLabel | null {
+  if (!dueAt) return null
+  const days = Math.round((dateOnly(dueAt) - dateOnly(now)) / DAY_MS)
+  if (Number.isNaN(days)) return null
+  return days < 0
+    ? { text: '지남', overdue: true, urgent: false }
+    : { text: `${days}일 남음`, overdue: false, urgent: days <= DUE_SOON_DAYS }
+}
+
+/** 진행 열 — 예정은 아직 아무 일도 없고(§notready), 진행 중은 응시 실수, 종료는 발행 완료 */
+export type ProgressCell =
+  { kind: 'RUNNING'; attended: number; attendable: number } | { kind: 'DONE' }
+
+export type ActionItem = { tone: 'warning' | 'danger' | 'todo'; text: string }
+
+/** classFilter가 있으면 그 반 하나만, 없으면 담당 반 합계 — MG-08이 반 단위로 펼 때 쓴다 */
+function scopedClasses(p: Project, classFilter: ClassName | null): ClassProgress[] {
+  if (!classFilter) return p.classes
+  return p.classes.filter((c) => c.className === classFilter)
+}
+
+/**
+ * 진행 열 — 파이프라인 현재 단계 하나만(정의서 §3). 이 데이터셋의 예정 회차는
+ * "아직 아무 일도 없음"이라 제출·분석 단계를 보일 자료가 없으므로 응시·리포트만 있다.
+ */
+export function progressCell(p: Project, classFilter: ClassName | null): ProgressCell | null {
+  if (p.status === 'PLANNED') return null
+  if (p.status === 'DONE') return { kind: 'DONE' }
+
+  const cs = scopedClasses(p, classFilter)
+  const attended = cs.reduce((n, c) => n + c.attended, 0)
+  const attendable = cs.reduce((n, c) => n + c.attendable, 0)
+  return { kind: 'RUNNING', attended, attendable }
+}
+
+/**
+ * 응시 실수 강조 색 — 0/25/50/75/100% 경계로 5단(사용자 지시). 새 토큰을 만들지
+ * 않고 이미 있는 `reach-0~4`(MG-05 개념 도달 5단 스케일)를 재사용한다 — 뜻은
+ * 다르지만 "5단 그라데이션"이 필요한 자리는 같다.
+ */
+export function attendanceReachLevel(attended: number, attendable: number): 0 | 1 | 2 | 3 | 4 {
+  if (attendable <= 0) return 0
+  const ratio = attended / attendable
+  if (ratio >= 1) return 4
+  if (ratio >= 0.75) return 3
+  if (ratio >= 0.5) return 2
+  if (ratio >= 0.25) return 1
+  return 0
+}
+
+/** 담당 반 스코프 문구 — 헤더(`담당 A·B·C반 · 75명`)와 반 필터 라벨이 같이 쓴다 */
+export function scopeLabel(classes: ClassName[], totalByClass: Record<ClassName, number>): string {
+  const total = classes.reduce((n, c) => n + totalByClass[c], 0)
+  return `${classes.join('·')} · ${total}명`
+}
+
+/** 조치 열 — "무엇이 밀렸는지"(정의서 §3). 비어 있으면 정상(축하 문구를 넣지 않는다) */
+export function actionItems(p: Project, classFilter: ClassName | null): ActionItem[] {
+  const cs = scopedClasses(p, classFilter)
+  const prefix = (c: ClassProgress) => (classFilter ? '' : `${c.className} `)
+
+  if (p.status === 'RUNNING') {
+    const items: ActionItem[] = []
+    for (const c of cs) {
+      if (c.unsubmittedTeams > 0) {
+        items.push({ tone: 'warning', text: `${prefix(c)}미제출 ${c.unsubmittedTeams}팀` })
+      }
+      if (c.analysisFailedTeams > 0) {
+        items.push({ tone: 'danger', text: `${prefix(c)}분석 실패 ${c.analysisFailedTeams}팀` })
+      }
+    }
+    return items
+  }
+  if (p.status === 'DONE') {
+    return cs
+      .filter((c) => c.interviewCount > 0)
+      .map((c) => ({ tone: 'todo' as const, text: `${prefix(c)}면담 ${c.interviewCount}명` }))
+  }
+  return []
+}
+
+// ── 정렬 ──────────────────────────────────────────────────────
+// 프로젝트 시작 순 · 마감 임박 순 2종(사용자 지시, 4차 반영).
+
+export type ProjectSort = 'START' | 'DUE'
+
+/** 날짜 하나로 비교. `nullFirst`는 정렬마다 다르다(OP-03 rules.ts byField와 같은 이유) */
+function byField(a: string | null, b: string | null, nullFirst = false): number {
+  if (!a && !b) return 0
+  if (!a) return nullFirst ? -1 : 1
+  if (!b) return nullFirst ? 1 : -1
+  return a.localeCompare(b)
+}
+
+/** 마감이 이미 지났나 — `dueLabel`과 기준일이 같다(MOCK_TODAY) */
+function isOverdue(p: Project): boolean {
+  return p.dueAt !== null && p.dueAt < MOCK_TODAY
+}
+
+/**
+ * 마감 임박 순 — **아직 안 지난 회차를 마감 이른 순으로 먼저**, 그 뒤에 **이미
+ * 지난 회차를 시작 순으로 이어붙인다**(사용자 지시 그대로). 지난 회차끼리는
+ * 마감 순으로 늘어놔 봐야 전부 과거라 의미가 없고, 대신 "어느 게 더 오래된
+ * 회차인가"(시작 순)가 실제로 쓸모 있는 축이라는 뜻으로 이해했다.
+ */
+function compareProjects(a: Project, b: Project, sort: ProjectSort): number {
+  if (sort === 'START') return byField(a.startAt, b.startAt)
+  const aOver = isOverdue(a)
+  const bOver = isOverdue(b)
+  if (aOver !== bOver) return aOver ? 1 : -1
+  return aOver ? byField(a.startAt, b.startAt) : byField(a.dueAt, b.dueAt)
+}
+
+// ── 조회(mock API) ──────────────────────────────────────────
+// 백엔드 연동 시 이 블록만 fetch로 바꾼다 — 화면·컴포넌트는 시그니처가 이미 실제 모양이다.
+
+/** 목 지연 — 로딩 상태가 실제로 보이는지 개발 중 확인하려면 필요하다(OP-03과 같은 값) */
+const LATENCY_MS = 250
+const delay = <T>(value: T): Promise<T> =>
+  new Promise((resolve) => setTimeout(() => resolve(value), LATENCY_MS))
+
+export type ProjectQuery = {
+  search?: string
+  classFilter?: ClassName
+  curriculum?: string
+  kind?: ProjectKind
+  status?: ProjectStatus
+  sort?: ProjectSort
+}
+
+export type ProjectListItem = {
+  project: Project
+  progress: ProgressCell | null
+  actions: ActionItem[]
+}
+
+export type ProjectListResult = {
+  items: ProjectListItem[]
+  total: number
+  /**
+   * 상태별 개수 — **필터와 무관한 전체 모집단 기준**이다(OP-03 `ProjectPage.counts`와
+   * 같은 이유). 상태 필터 옵션에 `전체 (6)`처럼 개수를 실어 "고르기 전에 분포를
+   * 안다"를 준다.
+   */
+  counts: Record<ProjectStatus, number>
+}
+
+/**
+ * `GET /cohorts/{cohortId}/manager/projects` — 담당 반 스코프의 회차 목록.
+ *
+ * 검색·필터·정렬은 서버가 처리한다(OP-03과 같은 경계 원칙). 반 필터는 **그 반
+ * 데이터가 실제로 있는 회차만** 남긴다(예정 회차는 `classes`가 비어 있어 걸러진다)
+ * — 진행·조치 값 자체를 반 단위로 다시 계산하지는 않는다(그건 MG-08 몫).
+ * `PROJECTS_UNAVAILABLE`(케이스 표)은 실제 연동에서만 발생하는 경로라 목에서는
+ * 일부러 던지지 않는다 — 화면의 실패 분기는 `useAsync`가 갖는다.
+ */
+export function listManagerProjects(q: ProjectQuery): Promise<ProjectListResult> {
+  const search = q.search?.trim().toLowerCase() ?? ''
+
+  const filtered = PROJECTS.filter((p) => {
+    if (search && !p.name.toLowerCase().includes(search)) return false
+    if (q.classFilter && !p.classes.some((c) => c.className === q.classFilter)) return false
+    if (q.curriculum && !p.curricula.includes(q.curriculum)) return false
+    if (q.kind && p.kind !== q.kind) return false
+    if (q.status && p.status !== q.status) return false
+    return true
+  })
+
+  const sorted = [...filtered].sort((a, b) => compareProjects(a, b, q.sort ?? 'DUE'))
+
+  const items = sorted.map((project) => ({
+    project,
+    progress: progressCell(project, null),
+    actions: actionItems(project, null),
+  }))
+
+  const counts: Record<ProjectStatus, number> = { PLANNED: 0, RUNNING: 0, DONE: 0 }
+  for (const p of PROJECTS) counts[p.status]++
+
+  return delay({ items, total: items.length, counts })
+}


### PR DESCRIPTION
## 작업 내용

매니저용 프로젝트 목록 화면(MG-07) 구현. 담당 반(A·B·C반) 스코프의 회차를
검색·상태·반·유형·교안으로 좁히고 프로젝트 시작 순/마감 임박 순으로 본다.
표는 프로젝트·유형·상태·반·프로젝트 기간·교안·검증 개념 3건·진행·조치 9열.

컬럼·필터 순서와 항목은 팀장님이 실제로 배포한 OP-03 화면에 맞췄고(정의서
원안과 갈라진 지점 다수), 매니저 전용 계약(상태 3종, 진행 열은 파이프라인
단계 하나, 조치 열은 "무엇이 밀렸는지")은 이 화면이 스스로 정의했다. 갈라진
지점과 판단 근거는 전부 `mockData.ts` 상단 주석(1차~6차 반영)에 기록.

생성 버튼은 없음 — 회차는 오퍼레이터(OP-03)가 만든다.

## 리뷰 포인트

- `mockData.ts` 1~6차 반영 주석 — 정의서 원안 대비 OP-03 정렬로 바뀐 지점들
  (교안 필터, 반 필터 부활, 프로젝트 기간 표시 방식, 정렬 2종·마감 임박 순의
  "안 지난 것 먼저 + 지난 것은 시작 순" 규칙)이 실제로 타당한지
- `ProjectFilters.tsx`의 셀렉트 트리거 고정폭 처리 — 공용 `Select` 컴포넌트를
  고치지 않고 이 필터들만 폭을 고정한 우회가 맞는 방향인지
- `attendanceReachLevel`이 기존 `reach-0~4` 토큰(개념 도달 5단)을 응시율에
  재사용한 것 — 새 토큰을 안 만드는 대신 의미가 다른 곳에 같은 토큰을 쓴 판단

## 확인

- [x] 로컬에서 동작 확인
- [x] 하나의 PR = 하나의 기능

closes #80