### PR TITLE
[Feat] Add TR-01 Trainee Home Screen

### DIFF
--- a/src/features/trainee/home/HomeScreen.tsx
+++ b/src/features/trainee/home/HomeScreen.tsx
@@ -1,11 +1,140 @@
+import { useCallback } from 'react'
+import { Link, useSearchParams } from 'react-router'
+import { Button } from '@/components/ui/Button'
+import { Card } from '@/components/ui/Card'
+import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from '@/components/ui/Empty'
+import { Spinner } from '@/components/ui/Spinner'
+import { useAsync } from '@/lib/useAsync'
 import ConsoleShell from '@/shells/ConsoleShell'
-import PlaceholderScreen from '@/app/PlaceholderScreen'
+import { getHome } from './api'
+import RoundListRow from './components/RoundListRow'
+import StatusCard from './components/StatusCard'
+import type { RoundStatus } from './types'
 
-/** TR-01 홈 — 화면 이식 전 자리표시. 실제 화면이 들어오면 이 파일 내용만 바뀐다. */
+/*
+  TR-01 교육생 홈 — "지금 무엇을 해야 하는지" 카드 하나.
+
+  상태 9종(회차 없음 포함)은 전부 서버가 정한 `currentRound.status` 하나로 갈린다 —
+  화면이 제출·분석·응시 여부를 조합해 유추하지 않는다(api-boundary.md §1 ②).
+
+  ?state= 는 API 명세가 없는 지금, 상태 9종 + 조회 실패를 눌러서 확인하기 위한
+  dev 전용 오버라이드다(mock-first-screens.md §1-4 "조건 × 상태 표"). 연동 시
+  `api.ts`의 `previewStatus` 파라미터와 함께 지운다 — 실서버는 이 값을 안 받는다.
+*/
+const PREVIEW_TO_STATUS: Record<string, RoundStatus | 'NONE' | 'ERROR'> = {
+  todo: 'NOT_SUBMITTED',
+  analyzing: 'ANALYZING',
+  ready: 'READY_TO_VERIFY',
+  done: 'VERIFY_DONE',
+  retry: 'RETRY_AVAILABLE',
+  failed: 'ANALYSIS_FAILED',
+  closed: 'VERIFICATION_CLOSED',
+  missed: 'SUBMISSION_CLOSED',
+  none: 'NONE',
+  error: 'ERROR',
+}
+
 export default function HomeScreen() {
+  const [searchParams] = useSearchParams()
+  const previewKey = searchParams.get('state')
+  const previewStatus = previewKey ? PREVIEW_TO_STATUS[previewKey] : undefined
+
+  const load = useCallback(() => getHome(previewStatus), [previewStatus])
+  const page = useAsync(load)
+
   return (
     <ConsoleShell role="trainee">
-      <PlaceholderScreen code="TR-01" title="홈" />
+      <div className="mx-auto max-w-[860px]">
+        {page.loading ? (
+          <div className="flex justify-center py-16">
+            <Spinner className="size-6" aria-label="홈을 불러오는 중" />
+          </div>
+        ) : page.failed || !page.data ? (
+          <Empty className="border-solid bg-danger-soft border-danger-border">
+            <EmptyHeader>
+              <EmptyTitle>홈을 불러오지 못했습니다</EmptyTitle>
+              <EmptyDescription>잠시 후 다시 시도해 주세요.</EmptyDescription>
+            </EmptyHeader>
+            <Button variant="ghost" onClick={page.reload}>
+              다시 시도
+            </Button>
+          </Empty>
+        ) : (
+          <div className="flex flex-col gap-6">
+            <div>
+              <div className="mb-2 text-xs font-semibold text-fg-subtle">지금 할 일</div>
+              {page.data.currentRound ? (
+                <StatusCard round={page.data.currentRound} onVerifyWindowExpire={page.reload} />
+              ) : (
+                <Card className="bg-surface-2 p-5">
+                  <div className="text-sm text-fg-subtle">
+                    {page.data.scope.cohort} · {page.data.scope.classTeam}
+                  </div>
+                  <h3 className="mt-1 text-lg font-semibold text-fg">
+                    지금은 예정된 일정이 없어요
+                  </h3>
+                  <p className="mt-2 text-sm text-fg-muted">
+                    다음 프로젝트가 시작되면 여기에 표시됩니다.
+                  </p>
+                </Card>
+              )}
+            </div>
+
+            {page.data.currentRound?.status === 'RETRY_AVAILABLE' && (
+              <div>
+                <div className="mb-2 text-xs font-semibold text-fg-subtle">이번 회차 리포트</div>
+                <Card className="gap-0 divide-y divide-border py-0">
+                  <RoundListRow
+                    kind="past"
+                    label={page.data.currentRound.roundLabel}
+                    detail="발행됨 · 자세한 해설은 다시 보기 후 열려요"
+                    to={`/trainee/report?round=${page.data.currentRound.reportRoundId}`}
+                  />
+                </Card>
+              </div>
+            )}
+
+            {page.data.upcomingRound && (
+              <div>
+                <div className="mb-2 text-xs font-semibold text-fg-subtle">예정</div>
+                <Card className="gap-0 divide-y divide-border py-0">
+                  <RoundListRow
+                    kind="upcoming"
+                    label={page.data.upcomingRound.roundLabel}
+                    detail={page.data.upcomingRound.scheduleLabel}
+                  />
+                </Card>
+              </div>
+            )}
+
+            <div>
+              <div className="mb-2 flex items-center justify-between text-xs font-semibold text-fg-subtle">
+                지난 회차
+                <Link to="/trainee/report" className="font-medium text-primary hover:underline">
+                  전체 보기 → 내 리포트
+                </Link>
+              </div>
+              {page.data.pastRounds.length === 0 ? (
+                <Empty>
+                  <EmptyDescription>아직 지난 회차가 없어요.</EmptyDescription>
+                </Empty>
+              ) : (
+                <Card className="gap-0 divide-y divide-border py-0">
+                  {page.data.pastRounds.map((r) => (
+                    <RoundListRow
+                      key={r.id}
+                      kind="past"
+                      label={r.roundLabel}
+                      detail={r.summary}
+                      to={`/trainee/report?round=${r.id}`}
+                    />
+                  ))}
+                </Card>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
     </ConsoleShell>
   )
 }

--- a/src/features/trainee/home/api.ts
+++ b/src/features/trainee/home/api.ts
@@ -1,0 +1,26 @@
+import type { HomeView, RoundStatus } from './types'
+import { buildHomeFixture } from './mockDb'
+
+/*
+  경계 — 화면이 유일하게 의존하는 곳(api-boundary.md §3). 실제 시그니처 그대로 두고
+  내부만 목이다. 연동 시 이 파일만 고친다.
+*/
+
+const LATENCY_MS = 250
+
+const delay = <T>(value: T): Promise<T> =>
+  new Promise((resolve) => setTimeout(() => resolve(value), LATENCY_MS))
+
+/**
+ * @param previewStatus 개발 중 상태 9종 + 조회 실패를 확인하기 위한 dev 전용
+ *   오버라이드(`/trainee/home?state=ready`, `?state=error`). 연동 시 이 파라미터와
+ *   함께 지운다 — 상태는 서버가 정한다(api-boundary.md §1 ②).
+ */
+export function getHome(previewStatus?: RoundStatus | 'NONE' | 'ERROR'): Promise<HomeView> {
+  // ===== Mock 버전 (현재 활성) =====
+  if (previewStatus === 'ERROR') {
+    return Promise.reject(new Error('HOME_FETCH_FAILED'))
+  }
+  return delay(buildHomeFixture(previewStatus ?? 'NOT_SUBMITTED', Date.now()))
+  // return http<HomeView>('/home')
+}

--- a/src/features/trainee/home/components/RoundListRow.tsx
+++ b/src/features/trainee/home/components/RoundListRow.tsx
@@ -1,0 +1,33 @@
+import { Link } from 'react-router'
+
+/** "예정" 회차 한 줄 또는 "지난 회차" 한 줄 — 둘 다 같은 배치(이름+설명 좌 · 태그/링크 우)를 쓴다 */
+type Props =
+  | { kind: 'upcoming'; label: string; detail: string }
+  | { kind: 'past'; label: string; detail: string; to: string }
+
+export default function RoundListRow(props: Props) {
+  return (
+    // 높이를 padding(py-2.5)이 아니라 고정값(h-11)으로 준다 — divide-y의 1px 선은
+    // 어느 행이 갖든(border-top 또는 border-bottom) border-box 계산에 실제로 더해져
+    // 그 행만 1px 커진다(실측 확인). 높이를 고정하면 선이 있는 행도 없는 행도 똑같은
+    // 바깥 높이를 갖는다 — 44px는 터치 타깃 권장값과도 맞아떨어진다.
+    <div className="flex h-11 items-center justify-between gap-3 px-4 text-sm">
+      <div className="min-w-0">
+        <span className="font-medium text-fg">{props.label}</span>
+        <span className="ml-2 text-fg-subtle">{props.detail}</span>
+      </div>
+      {props.kind === 'upcoming' ? (
+        <span className="shrink-0 rounded-full bg-surface-2 px-2 py-0.5 text-xs whitespace-nowrap text-fg-subtle">
+          예정
+        </span>
+      ) : (
+        <Link
+          to={props.to}
+          className="shrink-0 text-xs font-medium whitespace-nowrap text-primary hover:underline"
+        >
+          리포트 보기 →
+        </Link>
+      )}
+    </div>
+  )
+}

--- a/src/features/trainee/home/components/StatusCard.tsx
+++ b/src/features/trainee/home/components/StatusCard.tsx
@@ -1,0 +1,106 @@
+import { Link } from 'react-router'
+import { Button } from '@/components/ui/Button'
+import { Card } from '@/components/ui/Card'
+import { formatClock } from '@/lib/format'
+import { cn } from '@/lib/utils/cn'
+import { buildStatusContent, type StripTone } from '../labels'
+import type { CurrentRound } from '../types'
+import { useCountdown } from '../useCountdown'
+import StepTracker from './StepTracker'
+
+/** 훅은 조건 없이 불러야 해서, 응시 가능이 아닐 때는 절대 안 닿는 더미 마감을 준다 */
+const FAR_FUTURE = '2999-01-01T00:00:00Z'
+
+const STRIP_TONE_CLASS: Record<StripTone, string> = {
+  warn: 'bg-warning-soft text-warning',
+  go: 'bg-success-soft text-success',
+  stop: 'bg-danger-soft text-danger',
+}
+
+const MUTE_STATUSES: CurrentRound['status'][] = ['SUBMISSION_CLOSED', 'VERIFICATION_CLOSED']
+
+/**
+ * TR-01 "지금 할 일" 카드 — 상태 9종(진행 중인 회차 없음 제외)이 전부 이 셸의 variant다.
+ * 목업에서도 `missed`·`closed`는 별도 컴포넌트가 아니라 같은 카드의 회색 variant다.
+ */
+export default function StatusCard({ round, onVerifyWindowExpire }: Props) {
+  const isReady = round.status === 'READY_TO_VERIFY'
+  const liveMs = useCountdown(
+    isReady ? round.verifyClosesAt : FAR_FUTURE,
+    isReady ? onVerifyWindowExpire : undefined,
+  )
+  const content = buildStatusContent(round, Date.now())
+  const isMute = MUTE_STATUSES.includes(round.status)
+
+  return (
+    <div className="flex flex-col gap-3">
+      {content.steps && <StepTracker steps={content.steps} />}
+
+      <Card className={cn('gap-0 py-0', isMute && 'bg-surface-2')}>
+        {content.strip && (
+          <div
+            className={cn(
+              'flex items-center justify-between px-5 py-2.5 text-sm font-medium',
+              STRIP_TONE_CLASS[content.strip.tone],
+            )}
+          >
+            <span>
+              <span className="text-base font-bold">
+                {isReady ? formatClock(liveMs) : content.strip.big}
+              </span>{' '}
+              남음
+            </span>
+            <span className="text-xs font-normal opacity-80">{content.strip.at}</span>
+          </div>
+        )}
+
+        <div className="flex flex-col gap-3 p-5">
+          <div className="text-sm text-fg-subtle">
+            {round.roundLabel}{' '}
+            <span>
+              · {round.classTeam} · 교안 {round.curriculum}
+            </span>
+          </div>
+
+          <h3 className="text-lg font-semibold text-fg">{content.title}</h3>
+
+          <div className="flex flex-col gap-2 text-sm text-fg-muted">
+            {content.guide.map((line, i) => (
+              <div key={i} className="flex gap-2">
+                <line.icon aria-hidden="true" className="mt-0.5 size-4 shrink-0 text-fg-subtle" />
+                <span>{line.text}</span>
+              </div>
+            ))}
+          </div>
+
+          {content.cta && (
+            <div className="mt-1 flex items-center justify-between gap-3">
+              {content.cta.aside && (
+                <span className="text-xs text-fg-subtle">{content.cta.aside}</span>
+              )}
+              {content.cta.to ? (
+                <Button
+                  variant={content.cta.variant}
+                  nativeButton={false}
+                  render={<Link to={content.cta.to} />}
+                >
+                  {content.cta.label}
+                </Button>
+              ) : (
+                <Button variant={content.cta.variant} disabled={content.cta.disabled}>
+                  {content.cta.label}
+                </Button>
+              )}
+            </div>
+          )}
+        </div>
+      </Card>
+    </div>
+  )
+}
+
+type Props = {
+  round: CurrentRound
+  /** 응시 창이 화면을 띄워 둔 채로 닫히는 순간 한 번 호출된다 — 서버 재조회 트리거 */
+  onVerifyWindowExpire: () => void
+}

--- a/src/features/trainee/home/components/StepTracker.tsx
+++ b/src/features/trainee/home/components/StepTracker.tsx
@@ -1,0 +1,46 @@
+import { CheckIcon } from 'lucide-react'
+import { cn } from '@/lib/utils/cn'
+import { STEP_LABELS, type StepState } from '../labels'
+
+/*
+  4단계 진행 바 — 제출·분석·이해도 확인·리포트. 상태 9종 중 진행 중인 5종에서만 쓴다.
+
+  이전 버전은 16px 원 안의 숫자/체크 하나로만 "지금 단계"를 표시해 4개가 한 줄에
+  늘어서면 눈에 잘 안 띄었다(실사용 피드백으로 발견). 지금 단계는 원이 아니라
+  세그먼트 전체를 진하게 채워 크기·색 모두로 확실히 튀게 하고, 지난 단계는 연한
+  성공색 배지, 남은 단계는 테두리만 있는 pill로 세 상태가 한눈에 구분되게 한다.
+
+  now는 검정(bg-fg) 채움이었다가 다시 손봤다 — CTA와 겹치는 문제는 피했지만, 무채색
+  채움은 "비활성·닫힘"으로 읽혀 done(연초록)보다 오히려 무겁고 꺼져 보였다(실사용
+  피드백으로 발견, 20년차 UX 재검토). 색이 아니라 **형태**로 CTA와 구분한다 — CTA는
+  항상 꽉 찬 도형이니, now는 primary색을 다시 쓰되 꽉 채우지 않고 **링 + 연한 배경**
+  으로 그린다. 채움 vs 테두리는 "버튼"과 "상태 표시"를 형태만으로도 가르는 흔한
+  관용구라(GitHub PR 스테퍼 등) 같은 색이어도 헷갈리지 않는다.
+*/
+export default function StepTracker({ steps }: { steps: StepState[] }) {
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      {STEP_LABELS.map((label, i) => (
+        <div key={label} className="flex shrink-0 items-center gap-1.5">
+          {i > 0 && (
+            <span aria-hidden="true" className="text-fg-subtle">
+              →
+            </span>
+          )}
+          <span
+            className={cn(
+              'flex items-center gap-1 whitespace-nowrap rounded-full',
+              steps[i] === 'done' && 'bg-success-soft px-2.5 py-1 text-xs font-medium text-success',
+              steps[i] === 'now' &&
+                'border-1 border-primary bg-primary-soft px-2.5 py-1 text-sm font-bold text-primary',
+              steps[i] === 'pending' && 'border border-border px-2.5 py-1 text-xs text-fg-subtle',
+            )}
+          >
+            {steps[i] === 'done' && <CheckIcon className="size-3" />}
+            {label}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/features/trainee/home/labels.ts
+++ b/src/features/trainee/home/labels.ts
@@ -1,0 +1,236 @@
+import {
+  ArrowRightIcon,
+  CheckIcon,
+  ClockIcon,
+  EyeOffIcon,
+  InfoIcon,
+  MessageCircleIcon,
+  RotateCcwIcon,
+  TriangleAlertIcon,
+  UploadIcon,
+  XCircleIcon,
+  type LucideIcon,
+} from 'lucide-react'
+import {
+  formatClock,
+  formatCoarse,
+  formatDate,
+  formatDateKorean,
+  formatDateTime,
+} from '@/lib/format'
+import type { CurrentRound } from './types'
+
+/*
+  표시 라벨 — **화면 것**(api-boundary §1-⑤). 연동해도 남는다.
+
+  상태별 문구를 Record 여러 벌(제목·가이드·CTA...)로 흩어두지 않고 `buildStatusContent`
+  하나의 switch로 모았다 — Record<RoundStatus, (round: CurrentRound) => T> 형태로 짜면
+  TS가 함수 내부에서 round를 그 상태로 좁혀주지 않아 각 함수가 다시 `if (round.status !== ...)`
+  가드를 반복해야 한다. switch 한 곳이면 case별로 자동으로 좁혀진다.
+
+  문구는 목업(trainee/home.html) 각 .rpage에서 그대로 옮겼다 — 문구는 계약이다(00-index).
+  굵게(<b>) 표시는 타이포그래피라 여기서는 안 옮기고 컴포넌트가 필요하면 얹는다.
+
+  아이콘은 유니코드 손글씨 글리프(↥ ◇ – 등) 대신 lucide-react를 쓴다 — 사이드바가
+  이미 그렇게 하고 있고(sidebarConfig.ts "폰트마다 다르게 그려지고 접근성 트리에도
+  의미 없는 문자로 잡힌다"), 같은 뜻은 화면이 달라도 같은 아이콘이어야 한다("잠김"은
+  어디서나 LockIcon, "숨김"은 어디서나 EyeOffIcon).
+
+  ANALYZING의 "남은 시간은 알려드리지 않아요 — 정확하지 않은 예상을 드리지 않으려고요"
+  줄은 지웠다 — 바로 위 줄("끝나면 알려드릴게요")이 이미 같은 사실을 긍정형으로
+  전달한다. 이 줄은 그 사실의 **이유**(왜 안 보여주는지, 내부 정책)를 사용자에게
+  설명하는 것이었는데, 사용자가 알아야 할 것은 "무슨 일이 일어나는가"이지 "우리가
+  왜 그렇게 결정했는가"가 아니다(실사용 피드백으로 발견).
+*/
+
+export type GuideLine = { icon: LucideIcon; text: string }
+export type StepState = 'done' | 'now' | 'pending'
+export type StripTone = 'warn' | 'go' | 'stop'
+
+export const STEP_LABELS = ['코드 제출', '코드 분석', '이해도 확인', '리포트'] as const
+
+export type StatusContent = {
+  title: string
+  steps: StepState[] | null
+  strip: { tone: StripTone; big: string; at: string } | null
+  guide: GuideLine[]
+  cta: {
+    label: string
+    to?: string
+    variant?: 'primary' | 'ghost'
+    disabled?: boolean
+    aside?: string
+  } | null
+}
+
+export function buildStatusContent(round: CurrentRound, now: number): StatusContent {
+  switch (round.status) {
+    case 'NOT_SUBMITTED': {
+      const dueMs = new Date(round.submissionDueAt).getTime() - now
+      return {
+        title: '코드를 제출할 차례예요',
+        steps: ['now', 'pending', 'pending', 'pending'],
+        strip: {
+          tone: 'warn',
+          big: formatCoarse(dueMs),
+          at: `제출 마감 ${formatDateTime(round.submissionDueAt)}`,
+        },
+        guide: [
+          { icon: UploadIcon, text: 'GitHub 저장소 주소나 ZIP 파일로 제출해요.' },
+          {
+            icon: ArrowRightIcon,
+            text: '제출하면 코드 분석이 시작돼요. 분석이 끝난 시각부터 24시간 안에 이해도 확인을 하면 됩니다.',
+          },
+        ],
+        cta: { label: '코드 제출', to: '/trainee/submission', variant: 'primary' },
+      }
+    }
+
+    case 'ANALYZING':
+      return {
+        title: '코드 분석이 진행 중이에요',
+        steps: ['done', 'now', 'pending', 'pending'],
+        strip: null,
+        guide: [{ icon: ClockIcon, text: '끝나면 알려드릴게요. 이 화면을 켜 두지 않아도 됩니다.' }],
+        cta: { label: '이해도 확인', disabled: true, aside: '분석이 끝나면 열려요' },
+      }
+
+    case 'ANALYSIS_FAILED': {
+      const dueMs = new Date(round.submissionDueAt).getTime() - now
+      return {
+        title: '코드를 분석하지 못했어요',
+        steps: ['done', 'now', 'pending', 'pending'],
+        strip: {
+          tone: 'stop',
+          big: formatCoarse(dueMs),
+          at: `제출 마감 ${formatDateTime(round.submissionDueAt)}`,
+        },
+        guide: [
+          { icon: TriangleAlertIcon, text: round.failureReason },
+          {
+            icon: ArrowRightIcon,
+            text: '조직 밖 저장소라면 ZIP으로 올리면 됩니다. 계속 안 되면 매니저에게 알려 주세요.',
+          },
+        ],
+        cta: { label: '다시 제출', to: '/trainee/submission', variant: 'primary' },
+      }
+    }
+
+    case 'READY_TO_VERIFY': {
+      const closesMs = new Date(round.verifyClosesAt).getTime() - now
+      // ponytail: "지금 시작하면 새벽 3시 전에 끝나요"의 새벽/오전 같은 한국어 하루 표현은
+      // 만들지 않는다 — 24시간제 시각만 보여줘도 같은 정보를 준다. 하루 구간 이름이
+      // 필요해지면 그때 넣는다.
+      const finishBy = new Date(now + 40 * 60_000)
+      return {
+        title: '이해도 확인을 시작할 차례예요',
+        steps: ['done', 'done', 'now', 'pending'],
+        strip: {
+          tone: 'go',
+          big: formatClock(closesMs),
+          at: `${formatDateTime(round.verifyClosesAt)}까지`,
+        },
+        guide: [
+          {
+            icon: MessageCircleIcon,
+            text: '내가 쓴 코드 3군데에 대해 왜 그렇게 했는지 이야기하는 시간이에요.',
+          },
+          {
+            icon: ClockIcon,
+            text: '보통 30~40분, 잘 답할수록 길어질 수 있어요. 시작하면 중간에 나갈 수 없으니 시간이 되는 때에 시작하세요.',
+          },
+          {
+            icon: EyeOffIcon,
+            text: '점수는 표시되지 않아요. 모르면 다시 설명해 달라고 할 수 있고, 그걸 써도 불이익이 없어요.',
+          },
+        ],
+        cta: {
+          label: '이해도 확인 시작하기 →',
+          to: '/trainee/session',
+          variant: 'primary',
+          aside: `지금 시작하면 ${String(finishBy.getHours()).padStart(2, '0')}:${String(finishBy.getMinutes()).padStart(2, '0')}까지 끝나요`,
+        },
+      }
+    }
+
+    case 'VERIFY_DONE':
+      return {
+        title: '리포트를 기다리는 중이에요',
+        steps: ['done', 'done', 'done', 'now'],
+        strip: null,
+        guide: [
+          {
+            icon: CheckIcon,
+            text: `이해도 확인이 끝났어요. ${formatDateTime(round.verifiedAt)} 제출됨.`,
+          },
+          {
+            icon: ArrowRightIcon,
+            text: '리포트는 회차 마감 후 한꺼번에 발행됩니다. 발행되면 알려드릴게요.',
+          },
+        ],
+        cta: {
+          label: '내 리포트',
+          disabled: true,
+          aside: `발행 예정 ${formatDate(round.reportAfter)} 이후`,
+        },
+      }
+
+    case 'RETRY_AVAILABLE':
+      return {
+        title: `다시 볼 수 있는 문제가 ${round.retryConcepts.length}개 있어요`,
+        steps: ['done', 'done', 'done', 'now'],
+        strip: {
+          tone: 'warn',
+          big: formatCoarse(new Date(round.retryDueAt).getTime() - now),
+          at: `${formatDate(round.retryDueAt)}까지`,
+        },
+        guide: [
+          {
+            icon: RotateCcwIcon,
+            text: `${round.retryConcepts.join(' · ')} — 리포트에서 안내한 교안을 보고 오면 돼요.`,
+          },
+          { icon: InfoIcon, text: '기존 결과는 그대로예요. 다시 본 것은 기록에만 남아요.' },
+        ],
+        cta: {
+          label: '다시 보기',
+          to: '/trainee/session?retry=1',
+          variant: 'primary',
+          aside: `${formatDateKorean(round.retryDueAt)}까지`,
+        },
+      }
+
+    case 'SUBMISSION_CLOSED':
+      return {
+        title: '제출 기한이 지났어요',
+        steps: null,
+        strip: null,
+        guide: [
+          {
+            icon: XCircleIcon,
+            text: `제출 마감은 ${formatDateTime(round.submissionDueAt)}이었어요. 이번 회차는 미제출로 기록됩니다.`,
+          },
+          {
+            icon: ArrowRightIcon,
+            text: '제출하지 않아 이해도 확인도 열리지 않습니다. 사정이 있었다면 매니저에게 알려 주세요.',
+          },
+        ],
+        // ponytail: 매니저 문의 채널이 기획에 없다 — 안내 텍스트로 대신하고 버튼은 만들지 않는다.
+        cta: null,
+      }
+
+    case 'VERIFICATION_CLOSED':
+      return {
+        title: '응시 기한이 지났어요',
+        steps: null,
+        strip: null,
+        guide: [
+          {
+            icon: XCircleIcon,
+            text: `응시 창은 ${formatDateTime(round.verifyClosedAt)}에 닫혔어요. 이번 회차는 미응시로 기록됩니다.`,
+          },
+          { icon: ArrowRightIcon, text: '사정이 있었다면 매니저에게 알려 주세요.' },
+        ],
+        cta: null,
+      }
+  }
+}

--- a/src/features/trainee/home/mockDb.ts
+++ b/src/features/trainee/home/mockDb.ts
@@ -1,0 +1,89 @@
+import type { CurrentRound, HomeView, PastRound, RoundStatus, UpcomingRound } from './types'
+
+/*
+  ⚠️ Mock 전용 데이터 — 백엔드 연동 시 이 파일을 통째로 삭제하세요.
+
+  마감·발행일을 고정 날짜 문자열로 박지 않고 **호출 시점(now) + 오프셋**으로 만든다.
+  목업 스크린샷의 "1일 4시간 남음" 같은 숫자를 그대로 옮기는 게 아니라 — 살아있는
+  카운트다운 자체가 기능이라, 고정 날짜를 쓰면 오늘이 지날 때마다 전부 "이미 지남"이
+  된다(mock-first-screens.md §2-4는 값을 지어내지 말라고 하는데, 그 값이 절대 날짜인
+  게 오히려 화면을 죽인다 — 상대 오프셋이 "지어내지 않은 값"이다).
+*/
+
+const HOUR = 3_600_000
+const DAY = 86_400_000
+
+const ROUND_META = { roundLabel: '미프 3차', classTeam: 'A반 3팀', curriculum: 'AI_LLMOps' }
+
+const UPCOMING: UpcomingRound = {
+  roundLabel: '미프 4차',
+  scheduleLabel: '제출 07-21 · 이해도 확인 07-22~23',
+}
+
+const PAST_ROUNDS: PastRound[] = [
+  { id: 'mif-2', roundLabel: '미프 2차', summary: '완료 · 다시 보기 1건 완료' },
+  { id: 'mif-1', roundLabel: '미프 1차', summary: '완료' },
+]
+
+function currentRoundFor(status: RoundStatus, now: number): CurrentRound {
+  switch (status) {
+    case 'NOT_SUBMITTED':
+      return {
+        ...ROUND_META,
+        status,
+        submissionDueAt: new Date(now + DAY + 4 * HOUR).toISOString(),
+      }
+    case 'ANALYZING':
+      return { ...ROUND_META, status }
+    case 'ANALYSIS_FAILED':
+      return {
+        ...ROUND_META,
+        status,
+        submissionDueAt: new Date(now + 4 * HOUR).toISOString(),
+        failureReason:
+          '저장소가 비어 있거나 접근할 수 없었어요. 주소를 확인하고 다시 제출해 주세요.',
+      }
+    case 'READY_TO_VERIFY':
+      return {
+        ...ROUND_META,
+        status,
+        verifyClosesAt: new Date(now + 19 * HOUR + 12 * 60_000).toISOString(),
+      }
+    case 'VERIFY_DONE':
+      return {
+        ...ROUND_META,
+        status,
+        verifiedAt: new Date(now - 3 * HOUR).toISOString(),
+        reportAfter: new Date(now + DAY).toISOString(),
+      }
+    case 'RETRY_AVAILABLE':
+      return {
+        ...ROUND_META,
+        status,
+        retryDueAt: new Date(now + 6 * DAY).toISOString(),
+        retryConcepts: ['HITL Trigger 조건', 'Graph 구성'],
+        reportRoundId: 'mif-3',
+      }
+    case 'SUBMISSION_CLOSED':
+      return { ...ROUND_META, status, submissionDueAt: new Date(now - 2 * HOUR).toISOString() }
+    case 'VERIFICATION_CLOSED':
+      return { ...ROUND_META, status, verifyClosedAt: new Date(now - HOUR).toISOString() }
+  }
+}
+
+export function buildHomeFixture(status: RoundStatus | 'NONE', now: number): HomeView {
+  if (status === 'NONE') {
+    return {
+      currentRound: null,
+      scope: { cohort: '7기', classTeam: 'A반 3팀' },
+      upcomingRound: null,
+      pastRounds: [{ id: 'mif-3', roundLabel: '미프 3차', summary: '완료' }, ...PAST_ROUNDS],
+    }
+  }
+  return {
+    currentRound: currentRoundFor(status, now),
+    scope: { cohort: '7기', classTeam: 'A반 3팀' },
+    upcomingRound: UPCOMING,
+    pastRounds: PAST_ROUNDS,
+  }
+}

--- a/src/features/trainee/home/types.ts
+++ b/src/features/trainee/home/types.ts
@@ -1,0 +1,65 @@
+/*
+  TR-01 계약 — 서버와 주고받는 모양(api-boundary.md 갈래③). 값이 바뀌면 여기부터 바뀐다.
+
+  상태는 서버가 하나의 판정으로 내려준다(`status`). 화면이 제출/분석/응시 여부
+  3개를 조합해 상태를 유추하지 않는다 — 그러면 그 판정 로직이 화면에 생기고
+  (api-boundary.md §1 ②), 상태마다 필요한 필드가 달라 옵셔널 필드가 쌓인다.
+  discriminated union으로 상태마다 필요한 값만 갖게 한다.
+
+  8종 + `currentRound: null`(진행 중인 회차 없음) = 목업 9개 `.rpage`와 1:1.
+  "재시험"이라는 이름을 쓰지 않는다 — 체크리스트 G1이 금지한 내부 용어이고
+  목업·TR-03·TR-04 전부 "다시 보기"로 통일돼 있다(TR-01 정의서 §3·§5만 드리프트).
+*/
+
+export type RoundStatus =
+  | 'NOT_SUBMITTED' // 미제출 (기한 내)
+  | 'ANALYZING' // 제출 완료 · 분석 중
+  | 'ANALYSIS_FAILED' // 분석 실패
+  | 'READY_TO_VERIFY' // 응시 가능
+  | 'VERIFY_DONE' // 응시 완료 · 리포트 대기
+  | 'RETRY_AVAILABLE' // 다시 보기 대상
+  | 'SUBMISSION_CLOSED' // 제출 마감 지남 → 미제출로 확정
+  | 'VERIFICATION_CLOSED' // 응시 창 마감 → 미응시로 확정
+
+export type RoundMeta = {
+  roundLabel: string // "미프 3차"
+  classTeam: string // "A반 3팀"
+  curriculum: string // "AI_LLMOps"
+}
+
+export type CurrentRound = RoundMeta &
+  (
+    | { status: 'NOT_SUBMITTED'; submissionDueAt: string }
+    | { status: 'ANALYZING' }
+    | { status: 'ANALYSIS_FAILED'; submissionDueAt: string; failureReason: string }
+    | { status: 'READY_TO_VERIFY'; verifyClosesAt: string }
+    | { status: 'VERIFY_DONE'; verifiedAt: string; reportAfter: string }
+    | {
+        status: 'RETRY_AVAILABLE'
+        retryDueAt: string
+        retryConcepts: string[]
+        reportRoundId: string
+      }
+    | { status: 'SUBMISSION_CLOSED'; submissionDueAt: string }
+    | { status: 'VERIFICATION_CLOSED'; verifyClosedAt: string }
+  )
+
+export type UpcomingRound = {
+  roundLabel: string // "미프 4차"
+  scheduleLabel: string // "제출 07-21 · 이해도 확인 07-22~23"
+}
+
+export type PastRound = {
+  id: string // TR-04 라우트 `?round=` 값
+  roundLabel: string
+  summary: string // "완료 · 다시 보기 1건 완료"
+}
+
+export type HomeView = {
+  /** 진행 중인 회차가 없으면 null — "진행 중인 회차 없음" 상태 */
+  currentRound: CurrentRound | null
+  /** 회차가 없어도(none) 소속 표시에 쓴다 */
+  scope: { cohort: string; classTeam: string }
+  upcomingRound: UpcomingRound | null
+  pastRounds: PastRound[]
+}

--- a/src/features/trainee/home/useCountdown.ts
+++ b/src/features/trainee/home/useCountdown.ts
@@ -1,0 +1,37 @@
+import { useEffect, useRef, useState } from 'react'
+
+/**
+ * 마감까지 남은 ms — 1초마다 갱신한다. 0에 닿으면 `onExpire`를 **한 번만** 부른다 —
+ * 주기적으로 서버를 다시 묻는(폴링) 것이 아니라 화면을 띄워 둔 채로 창이 닫히는
+ * 그 순간에 한 번 재조회를 트리거하는 용도다(TR-01 §6 "학생이 상태를 폴링하지 않게").
+ *
+ * `now`를 주입할 수 있게 한 이유 — api-boundary.md §2-3: "화면은 now를 주입받아
+ * 테스트 가능해야 한다." 기본값은 실제 시계다.
+ */
+export function useCountdown(
+  deadlineIso: string,
+  onExpire?: () => void,
+  now: () => number = Date.now,
+) {
+  const [remainingMs, setRemainingMs] = useState(() => new Date(deadlineIso).getTime() - now())
+  const expiredRef = useRef(false)
+  const onExpireRef = useRef(onExpire)
+  onExpireRef.current = onExpire
+
+  useEffect(() => {
+    expiredRef.current = false
+    const tick = () => {
+      const next = new Date(deadlineIso).getTime() - now()
+      setRemainingMs(next)
+      if (next <= 0 && !expiredRef.current) {
+        expiredRef.current = true
+        onExpireRef.current?.()
+      }
+    }
+    tick()
+    const id = setInterval(tick, 1000)
+    return () => clearInterval(id)
+  }, [deadlineIso, now])
+
+  return Math.max(0, remainingMs)
+}

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,45 @@
+/*
+  날짜·카운트다운 포맷 — 도메인을 모르는 순수 함수. `trainee/home`이 먼저 만들었고
+  `trainee/submission`이 같은 것을 필요로 했다 — 두 번째 도메인이 필요로 한 시점에
+  올린다는 규칙(`lib/useAsync.ts` 결정 기록과 같은 판단)을 그대로 따른다.
+*/
+
+const pad2 = (n: number) => String(n).padStart(2, '0')
+
+/** "07-14 18:00" */
+export function formatDateTime(iso: string): string {
+  const d = new Date(iso)
+  return `${pad2(d.getMonth() + 1)}-${pad2(d.getDate())} ${pad2(d.getHours())}:${pad2(d.getMinutes())}`
+}
+
+/** "07-24" */
+export function formatDate(iso: string): string {
+  const d = new Date(iso)
+  return `${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`
+}
+
+/** "7월 24일" */
+export function formatDateKorean(iso: string): string {
+  const d = new Date(iso)
+  return `${d.getMonth() + 1}월 ${d.getDate()}일`
+}
+
+/** "HH:MM:SS" — 초단위 실시간 카운트다운(체크리스트 §6 "초 단위로") */
+export function formatClock(ms: number): string {
+  const total = Math.max(0, Math.floor(ms / 1000))
+  const h = Math.floor(total / 3600)
+  const m = Math.floor((total % 3600) / 60)
+  const s = total % 60
+  return `${pad2(h)}:${pad2(m)}:${pad2(s)}`
+}
+
+/** "1일 4시간" · "6일" · "4시간" · "40분" — 굵은 단위 표시 */
+export function formatCoarse(ms: number): string {
+  const total = Math.max(0, Math.floor(ms / 1000))
+  const days = Math.floor(total / 86400)
+  const hours = Math.floor((total % 86400) / 3600)
+  const minutes = Math.floor((total % 3600) / 60)
+  if (days >= 1) return hours > 0 ? `${days}일 ${hours}시간` : `${days}일`
+  if (hours >= 1) return `${hours}시간`
+  return `${minutes}분`
+}


### PR DESCRIPTION
## 작업 내용

TR-01 교육생 홈 화면 신규 구현. 플레이스홀더 자리를 채웁니다.

커밋 2개로 갈랐습니다.

| 커밋 | 무엇 |
|---|---|
| `feat: add TR-01 trainee home contract and mock data` | `api.ts`/`mockDb.ts`/`types.ts`/`labels.ts`/`useCountdown.ts` + `lib/format.ts`(공용 포맷터, 신규) |
| `feat: build TR-01 trainee home screen` | `HomeScreen.tsx` + `StatusCard`/`StepTracker`/`RoundListRow` |

상태 9종(진행 중인 회차 없음 포함)이 `round.status` 하나로 완전히 갈립니다 — `buildStatusContent` 스위치 하나에 제목·안내문·CTA를 전부 모아, 케이스별로 파일이 흩어지지 않게 했습니다.

## 리뷰 포인트

### 공용 기반 — `lib/format.ts` 신규

TR-02·TR-04도 이 포맷터를 재사용합니다. 화면 전용 유틸이 아니라 `lib/`에 바로 뒀습니다.

### StepTracker의 "지금 단계" — 색이 아니라 형태로 구분

같은 카드 안 CTA 버튼도 primary색이라, now 단계를 꽉 채운 primary로 두면 "여기가 지금 위치"와 "여길 누르세요" 신호가 겹칩니다. now는 링(테두리)+연한 배경으로 그려서, 버튼(꽉 찬 도형)과 상태 표시(테두리만)를 형태로 가릅니다.

## 확인

- [x] 로컬에서 동작 확인
  - `tsc -b` · `vite build` · `oxlint` · `check:design` 통과
  - 상태 9종 전부 렌더 확인(`?state=` dev 오버라이드)
- [x] 하나의 PR = 하나의 기능

closes #97