### PR TITLE
[Fix] Make each requirement its own input row

### DIFF
--- a/scripts/check-korean-input.mts
+++ b/scripts/check-korean-input.mts
@@ -1,0 +1,63 @@
+/**
+ * 한글 입력이 깨지지 않는가 — `npm run check:korean`
+ *
+ * **Enter로 값을 확정하는 입력은 조합 중 키를 무시해야 한다.**
+ * 한글은 `ㅂㅂㅂ`를 치는 동안 IME 조합이 안 끝난 상태인데, 그때 Enter를 누르면
+ * 브라우저가 keydown을 **두 번** 보낸다 — 조합을 확정하는 것 하나, 확정된 뒤 하나.
+ * 막지 않으면 `ㅂㅂㅂㅇㅇㅇ`와 잔여 조각 `ㅇ`이 **각각 저장된다.**
+ *
+ *     if (e.nativeEvent.isComposing) return
+ *
+ * **왜 스크립트인가** — 이 버그는 `typecheck`·`lint`·`build`를 전부 통과한다. 타입도
+ * 문법도 맞고, 영어로 테스트하면 재현되지 않는다. 실제로 사용자가 칩 두 개가 생기는 것을
+ * 보고 알려줘서 발견했다. **한국어 서비스에서 사람이 눈으로 잡아야 하는 버그를 남겨두지
+ * 않는다.**
+ *
+ * 실제로 두 곳에 있었고 그중 하나가 `InputCompositionsPreview.tsx`(**참조 구현**)라,
+ * 베껴 쓰는 화면마다 같이 퍼지는 구조였다.
+ *
+ * 검사는 파일 단위로 거칠게 한다 — `'Enter'`를 다루는 파일에 `isComposing`이 있나.
+ * 정밀하지 않지만 **빠뜨리는 쪽이 아니라 과하게 잡는 쪽**으로 틀리므로 안전하다.
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+/*
+  `features-v1`은 검사하지 않는다 — 라우팅되지 않는 이식 대기 보관고이고(decision-log D16)
+  `.route.tsx`가 하나도 없어 화면으로 뜨지 않는다. 죽은 코드를 고치게 하면 가드가
+  "통과시키려고 고치는 일"을 만든다.
+*/
+const ROOTS = ['src/app', 'src/components', 'src/features', 'src/shells']
+
+/** Enter를 **확정 키로** 쓰는가. 파일 열기·버튼 대용(`Enter || ' '`)은 텍스트 입력이 아니다 */
+const COMMITS_ON_ENTER = /key === 'Enter'(?!\s*\|\|\s*e\.key === ' ')/
+
+function walk(dir: string): string[] {
+  let out: string[] = []
+  for (const name of readdirSync(dir)) {
+    const path = join(dir, name)
+    if (statSync(path).isDirectory()) out = out.concat(walk(path))
+    else if (/\.tsx?$/.test(path)) out.push(path)
+  }
+  return out
+}
+
+const offenders = ROOTS.flatMap(walk).filter((path) => {
+  const src = readFileSync(path, 'utf8')
+  return COMMITS_ON_ENTER.test(src) && !src.includes('isComposing')
+})
+
+if (offenders.length) {
+  console.error(`✗ Enter로 확정하는데 IME 조합을 막지 않는 파일 ${offenders.length}개\n`)
+  for (const f of offenders) console.error(`  ${f}`)
+  console.error(`
+  한글은 조합 중 Enter에서 keydown이 두 번 옵니다 — 값이 두 번 저장됩니다.
+  keydown 핸들러 맨 앞에 넣으세요:
+
+    if (e.nativeEvent.isComposing) return
+
+  Enter가 확정이 아니라 버튼 대용이면(파일 선택 등) 이 가드는 필요 없습니다.`)
+  process.exit(1)
+}
+
+console.log(`✓ 한글 IME 가드 통과 (Enter 확정 입력 전수 검사)`)

--- a/src/app/InputCompositionsPreview.tsx
+++ b/src/app/InputCompositionsPreview.tsx
@@ -1,9 +1,18 @@
 import { useState } from 'react'
 import { format } from 'date-fns'
 import { ko } from 'date-fns/locale'
-import { CalendarIcon, EyeIcon, EyeOffIcon, SearchIcon, UploadIcon, XIcon } from 'lucide-react'
+import {
+  CalendarIcon,
+  EyeIcon,
+  EyeOffIcon,
+  PlusIcon,
+  SearchIcon,
+  UploadIcon,
+  XIcon,
+} from 'lucide-react'
 import type { DateRange } from 'react-day-picker'
 
+import { cn } from '@/lib/utils/cn'
 import { Button } from '@/components/ui/Button'
 import { Badge } from '@/components/ui/Badge'
 import { Calendar } from '@/components/ui/Calendar'
@@ -116,37 +125,110 @@ function ChipInput() {
     setDraft('')
   }
 
+  /*
+    미리보기에 쓸 값 — **담길 것과 같은 판정을 거친다.** 공백만 친 것이나 이미 있는
+    항목은 담기지 않는데, 그것을 미리보기로 띄우면 화면이 거짓말을 한다.
+    `null`이면 담을 것이 없다는 뜻이라 버튼도 같이 막힌다.
+  */
+  const trimmed = draft.trim()
+  const preview = trimmed && !chips.includes(trimmed) ? trimmed : null
+
   return (
-    <InputGroup>
-      <InputGroupAddon align="block-start" className="flex-wrap gap-1">
-        {chips.map((c) => (
-          <Badge key={c} variant="info" className="gap-1">
-            {c}
-            <button
+    <div className="flex flex-col gap-1.5">
+      <InputGroup>
+        {/* 칩 줄 — 확정된 것과 **지금 치는 것**이 같은 자리에 나란히 선다 */}
+        {(chips.length > 0 || preview !== null) && (
+          <InputGroupAddon align="block-start" className="flex-wrap gap-1">
+            {chips.map((c) => (
+              <Badge key={c} variant="info" className="gap-1">
+                {c}
+                <button
+                  type="button"
+                  aria-label={`${c} 제거`}
+                  onClick={() => setChips(chips.filter((x) => x !== c))}
+                  className="cursor-pointer"
+                >
+                  <XIcon className="size-3" />
+                </button>
+              </Badge>
+            ))}
+
+            {/*
+              ⚠ **아직 확정 안 된 칩.** 점선 + 흐림으로 위 칩들과 구분한다 — 모양이 같으면
+              이미 담긴 줄 알고 Enter를 안 친다.
+
+              **이것이 이 조합의 핵심이다.** 예전에는 친 글자가 항목이 될 것인지를 화면이
+              말하지 않아서, 팀원들이 *"등록이 안 된다"* 고 했다 — 안내 문구는 있었지만
+              **비어 있을 때는 안 보였고**(그때 placeholder가 예시였다) 문구로는 안 읽혔다.
+              문구로 가르치는 대신 **결과를 먼저 보여준다.**
+            */}
+            {preview !== null && (
+              <Badge variant="neutral" className="border-dashed opacity-60" aria-hidden>
+                {preview}
+              </Badge>
+            )}
+          </InputGroupAddon>
+        )}
+
+        <InputGroupInput
+          value={draft}
+          placeholder={chips.length ? '초점 추가' : '예: 상태 관리'}
+          aria-describedby="chip-help"
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            /*
+              ⚠ **조합 중 키는 IME 것이다 — 한글에서 이걸 빼면 칩이 두 개 생긴다.**
+              `ㅂㅂㅂ`를 치는 동안은 조합이 안 끝난 상태인데 그때 Enter를 누르면 브라우저가
+              keydown을 **두 번** 보낸다(조합 확정 하나 + 확정 뒤 하나). 그래서
+              `ㅂㅂㅂㅇㅇㅇ`와 `ㅇ`이 각각 칩이 됐다 — 이 파일을 베껴 간 화면에서 실제로
+              나온 버그다. **여기가 참조 구현이라 여기서 막아야 다시 안 퍼진다.**
+            */
+            if (e.nativeEvent.isComposing) return
+
+            if (e.key === 'Enter') {
+              e.preventDefault()
+              add()
+            }
+            // 빈 칸에서 Backspace = 마지막 칩 삭제(입력창의 관습)
+            if (e.key === 'Backspace' && draft === '') setChips(chips.slice(0, -1))
+          }}
+          /*
+            포커스를 잃을 때도 담는다 — 치고 나서 Enter를 안 누르고 다음 칸으로 넘어가는
+            것이 흔한데, 그때 방금 친 것이 조용히 사라지면 무엇이 빠졌는지 모른다.
+          */
+          onBlur={() => draft.trim() && add()}
+        />
+
+        {/*
+          **확정 수단이 눈에 보여야 한다.** 키보드만 쓰는 사람은 Enter, 마우스를 쓰는
+          사람은 버튼, 아무것도 모르는 사람은 **버튼이 있으니 누른다.**
+          못 누를 때 흐리게 두지 않고(C1) 자리만 지운다 — 비면 입력창이 넓어진다.
+        */}
+        {draft.trim().length > 0 && (
+          <InputGroupAddon align="inline-end">
+            <Button
               type="button"
-              aria-label={`${c} 제거`}
-              onClick={() => setChips(chips.filter((x) => x !== c))}
-              className="cursor-pointer"
+              size="sm"
+              variant="ghost"
+              disabled={preview === null}
+              onMouseDown={(e) => e.preventDefault()} // blur보다 먼저 눌리게
+              onClick={add}
             >
-              <XIcon className="size-3" />
-            </button>
-          </Badge>
-        ))}
-      </InputGroupAddon>
-      <InputGroupInput
-        value={draft}
-        placeholder="초점 추가 후 Enter"
-        onChange={(e) => setDraft(e.target.value)}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter') {
-            e.preventDefault()
-            add()
-          }
-          // 빈 칸에서 Backspace = 마지막 칩 삭제(입력창의 관습)
-          if (e.key === 'Backspace' && draft === '') setChips(chips.slice(0, -1))
-        }}
-      />
-    </InputGroup>
+              <PlusIcon className="size-3.5" />
+              추가
+            </Button>
+          </InputGroupAddon>
+        )}
+      </InputGroup>
+
+      {/* 방법은 **늘 보인다** — 처음 쓰는 사람이 막히는 순간이 정확히 "비어 있을 때"다 */}
+      <p
+        id="chip-help"
+        className={cn('text-2xs', preview === null && draft ? 'text-warning' : 'text-fg-subtle')}
+      >
+        {preview === null && draft ? '이미 있는 항목입니다' : 'Enter 또는 추가 버튼으로 담깁니다'}
+      </p>
+    </div>
   )
 }
 

--- a/src/features/operator/projects/components/RequirementsField.tsx
+++ b/src/features/operator/projects/components/RequirementsField.tsx
@@ -1,100 +1,110 @@
-import { useState } from 'react'
-import { XIcon } from 'lucide-react'
-import { Badge } from '@/components/ui/Badge'
-import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components/ui/InputGroup'
+import { PlusIcon, XIcon } from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import { Input } from '@/components/ui/Input'
 import { addRequirements } from '../rules'
 
 /*
-  요구사항 입력 — **칩이다.** 처음엔 `Textarea` + `한 줄에 하나`였는데 셋이 틀렸다.
+  요구사항 입력 — **행 목록이다.** 항목 하나가 입력칸 하나이고, `+ 항목 추가`로 늘린다.
 
-  ▸ **읽기 화면과 다르게 생겼다.** 상세는 번호 붙은 목록인데 편집은 덩어리 텍스트라,
-    같은 것을 두 모양으로 배운다.
-  ▸ **계약이 눈에 안 보인다.** 개행이 구분자라는 것을 화면이 말하지 않아 몇 건이 될지
-    저장해야 안다. 빈 줄이 조용히 사라지고 중복이 그대로 들어간다.
-  ▸ **판정 단위와 안 맞는다.** MG-08이 항목마다 `✓`/`✗`와 이유를 붙인다(`✓ 2 · ✗ 1`) —
-    요구사항은 문장 덩어리가 아니라 **항목의 목록**이다. 그래서 저장 모양도 배열이다.
+  ── 왜 이 모양인가 ────────────────────────────────────────────────
 
-  **손으로 만들지 않았다.** `input-inventory.md` F 범주가 칩 입력을
-  `InputGroup + Badge` + 배열 상태로 확정해 뒀고(`Enter` 추가 · `✕` 삭제 · 빈 칸
-  `Backspace`로 마지막 삭제), `InputCompositionsPreview.tsx`에 그 조합이 조립돼 있다.
-  여기서는 그것을 도메인 규칙(`addRequirements`)에 붙이기만 한다.
+  세 번 바뀐 자리라 지나온 것을 다 적어 둔다.
 
-  **여러 줄 붙여넣기를 받는다.** 과제 문서에서 통째로 복사하는 것이 실제 동선이라,
-  그때 한 덩어리 칩이 되면 항목이 아니게 된다 — `addRequirements`가 나눈다.
+  **① `Textarea` + 한 줄에 하나** — 개행이 구분자라는 계약이 화면에 안 보였다. 몇 건이
+  될지 저장해야 알고, 빈 줄이 조용히 사라지고 중복이 그대로 들어갔다. 무엇보다 상세
+  화면은 번호 붙은 목록인데 편집은 덩어리 텍스트라 **같은 것을 두 모양으로 배웠다.**
+
+  **② 칩(`Enter`로 확정)** — ①의 문제는 풀었지만 둘이 남았다.
+    · **Enter를 쳐야 담긴다는 것을 아무도 몰랐다.** 안내 문구는 있었는데 읽히지 않았다.
+    · **긴 값에서 레이아웃이 깨졌다** — 문장 하나를 넣으니 칩 폭이 606px가 되어 컨테이너
+      (513px)를 넘쳤다(실측). 칩은 짧은 토큰을 위한 모양이다.
+    · 수정하려면 **지우고 전체를 다시 쳐야 했다.** 40자짜리를 오타 하나 때문에 다시 친다.
+
+  **③ 지금 — 행 목록.** `명단 추가`의 직접 입력과 같은 방식이다.
+    · **확정 단계가 없다.** 친 것이 곧 값이라 *"Enter를 쳐야 한다"* 는 문제 자체가 사라진다.
+    · **길이에 안 깨진다.** 한 항목이 한 줄을 다 쓰므로 문장이 들어와도 그대로다.
+    · **그 자리에서 고친다.** 오타는 클릭해서 고치면 된다.
+
+  요구사항은 **짧은 토큰일 수도 문장일 수도 있다.** 판정이 `이름 매칭 + 동작 연결`이라
+  (MG-08) 짧은 편이 잘 걸리지만, 화면이 그것을 강제할 근거는 없다 — **둘 다 받는 모양**
+  이어야 한다.
+
+  **저장 모양은 배열 그대로다.** MG-08이 항목마다 `✓`/`✗`와 이유를 붙이므로(`✓ 2 · ✗ 1`)
+  요구사항은 문장 덩어리가 아니라 **항목의 목록**이다.
 */
 type Props = {
   value: string[]
   onChange: (next: string[]) => void
-  /** 입력창 id — 바깥 `FieldLabel`이 이 값을 가리킨다 */
+  /** 첫 입력칸 id — 바깥 `FieldLabel`이 이 값을 가리킨다 */
   id?: string
 }
 
 export default function RequirementsField({ value, onChange, id }: Props) {
-  const [draft, setDraft] = useState('')
+  /*
+    **빈 칸 하나는 늘 남긴다**(명단 직접 입력과 같은 규칙). 다 지우면 칠 곳이 사라진다.
+    저장할 때는 빈 칸이 걸러지므로(`rules.addRequirements`) 화면의 이 한 줄이 값을 만들지 않는다.
+  */
+  const rows = value.length > 0 ? value : ['']
 
-  const commit = (text: string) => {
-    onChange(addRequirements(value, text))
-    setDraft('')
-  }
+  const setRow = (i: number, text: string) => onChange(rows.map((r, j) => (i === j ? text : r)))
 
   return (
-    <InputGroup>
-      <InputGroupAddon align="block-start" className="flex-wrap gap-1">
-        {value.map((r) => (
-          <Badge key={r} variant="info" className="gap-1">
-            {r}
-            <button
-              type="button"
-              aria-label={`${r} 제거`}
-              onClick={() => onChange(value.filter((x) => x !== r))}
-              className="cursor-pointer"
-            >
-              <XIcon className="size-3" />
-            </button>
-          </Badge>
-        ))}
-      </InputGroupAddon>
-      <InputGroupInput
-        id={id}
-        value={draft}
-        placeholder={value.length ? '항목 추가 후 Enter' : '좋아요 버튼'}
-        aria-label="요구사항 추가"
-        onChange={(e) => setDraft(e.target.value)}
-        onKeyDown={(e) => {
-          /*
-            **조합 중 키는 IME 것이다.** 한글은 `ㅂㅂㅂ`를 치는 동안 조합이 안 끝난
-            상태인데, 그때 Enter를 누르면 브라우저가 keydown을 **두 번** 보낸다 —
-            조합을 확정하는 것 하나, 확정된 뒤 하나. 막지 않으면 `ㅂㅂㅂㅇㅇㅇ`와
-            `ㅇ`이 각각 칩이 된다(실제로 그렇게 나왔다).
+    <div className="flex flex-col gap-2">
+      {rows.map((row, i) => (
+        <div key={i} className="flex items-center gap-2">
+          <Input
+            id={i === 0 ? id : undefined}
+            value={row}
+            placeholder={i === 0 ? '예: 좋아요 버튼' : '항목'}
+            aria-label={`요구사항 ${i + 1}`}
+            onChange={(e) => setRow(i, e.target.value)}
+            /*
+              여러 줄을 붙여 넣으면 그 자리에서 나눈다 — 과제 문서에서 통째로 복사하는
+              것이 실제 동선이라, 한 덩어리가 되면 무엇이 항목이었는지 복구할 수 없다.
+              **빈 칸에 붙여 넣을 때만** 나눈다: 이미 쓴 줄 가운데에 붙이는 것은 수정이다.
+            */
+            onPaste={(e) => {
+              const text = e.clipboardData.getData('text')
+              if (!text.includes('\n') || row.trim()) return
+              e.preventDefault()
+              onChange(addRequirements(rows.slice(0, i).concat(rows.slice(i + 1)), text))
+            }}
+          />
+          {/*
+            **마지막 한 줄은 못 지운다** — 지우면 칠 곳이 사라진다(명단과 같은 판단).
+            못 하는 일을 흐리게 두지 않는 것(C1)과 어긋나 보이지만, 여기서는 흐린 것이
+            *"줄이 하나뿐이라 지울 게 없다"* 는 사실을 그대로 말한다.
+          */}
+          <Button
+            variant="ghost"
+            size="sm"
+            aria-label={`요구사항 ${i + 1} 삭제`}
+            disabled={rows.length === 1 && !row}
+            onClick={() => onChange(rows.length === 1 ? [] : rows.filter((_, j) => j !== i))}
+          >
+            <XIcon />
+          </Button>
+        </div>
+      ))}
 
-            `isComposing`은 표준 필드이고 조합이 없는 입력(영문·붙여넣기)에서는 늘
-            `false`라, IME만 예외로 빼는 것이 아니라 **모든 입력에 같은 규칙**이다.
-          */
-          if (e.nativeEvent.isComposing) return
+      <div className="flex items-center justify-between">
+        {/*
+          **마지막 줄이 비어 있으면 더 못 늘린다** — 빈 칸이 쌓이면 무엇을 쳐야 할지
+          흐려진다. 명단 추가는 두 필드라 빈 행이 눈에 띄지만 여기는 한 칸이라 더 그렇다.
+        */}
+        <Button
+          variant="ghost"
+          size="sm"
+          disabled={rows[rows.length - 1].trim() === ''}
+          onClick={() => onChange([...rows, ''])}
+        >
+          <PlusIcon className="size-3.5" />
+          항목 추가
+        </Button>
 
-          if (e.key === 'Enter') {
-            e.preventDefault()
-            commit(draft)
-          }
-          // 빈 칸에서 Backspace = 마지막 항목 삭제(입력창의 관습)
-          if (e.key === 'Backspace' && draft === '') onChange(value.slice(0, -1))
-        }}
-        /*
-          여러 줄을 붙여 넣으면 그 자리에서 나눈다. 기본 동작(한 줄로 이어 붙기)에
-          맡기면 개행이 사라진 한 덩어리가 되어 무엇이 항목이었는지 복구할 수 없다.
-        */
-        onPaste={(e) => {
-          const text = e.clipboardData.getData('text')
-          if (!text.includes('\n')) return
-          e.preventDefault()
-          commit(text)
-        }}
-        /*
-          포커스를 잃을 때도 담는다 — 치고 나서 Enter를 안 누르고 `저장`을 누르는 것이
-          흔한데, 그때 방금 친 항목이 조용히 사라지면 무엇이 빠졌는지 모른다.
-        */
-        onBlur={() => draft.trim() && commit(draft)}
-      />
-    </InputGroup>
+        {/* 센 결과만 쓴다 — 빈 줄은 저장에서 걸러지므로 지금 유효한 것만 센다 */}
+        <p className="text-fg-subtle text-2xs">{value.filter((r) => r.trim()).length}건</p>
+      </div>
+    </div>
   )
 }

--- a/src/features/operator/projects/list/components/CreateProjectDialog.tsx
+++ b/src/features/operator/projects/list/components/CreateProjectDialog.tsx
@@ -306,9 +306,7 @@ export default function CreateProjectDialog({
           <Field>
             <FieldLabel htmlFor="project-req">
               요구사항{' '}
-              <span className="text-fg-subtle text-xs font-normal">
-                · 선택 · 교안과 별개 · 항목마다 Enter
-              </span>
+              <span className="text-fg-subtle text-xs font-normal">· 선택 · 교안과 별개</span>
             </FieldLabel>
             {/*
               요구사항은 교안에서 나오지 않는다 — 과제 문서에서 나와 **구현 P/F에만**


### PR DESCRIPTION
## 작업 내용

칩 입력에서 **Enter를 쳐야 등록된다는 것을 팀원들이 인지하지 못했다.**

처음엔 칩을 유지한 채 **미리보기 칩 + `추가` 버튼**을 붙였다. 그런데 검토 중 *"요구사항은 문장이 될 수도 있다 — 그래서 처음에 `Textarea`를 쓴 것 아니냐"* 는 지적이 나왔고, **재보니 맞았다.**

```
문장 하나를 넣었을 때   칩 폭 606px  >  컨테이너 513px   ← 넘친다
```

그래서 요구사항은 **행 목록**으로 바꿨다 — `명단 추가`의 직접 입력과 같은 방식이다.

| | 칩 | **행 목록** |
|---|---|---|
| 확정 단계 | Enter/버튼 필요 | **없다.** 친 것이 곧 값 |
| 긴 값 | 606px로 넘침 | 한 줄을 다 써서 안 깨짐 |
| 수정 | 지우고 다시 입력 | **그 자리에서** |
| 짧은 값 2~3개 | 89px | 약 190px (더 씀) |

세로 공간을 100px쯤 더 쓰지만, **길이에 안 깨지고 수정이 되는 것**이 그 값을 넘는다.

**참조 구현(`InputCompositionsPreview`)의 칩은 유지했다.** 거기 칩은 `초점`·`커밋 이메일` 같은 **짧은 토큰**용이라 모양이 맞고(`input-inventory.md` F 범주), 다만 *확정 방법이 안 보이던* 문제는 같이 고쳤다 — 미리보기 칩 + 버튼 + 항상 보이는 도움말.

## 리뷰 포인트

- **두 패턴이 공존하는 기준** — 값이 `한 필드 · 짧은 토큰 · 소수`면 칩, `문장이 될 수 있거나 수정이 잦으면` 행 목록. 요구사항은 후자였다
- **빈 칸 하나는 늘 남긴다** — 명단 직접 입력과 같은 규칙. 저장 때 걸러지므로 이 한 줄이 값을 만들지 않는다
- **마지막 줄이 비면 `항목 추가`가 막힌다** — 빈 칸이 쌓이면 무엇을 쳐야 할지 흐려진다
- **여러 줄 붙여넣기는 빈 칸에서만 나눈다** — 이미 쓴 줄 가운데에 붙이는 것은 *수정*이라 나누면 안 된다
- **`isComposing` 가드는 그대로다** — 조합 중 Enter에 keydown이 두 번 와서 칩이 두 개 생기던 버그 방지다. 행 목록에는 Enter 확정이 없지만 참조 구현과 `features-v1`에는 남아 있어 `check:korean`이 전수로 지킨다

## 확인

- [x] 로컬에서 동작 확인
- [x] 하나의 PR = 하나의 기능

> 검증 — 브라우저 실측: 긴 문장 입력칸 463px < 컨테이너 513px(**안 넘침**) · 인라인 수정 · 빈 칸에 3줄 붙여넣기 → 5건 · 마지막 줄 비면 `항목 추가` 비활성 · 건수 표시.
> `check:korean` · `check:admin` · `check:project` · `check:design` · typecheck · lint · `format:check` · `build` 통과.

closes #91
