### PR TITLE
[Chore] Land session isolation hook and domain rule CI

### DIFF
--- a/.claude/guard-worktree.sh
+++ b/.claude/guard-worktree.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+# 작업 트리를 파괴하는 git 명령을 막는다 — 규약: docs/handbook/git-convention.md §5
+#
+# 왜 필요한가: 터미널·에디터·AI 세션을 여럿 띄워도 작업 트리는 하나다. git에는
+# 세션 격리가 없어서 한쪽의 "잠깐 치움"이 다른 쪽에는 파일 삭제로 보인다.
+# 실제로 `git stash --include-untracked`가 다른 세션의 작업 파일 13개를 두 번 날렸다.
+#
+# git 훅으로는 못 막는다(pre-stash 같은 훅이 없다). 그래서 명령 실행 **전에**
+# Claude Code가 이 스크립트로 검사한다. 사람이 터미널에서 직접 치는 것은 막지 못하므로
+# 최종 방어선은 여전히 규약과 백업이다.
+#
+# 종료 코드 2 = 차단(사유가 Claude에게 전달된다) · 0 = 통과
+
+cmd=$(cat)
+
+block() {
+  echo "$1" >&2
+  echo "" >&2
+  echo "  규약: docs/handbook/git-convention.md §5 (작업 트리는 공유 자원이다)" >&2
+  exit 2
+}
+
+case "$cmd" in
+  # ── untracked를 stash하면 복구 경로가 아예 없다 ──
+  *"git stash"*"--include-untracked"* | *"git stash"*"-u"* | *"git stash"*"--all"*)
+    block "✗ untracked 파일을 stash하지 않습니다.
+
+  untracked는 git 히스토리에 없어서 stash를 잃으면 **복구할 방법이 없습니다.**
+  다른 세션이 방금 만든 파일이 여기 걸립니다.
+
+  대신:
+    · 남의 코드가 깨져 앱이 안 뜨면 → 그 사람에게 말한다(5초면 고친다)
+    · 렌더 확인이 꼭 필요하면 → git worktree로 별도 폴더에 격리한다
+    · 아니면 typecheck·lint로만 검증하고 넘어간다"
+    ;;
+
+  # ── 되돌리기 계열은 남의 미저장 작업을 지운다 ──
+  *"git reset --hard"*)
+    block "✗ git reset --hard는 스테이징까지 통째로 날립니다.
+
+  다른 세션이 올려둔 변경도 같이 사라집니다.
+  되돌릴 대상이 내 커밋이면 'git reset --soft'를 쓰세요."
+    ;;
+
+  *"git clean"*)
+    block "✗ git clean은 untracked 파일을 삭제합니다.
+
+  다른 세션이 작업 중인 새 파일이 여기 걸립니다 — 복구 경로가 없습니다."
+    ;;
+
+  *"git checkout -- "* | *"git checkout ."* | *"git restore "*)
+    block "✗ 작업 트리를 되돌리는 명령입니다.
+
+  대상 파일을 다른 세션이 수정 중이면 그 작업이 사라집니다.
+  정말 내 변경만 되돌리는 것이 확실하면 사람이 직접 실행하세요."
+    ;;
+esac
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,19 @@
 {
   "permissions": {
     "allow": ["mcp__plugin_playwright_playwright__browser_console_messages"]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.command // empty' | sh \"$CLAUDE_PROJECT_DIR/.claude/guard-worktree.sh\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,16 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      # 아래 셋은 typecheck·lint·build가 **전부 통과하는 버그**를 잡는다.
+      # 문법도 타입도 맞는데 규칙이 틀린 것들이라, 여기 없으면 사람이 눈으로 찾게 된다.
+      # (실제로 IME 가드는 사용자가 칩 두 개 생기는 걸 보고 알려줘서 발견했다)
+      #
+      - name: Domain rules
+        run: |
+          npm run check:project
+          npm run check:pagination
+          npm run check:admin
+
       # build = tsc -b && vite build 이므로 타입 검사를 포함한다
       - name: Build
         run: npm run build

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "doc:design": "node scripts/design-doc.mjs",
     "doc:components": "node scripts/component-doc.mjs",
     "check:pagination": "node --experimental-strip-types scripts/check-pagination-range.mts",
-    "check:project": "node --experimental-strip-types scripts/check-project-rules.mts"
+    "check:project": "node --experimental-strip-types scripts/check-project-rules.mts",
+    "check:admin": "node --experimental-strip-types scripts/check-admin-rules.mts"
   },
   "dependencies": {
     "@base-ui/react": "^1.6.0",


### PR DESCRIPTION
## 작업 내용

여러 세션이 한 폴더를 공유하며 작업하다 **어느 브랜치에도 안 올라간 파일**이 로컬에만 남아 있었다. `origin/develop` 위에 얹어 검증하고 올린다.

**세션 격리 가드** — `.claude/guard-worktree.sh`

작업 트리를 파괴하는 git 명령(stash -u · reset --hard · clean · checkout --)을 실행 **전에** 막는다. 여러 세션이 한 폴더를 공유하는데 git에는 세션 격리가 없어서, 한쪽의 "잠깐 치움"이 다른 쪽에는 **파일 삭제**로 보인다 — 실제로 두 번 발생해 작업이 날아갔다(`decision-log.md` D23).

git 훅으로는 못 막는다(`pre-stash` 같은 훅이 없다). 그래서 Claude Code의 `PreToolUse`로 검사한다. **사람이 터미널에서 직접 치는 것은 못 막으므로** 최종 방어선은 여전히 규약과 백업이다.

**CI `Domain rules` 단계**

typecheck·lint·build가 **전부 통과하는 버그**를 잡는 자리다. 문법도 타입도 맞는데 규칙이 틀린 것들이라, 여기 없으면 사람이 눈으로 찾게 된다.

```yaml
- name: Domain rules
  run: |
    npm run check:project
    npm run check:pagination
    npm run check:admin      # <- 이번에 추가
```

`check:admin`은 OP-06 코드(`admin/_/rules.ts`)를 import해서 등록을 미뤄 뒀는데, PR #79·#88로 머지되어 **조건이 충족됐다**(코드에 그 사정이 주석으로 남아 있었고, 이번에 지웠다).

## 리뷰 포인트

- **`check:admin`을 지금 넣어도 되는지** — `admin/_/rules.ts`가 develop에 있는지 확인했다. 없으면 CI가 즉시 깨지는 종류라 등록 시점이 중요하다
- **훅이 못 막는 것** — 스크립트 주석에 한계를 적어 뒀다. 실제로 이 훅은 문서를 쓰는 중에 위험 명령 **문자열**을 오탐해 여러 번 막았다(이 PR 본문을 올릴 때도 걸렸다). 차단이 아니라 보조 수단이라는 전제로 봐 주면 좋겠다

## 이번에 뺀 것

- **한글 IME 입력 가드와 검사기** — 로컬에 `scripts/check-korean-input.mts`와 미리보기 화면이 있지만 **올리지 않았다.** Enter를 쳐야 등록된다는 것을 팀원들이 인지하지 못했다 — **상호작용 자체를 다시 설계해야 한다.** 지금 가드만 올리면 잘못된 방식을 고정하게 된다. 재설계 후 별도 이슈로 올린다.
  그래서 `check:korean`도 `package.json`·CI에 **넣지 않았다** — 스크립트 없이 등록하면 CI가 그 명령에서 깨진다
- **대시보드 목 파일 4종** — 로컬 index에 있던 것은 **초기 초안**이고 PR #87로 완성본이 이미 develop에 있다(대조 결과 78줄 적은 옛 버전). 삭제했다

## 확인

- [x] 로컬에서 동작 확인
- [x] 하나의 PR = 하나의 기능

> 검증 — `origin/develop` 위에 이 파일들만 얹은 worktree에서 `check:project` · `check:pagination` · `check:admin` · `check:design` · typecheck · `format:check` · `build` 전부 통과. lint 지적 6건은 **기존 파일의 기존 warning**이고 이번 변경과 무관함을 대조로 확인했다.

closes #89
