### PR TITLE
[Feat] Add TR-02 Code Submission Screen

### DIFF
--- a/src/features/trainee/submission/SubmissionScreen.tsx
+++ b/src/features/trainee/submission/SubmissionScreen.tsx
@@ -1,11 +1,263 @@
+import { useCallback, useState } from 'react'
+import { Link, useSearchParams } from 'react-router'
+import { Button } from '@/components/ui/Button'
+import { Card } from '@/components/ui/Card'
+import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from '@/components/ui/Empty'
+import { Spinner } from '@/components/ui/Spinner'
+import { formatDateTime } from '@/lib/format'
+import { useAsync } from '@/lib/useAsync'
 import ConsoleShell from '@/shells/ConsoleShell'
-import PlaceholderScreen from '@/app/PlaceholderScreen'
+import { getSubmission, submitCode } from './api'
+import { buildStateBanner } from './labels'
+import StateBanner from './components/StateBanner'
+import SubmissionForm from './components/SubmissionForm'
+import SubmittedContentCard from './components/SubmittedContentCard'
+import type { SubmissionView, SubmitInput } from './types'
 
-/** TR-02 코드 제출 — 홈에서만 진입, 사이드바 항목 없음 — 화면 이식 전 자리표시. 실제 화면이 들어오면 이 파일 내용만 바뀐다. */
+/*
+  TR-02 코드 제출 — 레포를 내고 분석이 끝날 때까지의 상태를 본다.
+
+  `#page-closed`가 `#page-locked`를 복붙한 목업 버그를 케이스표 기준으로 고쳐서
+  구현했다(types.ts 머리 주석). SUBMISSION_CLOSED는 폼·카드 없이 안내만 — TR-01
+  `missed`와 같은 모양이다.
+
+  제출 후 다음 상태로의 전환은 실제 서버 없이 로컬에서 흉내낸다(design-checklist I1
+  "누르면 결과를 같이 그린다"). 연동 시 이 낙관적 전환 로직은 지우고 `page.reload()`만
+  남는다 — 실제로는 서버가 분석 상태를 갖고 있다.
+*/
+
+const PREVIEW_STATUSES = new Set<SubmissionView['status'] | 'ERROR'>([
+  'DRAFT',
+  'ANALYZING',
+  'READY',
+  'LOCKED',
+  'ANALYSIS_FAILED',
+  'SUBMISSION_CLOSED',
+  'ERROR',
+])
+
 export default function SubmissionScreen() {
+  const [searchParams] = useSearchParams()
+  const stateParam = searchParams.get('state')?.toUpperCase()
+  const previewStatus =
+    stateParam && PREVIEW_STATUSES.has(stateParam as SubmissionView['status'])
+      ? (stateParam as SubmissionView['status'] | 'ERROR')
+      : undefined
+
+  const load = useCallback(() => getSubmission(previewStatus), [previewStatus])
+  const page = useAsync(load)
+
+  const [override, setOverride] = useState<SubmissionView | null>(null)
+  const [resubmitting, setResubmitting] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+
+  const view = override ?? page.data
+
+  const handleSubmit = async (input: SubmitInput) => {
+    if (!view) return
+    setSubmitting(true)
+    await submitCode(input)
+    setSubmitting(false)
+    setResubmitting(false)
+    // ponytail: ZIP 제출의 "제출한 내용" 표시 형태는 기획에 없다 — 저장소·브랜치 형태를
+    // 그대로 빌려 쓴다. 실제 API 문서가 정해지면 이 합성 로직을 지운다.
+    const content =
+      input.method === 'GITHUB'
+        ? {
+            repoUrl: input.repoUrl,
+            branch: input.branch,
+            lastCommit: {
+              sha: '방금 제출됨',
+              message: '분석 대기 중',
+              at: formatDateTime(new Date().toISOString()),
+            },
+          }
+        : {
+            repoUrl: `ZIP · ${input.file.name}`,
+            branch: '-',
+            lastCommit: {
+              sha: '-',
+              message: 'ZIP 업로드',
+              at: formatDateTime(new Date().toISOString()),
+            },
+          }
+    setOverride({
+      status: 'ANALYZING',
+      roundLabel: view.roundLabel,
+      submissionDueAt: view.submissionDueAt,
+      submittedAt: new Date().toISOString(),
+      content,
+    })
+  }
+
   return (
     <ConsoleShell role="trainee">
-      <PlaceholderScreen code="TR-02" title="코드 제출" />
+      {/*
+        TR-01과 같은 860px — 목업은 홈 860 · 제출 620으로 서로 다르게 그렸지만(폼은
+        좁게, 읽기는 넓게가 원 원칙), 실제로 나란히 써 보면 한 플로우(홈→제출→홈) 안에서
+        폭이 화면마다 바뀌는 게 더 어색하다. 제출 폼의 입력칸(저장소 URL·브랜치)은
+        한두 줄이라 넓어져도 가독성 손해가 없어 홈 쪽 값으로 맞춘다.
+      */}
+      <div className="mx-auto flex max-w-[860px] flex-col gap-4">
+        {/* flex-col 부모의 stretch 기본값 때문에 클릭 영역이 컨테이너 전체 폭으로 늘어나
+            있었다(시각적으로는 안 보이지만 호버·포커스 영역이 실제 텍스트보다 훨씬 넓음) */}
+        <Link to="/trainee/home" className="self-start text-sm text-fg-subtle hover:underline">
+          ← 홈
+        </Link>
+
+        {page.loading ? (
+          <div className="flex justify-center py-16">
+            <Spinner className="size-6" aria-label="제출 현황을 불러오는 중" />
+          </div>
+        ) : page.failed || !view ? (
+          <Empty className="border-solid bg-danger-soft border-danger-border">
+            <EmptyHeader>
+              <EmptyTitle>제출 현황을 불러오지 못했습니다</EmptyTitle>
+              <EmptyDescription>잠시 후 다시 시도해 주세요.</EmptyDescription>
+            </EmptyHeader>
+            <Button variant="ghost" onClick={page.reload}>
+              다시 시도
+            </Button>
+          </Empty>
+        ) : (
+          <SubmissionBody
+            view={view}
+            resubmitting={resubmitting}
+            submitting={submitting}
+            onResubmitClick={() => setResubmitting(true)}
+            onCancelResubmit={() => setResubmitting(false)}
+            onSubmit={handleSubmit}
+          />
+        )}
+      </div>
     </ConsoleShell>
+  )
+}
+
+function SubmissionBody({
+  view,
+  resubmitting,
+  submitting,
+  onResubmitClick,
+  onCancelResubmit,
+  onSubmit,
+}: {
+  view: SubmissionView
+  resubmitting: boolean
+  submitting: boolean
+  onResubmitClick: () => void
+  onCancelResubmit: () => void
+  onSubmit: (input: SubmitInput) => void
+}) {
+  // 재제출 폼을 펴면 "분석이 끝났어요" 성공 배너를 감춘다 — 지금 하려는 일(다시 제출)과
+  // 반대되는 메시지("시작하세요")가 폼 위에 그대로 남으면 서로 부딪힌다.
+  const banner = resubmitting ? null : buildStateBanner(view)
+
+  return (
+    <>
+      <header className="flex items-baseline justify-between">
+        <h1 className="text-xl font-bold">{view.roundLabel} 코드 제출</h1>
+        <DueLabel view={view} />
+      </header>
+
+      {banner && <StateBanner {...banner} />}
+
+      {view.status === 'DRAFT' && <SubmissionForm submitting={submitting} onSubmit={onSubmit} />}
+
+      {view.status === 'ANALYSIS_FAILED' && (
+        <SubmissionForm
+          submitting={submitting}
+          onSubmit={onSubmit}
+          initial={{ repoUrl: view.content.repoUrl, branch: view.content.branch }}
+        />
+      )}
+
+      {view.status === 'ANALYZING' && (
+        <SubmittedContentCard
+          content={view.content}
+          actions={
+            <Button variant="ghost" nativeButton={false} render={<Link to="/trainee/home" />}>
+              홈으로
+            </Button>
+          }
+        />
+      )}
+
+      {view.status === 'READY' &&
+        (resubmitting ? (
+          <div className="flex flex-col gap-2">
+            <Button variant="ghost" size="sm" className="self-start" onClick={onCancelResubmit}>
+              ← 취소
+            </Button>
+            <SubmissionForm
+              submitting={submitting}
+              onSubmit={onSubmit}
+              initial={{ repoUrl: view.content.repoUrl, branch: view.content.branch }}
+            />
+          </div>
+        ) : (
+          <SubmittedContentCard
+            content={view.content}
+            actions={
+              <>
+                <span className="mr-auto text-xs text-fg-subtle">
+                  다시 제출하면 분석도 다시 돌아가요
+                </span>
+                <Button variant="ghost" onClick={onResubmitClick}>
+                  다시 제출
+                </Button>
+                <Button nativeButton={false} render={<Link to="/trainee/home" />}>
+                  홈으로
+                </Button>
+              </>
+            }
+          />
+        ))}
+
+      {view.status === 'LOCKED' && (
+        <SubmittedContentCard
+          content={view.content}
+          actions={
+            <Button nativeButton={false} render={<Link to="/trainee/home" />}>
+              홈으로
+            </Button>
+          }
+        />
+      )}
+
+      {view.status === 'SUBMISSION_CLOSED' && (
+        <Card className="bg-surface-2 p-5">
+          <h3 className="text-lg font-semibold text-fg">제출 기한이 지났어요</h3>
+          <p className="mt-2 text-sm text-fg-muted">
+            제출 마감은 {formatDateTime(view.submissionDueAt)}이었어요. 이번 회차는 미제출로
+            기록됩니다. 사정이 있었다면 매니저에게 알려 주세요.
+          </p>
+        </Card>
+      )}
+    </>
+  )
+}
+
+function DueLabel({ view }: { view: SubmissionView }) {
+  if (view.status === 'ANALYZING')
+    return (
+      <span className="text-sm text-fg-subtle">제출 완료 {formatDateTime(view.submittedAt)}</span>
+    )
+  if (view.status === 'READY')
+    return (
+      <span className="text-sm text-fg-subtle">분석 완료 {formatDateTime(view.analyzedAt)}</span>
+    )
+  if (view.status === 'LOCKED')
+    return (
+      <span className="text-sm text-fg-subtle">분석 완료 {formatDateTime(view.analyzedAt)}</span>
+    )
+  if (view.status === 'SUBMISSION_CLOSED')
+    return (
+      <span className="text-sm text-fg-subtle">
+        제출 마감 {formatDateTime(view.submissionDueAt)} · 지남
+      </span>
+    )
+  return (
+    <span className="text-sm text-fg-subtle">제출 마감 {formatDateTime(view.submissionDueAt)}</span>
   )
 }

--- a/src/features/trainee/submission/api.ts
+++ b/src/features/trainee/submission/api.ts
@@ -1,0 +1,65 @@
+import type { RepoCheckResult, SubmissionView, SubmitInput, ZipCheckResult } from './types'
+import { buildSubmissionFixture } from './mockDb'
+
+/*
+  경계 — 화면이 유일하게 의존하는 곳(api-boundary.md §3).
+
+  저장소 확인·ZIP 용량 체크는 "제출 버튼을 누르기 전에" 막는 폼 검증이라 조회 상태
+  머신과 분리했다(types.ts 머리 주석). ZIP 용량은 `File.size`만 보면 되는 순수 계산이라
+  네트워크가 필요 없다 — 지연 없이 동기 반환한다.
+*/
+
+const LATENCY_MS = 250
+const MAX_ZIP_BYTES = 50 * 1024 * 1024
+
+const delay = <T>(value: T): Promise<T> =>
+  new Promise((resolve) => setTimeout(() => resolve(value), LATENCY_MS))
+
+/** @param previewStatus dev 전용 오버라이드(`?state=`). 연동 시 지운다 */
+export function getSubmission(
+  previewStatus?: SubmissionView['status'] | 'ERROR',
+): Promise<SubmissionView> {
+  // ===== Mock 버전 (현재 활성) =====
+  if (previewStatus === 'ERROR') {
+    return Promise.reject(new Error('SUBMISSION_FETCH_FAILED'))
+  }
+  return delay(buildSubmissionFixture(previewStatus ?? 'DRAFT', Date.now()))
+  // return http<SubmissionView>('/submissions/current')
+}
+
+/**
+ * 제출 버튼을 누르기 전에 막는다(정의서 §6). ponytail: 데모용 트리거 —
+ * url에 "notfound"가 있으면 실패를 재현한다. 실제 검증은 서버가 저장소 접근을 시도한다.
+ */
+export function checkRepoUrl(repoUrl: string): Promise<RepoCheckResult> {
+  // ===== Mock 버전 (현재 활성) =====
+  if (repoUrl.includes('notfound')) {
+    return delay({
+      ok: false,
+      code: 'REPO_NOT_FOUND',
+      message: '저장소를 찾지 못했어요. 주소를 다시 확인해 주세요.',
+    })
+  }
+  return delay({ ok: true })
+  // return http<RepoCheckResult>('/submissions/check-repo', { method: 'POST', body: { repoUrl } })
+}
+
+/** 순수 계산 — 네트워크가 필요 없다. 실제 서버도 같은 상한을 검증한다(기획 상수) */
+export function validateZipSize(file: File): ZipCheckResult {
+  if (file.size > MAX_ZIP_BYTES) {
+    const mb = Math.round(file.size / (1024 * 1024))
+    return {
+      ok: false,
+      code: 'FILE_TOO_LARGE',
+      message: `${file.name} · ${mb}MB — 50MB를 넘어 제출할 수 없어요`,
+    }
+  }
+  return { ok: true }
+}
+
+export function submitCode(input: SubmitInput): Promise<void> {
+  // ===== Mock 버전 (현재 활성) =====
+  void input
+  return delay(undefined)
+  // return http<void>('/submissions', { method: 'POST', body: toFormData(input) })
+}

--- a/src/features/trainee/submission/components/StateBanner.tsx
+++ b/src/features/trainee/submission/components/StateBanner.tsx
@@ -1,0 +1,50 @@
+import type { LucideIcon } from 'lucide-react'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/Alert'
+import type { StateTone, StateWeight } from '../labels'
+
+const TONE_VARIANT: Record<StateTone, 'info' | 'success' | 'warning' | 'danger'> = {
+  info: 'info',
+  success: 'success',
+  warning: 'warning',
+  danger: 'danger',
+}
+
+type Props = {
+  tone: StateTone
+  weight: StateWeight
+  icon: LucideIcon
+  title: string
+  description: string
+  sub?: string
+}
+
+/*
+  weight === 'card' → 목업의 `.state` 카드(Alert). weight === 'inline' → 색 배경 없는
+  얇은 한 줄 — 참고만 하면 되는 진행/과거 사실에 경고 카드와 같은 무게를 주지 않는다
+  (labels.ts 머리 주석 참고).
+*/
+export default function StateBanner({ tone, weight, icon: Icon, title, description, sub }: Props) {
+  if (weight === 'inline') {
+    return (
+      <div className="flex items-start gap-2.5 border-b border-border pb-4 text-sm">
+        <Icon aria-hidden="true" className="mt-0.5 size-4 shrink-0 text-fg-subtle" />
+        <div>
+          <p className="text-fg">{title}</p>
+          <p className="mt-0.5 text-fg-subtle">{description}</p>
+          {sub && <p className="mt-1 text-xs text-fg-subtle">{sub}</p>}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <Alert variant={TONE_VARIANT[tone]}>
+      <Icon aria-hidden="true" className="size-5" />
+      <AlertTitle>{title}</AlertTitle>
+      <AlertDescription>
+        <p>{description}</p>
+        {sub && <p className="mt-1 text-xs text-fg-subtle">{sub}</p>}
+      </AlertDescription>
+    </Alert>
+  )
+}

--- a/src/features/trainee/submission/components/SubmissionForm.tsx
+++ b/src/features/trainee/submission/components/SubmissionForm.tsx
@@ -1,0 +1,207 @@
+import { UploadIcon, XIcon } from 'lucide-react'
+import { useRef, useState } from 'react'
+import {
+  Attachment,
+  AttachmentActions,
+  AttachmentAction,
+  AttachmentContent,
+  AttachmentDescription,
+  AttachmentMedia,
+  AttachmentTitle,
+  AttachmentTrigger,
+} from '@/components/ui/Attachment'
+import { Button } from '@/components/ui/Button'
+import { ButtonGroup } from '@/components/ui/ButtonGroup'
+import { Card } from '@/components/ui/Card'
+import { Field, FieldDescription, FieldLabel } from '@/components/ui/Field'
+import { Input } from '@/components/ui/Input'
+import { checkRepoUrl, validateZipSize } from '../api'
+import { REPO_HELP, REPO_NOT_FOUND_HELP, ZIP_HELP } from '../labels'
+import type { SubmitInput } from '../types'
+
+type Props = {
+  /** 재제출일 때 이전 값으로 채운다("다시 제출"은 폼으로 돌아간다 — TR-02 §6) */
+  initial?: { repoUrl: string; branch: string }
+  submitting: boolean
+  onSubmit: (input: SubmitInput) => void
+}
+
+/** GitHub/ZIP 세그먼트 토글 + 각 방식의 폼. `InputCompositionsPreview.tsx` 케이스 J의 2지 토글 패턴 */
+export default function SubmissionForm({ submitting, onSubmit, initial }: Props) {
+  const [method, setMethod] = useState<'GITHUB' | 'ZIP'>('GITHUB')
+  const [repoUrl, setRepoUrl] = useState(initial?.repoUrl ?? '')
+  const [branch, setBranch] = useState(initial?.branch ?? '')
+  const [repoError, setRepoError] = useState<string | null>(null)
+  const [checkingRepo, setCheckingRepo] = useState(false)
+  const [file, setFile] = useState<File | null>(null)
+  const [zipError, setZipError] = useState<string | null>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const handleRepoBlur = async () => {
+    if (!repoUrl.trim()) return
+    setCheckingRepo(true)
+    const result = await checkRepoUrl(repoUrl.trim())
+    setCheckingRepo(false)
+    setRepoError(result.ok ? null : result.message)
+  }
+
+  const handleFilePicked = (picked: File | undefined) => {
+    if (!picked) return
+    const result = validateZipSize(picked)
+    if (!result.ok) {
+      setZipError(result.message)
+      setFile(null)
+      return
+    }
+    setZipError(null)
+    setFile(picked)
+  }
+
+  const canSubmit =
+    !submitting &&
+    (method === 'GITHUB'
+      ? repoUrl.trim().length > 0 && !repoError && !checkingRepo
+      : !!file && !zipError)
+
+  const handleSubmit = () => {
+    if (!canSubmit) return
+    if (method === 'GITHUB') {
+      onSubmit({ method: 'GITHUB', repoUrl: repoUrl.trim(), branch: branch.trim() || 'main' })
+    } else if (file) {
+      onSubmit({ method: 'ZIP', file })
+    }
+  }
+
+  return (
+    <Card className="p-5">
+      <ButtonGroup className="mb-4">
+        <Button
+          type="button"
+          variant={method === 'GITHUB' ? 'primary' : 'ghost'}
+          size="sm"
+          onClick={() => setMethod('GITHUB')}
+        >
+          GitHub 저장소
+        </Button>
+        <Button
+          type="button"
+          variant={method === 'ZIP' ? 'primary' : 'ghost'}
+          size="sm"
+          onClick={() => setMethod('ZIP')}
+        >
+          ZIP 업로드
+        </Button>
+      </ButtonGroup>
+
+      {method === 'GITHUB' ? (
+        <div className="flex flex-col gap-4">
+          <Field data-invalid={!!repoError}>
+            <FieldLabel htmlFor="repo-url">저장소 주소</FieldLabel>
+            <Input
+              id="repo-url"
+              placeholder="https://github.com/팀이름/저장소"
+              value={repoUrl}
+              onChange={(e) => {
+                setRepoUrl(e.target.value)
+                setRepoError(null)
+              }}
+              onBlur={handleRepoBlur}
+              aria-invalid={!!repoError}
+            />
+            {repoError ? (
+              <div className="flex flex-col gap-2">
+                <p className="text-sm text-danger">{repoError}</p>
+                <FieldDescription>{REPO_NOT_FOUND_HELP}</FieldDescription>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="self-start"
+                  onClick={() => setMethod('ZIP')}
+                >
+                  ZIP으로 올리기
+                </Button>
+              </div>
+            ) : (
+              <FieldDescription className="whitespace-pre-line">{REPO_HELP}</FieldDescription>
+            )}
+          </Field>
+
+          <Field>
+            <FieldLabel htmlFor="repo-branch">
+              브랜치 <span className="text-fg-subtle">비우면 기본 브랜치</span>
+            </FieldLabel>
+            <Input
+              id="repo-branch"
+              placeholder="main"
+              value={branch}
+              onChange={(e) => setBranch(e.target.value)}
+            />
+          </Field>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-3">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".zip"
+            className="sr-only"
+            onChange={(e) => handleFilePicked(e.target.files?.[0])}
+          />
+          <Attachment
+            state={zipError ? 'error' : file ? 'done' : 'idle'}
+            className="w-full"
+            onDragOver={(e) => e.preventDefault()}
+            onDrop={(e) => {
+              e.preventDefault()
+              handleFilePicked(e.dataTransfer.files[0])
+            }}
+          >
+            {!file && <AttachmentTrigger onClick={() => fileInputRef.current?.click()} />}
+            <AttachmentMedia>
+              <UploadIcon />
+            </AttachmentMedia>
+            {/*
+              AttachmentTitle/Description 기본값은 한 줄 말줄임(truncate)이다 — 이 드롭존
+              안내문은 좁은 화면에서 두 줄이 되는 게 잘리는 것보다 낫다(핵심 동작 문구가
+              사라지면 안 된다). !important로 명시적으로 덮어써 우선순위 경쟁을 없앤다.
+            */}
+            <AttachmentContent>
+              <AttachmentTitle className="!overflow-visible !text-clip !whitespace-normal">
+                {file ? file.name : 'ZIP 파일을 끌어다 놓거나 눌러서 고르세요'}
+              </AttachmentTitle>
+              <AttachmentDescription className="!overflow-visible !text-clip !whitespace-normal">
+                {zipError ?? (file ? `${Math.round(file.size / (1024 * 1024))}MB` : ZIP_HELP)}
+              </AttachmentDescription>
+            </AttachmentContent>
+            {file && (
+              <AttachmentActions>
+                <AttachmentAction
+                  onClick={() => {
+                    setFile(null)
+                    setZipError(null)
+                  }}
+                >
+                  <XIcon />
+                </AttachmentAction>
+              </AttachmentActions>
+            )}
+          </Attachment>
+        </div>
+      )}
+
+      <div className="mt-4 flex items-center justify-between gap-3">
+        <span className="text-xs text-fg-subtle">
+          {method === 'GITHUB'
+            ? '제출하면 코드 분석이 시작돼요'
+            : file
+              ? '파일을 골랐어요 — 제출할 수 있어요'
+              : '파일을 고르면 제출할 수 있어요'}
+        </span>
+        <Button disabled={!canSubmit} onClick={handleSubmit}>
+          제출
+        </Button>
+      </div>
+    </Card>
+  )
+}

--- a/src/features/trainee/submission/components/SubmittedContentCard.tsx
+++ b/src/features/trainee/submission/components/SubmittedContentCard.tsx
@@ -1,0 +1,44 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card'
+import type { SubmittedContent } from '../types'
+
+/** ANALYZING·READY·LOCKED·ANALYSIS_FAILED 4상태가 반복하는 "제출한 내용" 카드 */
+export default function SubmittedContentCard({
+  content,
+  actions,
+}: {
+  content: SubmittedContent
+  actions?: React.ReactNode
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>제출한 내용</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-2 text-sm">
+        <Row k="저장소" v={content.repoUrl} />
+        <Row k="브랜치" v={content.branch} />
+        <Row
+          k="최근 커밋"
+          v={
+            <>
+              {content.lastCommit.sha} · {content.lastCommit.message}{' '}
+              <span className="text-fg-subtle">({content.lastCommit.at})</span>
+            </>
+          }
+        />
+        {actions && (
+          <div className="mt-3 flex flex-wrap items-center justify-end gap-2">{actions}</div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function Row({ k, v }: { k: string; v: React.ReactNode }) {
+  return (
+    <div className="flex gap-3">
+      <span className="w-20 shrink-0 text-fg-subtle">{k}</span>
+      <span className="text-fg">{v}</span>
+    </div>
+  )
+}

--- a/src/features/trainee/submission/labels.ts
+++ b/src/features/trainee/submission/labels.ts
@@ -1,0 +1,86 @@
+import { CheckIcon, ClockIcon, LockIcon, TriangleAlertIcon, type LucideIcon } from 'lucide-react'
+import { formatDateTime } from '@/lib/format'
+import type { SubmissionView } from './types'
+
+/*
+  표시 라벨 — **화면 것**(api-boundary §1-⑤). 문구는 목업(trainee/submission.html)
+  각 .rpage에서 그대로 옮겼다. `#page-closed`는 목업 자체가 `#page-locked`를 복붙한
+  버그라 옮기지 않고 케이스표 문구(`제출 기한이 지났어요 · 미제출로 기록`)로 새로 썼다
+  (types.ts 머리 주석 참고).
+
+  아이콘은 lucide-react로 통일한다(trainee/home/labels.ts와 같은 이유 — 사이드바가
+  이미 그렇게 하고 있고, 같은 뜻은 화면이 달라도 같은 아이콘을 쓴다).
+*/
+
+export type StateTone = 'info' | 'success' | 'warning' | 'danger'
+
+/*
+  weight — 4개 상태가 요구하는 반응 수준이 다르다. 분석중·잠김은 "참고만 하면 되는
+  진행/과거 사실"이라 카드로 색칠하면 실제 경고(분석 실패)와 같은 무게로 보여 신호가
+  죽는다. 완료(다음 행동을 여는 좋은 소식)·실패(진짜 봐야 하는 에러)만 카드를 쓴다
+  (실사용 피드백으로 발견 — "알림창 UI/UX 재검토").
+*/
+export type StateWeight = 'inline' | 'card'
+
+export type StateBannerContent = {
+  tone: StateTone
+  weight: StateWeight
+  icon: LucideIcon
+  title: string
+  description: string
+  sub?: string
+}
+
+/** 상태별 상단 배너 — 목업의 `.state`(아이콘·제목·설명·보조문구) 카드 */
+export function buildStateBanner(view: SubmissionView): StateBannerContent | null {
+  switch (view.status) {
+    case 'DRAFT':
+      return null // 아직 아무것도 안 일어났다 — 배너 대신 폼만 있다
+    case 'ANALYZING':
+      return {
+        tone: 'info',
+        weight: 'inline',
+        icon: ClockIcon,
+        title: '제출됐어요. 코드를 분석하고 있습니다',
+        description: '끝나면 알려드릴게요. 이 화면을 켜 두지 않아도 됩니다.',
+        // "남은 시간은 알려드리지 않아요 — 정확하지 않은 예상을 드리지 않으려고요"는
+        // 지웠다 — description이 이미 같은 사실을 긍정형으로 전달한다. trainee/home
+        // 쪽 ANALYZING과 같은 판단이다(labels.ts 머리 주석 참고).
+      }
+    case 'READY':
+      return {
+        tone: 'success',
+        weight: 'card',
+        icon: CheckIcon,
+        title: '분석이 끝났어요',
+        description: '이해도 확인을 시작할 수 있습니다. 홈에서 시작하면 돼요.',
+        sub: `${formatDateTime(view.verifyClosesAt)}까지 · 시작 전까지는 다시 제출할 수 있어요`,
+      }
+    case 'LOCKED':
+      return {
+        tone: 'warning',
+        weight: 'inline',
+        icon: LockIcon,
+        title: '이제 다시 제출할 수 없어요',
+        description: '이해도 확인을 시작해서 잠겼습니다.',
+        sub: '질문이 지금 제출된 코드로 만들어졌어요. 코드가 바뀌면 질문과 답이 어긋납니다.',
+      }
+    case 'ANALYSIS_FAILED':
+      return {
+        tone: 'danger',
+        weight: 'card',
+        icon: TriangleAlertIcon,
+        title: '코드를 분석하지 못했어요',
+        description: '저장소는 열렸지만 분석할 코드를 찾지 못했습니다.',
+        sub: '브랜치가 비어 있거나 소스 폴더가 없는지 확인해 주세요. 계속 안 되면 매니저에게 알려 주세요.',
+      }
+    case 'SUBMISSION_CLOSED':
+      return null // 폼도 카드도 없이 안내 문단 하나만 — TR-01 `missed`와 같은 모양
+  }
+}
+
+export const REPO_HELP =
+  '우리 기관 GitHub 조직 안의 저장소는 따로 권한을 주지 않아도 돼요.\n조직 밖이거나 비공개라면 ZIP으로 올려 주세요.'
+export const ZIP_HELP = '최대 50MB · node_modules, .venv 같은 폴더는 빼고 압축해 주세요.'
+export const REPO_NOT_FOUND_HELP =
+  '비공개 저장소이거나 우리 기관 조직 밖에 있으면 열 수 없어요 — 그럴 땐 ZIP으로 올리면 됩니다.'

--- a/src/features/trainee/submission/mockDb.ts
+++ b/src/features/trainee/submission/mockDb.ts
@@ -1,0 +1,69 @@
+import type { SubmissionView } from './types'
+
+/*
+  ⚠️ Mock 전용 데이터 — 백엔드 연동 시 이 파일을 통째로 삭제하세요.
+  마감·발행일은 now + 오프셋으로 만든다(trainee/home/mockDb.ts와 같은 이유).
+*/
+
+const HOUR = 3_600_000
+const DAY = 86_400_000
+
+const CONTENT = {
+  repoUrl: 'github.com/team-a/miniproject-3',
+  branch: 'main',
+  lastCommit: { sha: 'a3f9c21', message: 'feat: HITL 재시도 상한 추가', at: '07-13 22:12' },
+}
+
+export function buildSubmissionFixture(
+  status: SubmissionView['status'],
+  now: number,
+): SubmissionView {
+  const roundLabel = '미프 3차'
+  switch (status) {
+    case 'DRAFT':
+      return {
+        status,
+        roundLabel,
+        submissionDueAt: new Date(now + DAY + 4 * HOUR).toISOString(),
+      }
+    case 'ANALYZING':
+      return {
+        status,
+        roundLabel,
+        submissionDueAt: new Date(now + DAY).toISOString(),
+        submittedAt: new Date(now - 20 * 60_000).toISOString(),
+        content: CONTENT,
+      }
+    case 'READY':
+      return {
+        status,
+        roundLabel,
+        submissionDueAt: new Date(now + DAY).toISOString(),
+        analyzedAt: new Date(now - HOUR).toISOString(),
+        verifyClosesAt: new Date(now + 23 * HOUR).toISOString(),
+        content: CONTENT,
+      }
+    case 'LOCKED':
+      return {
+        status,
+        roundLabel,
+        submissionDueAt: new Date(now + DAY).toISOString(),
+        analyzedAt: new Date(now - 2 * HOUR).toISOString(),
+        content: CONTENT,
+      }
+    case 'ANALYSIS_FAILED':
+      return {
+        status,
+        roundLabel,
+        submissionDueAt: new Date(now + 4 * HOUR).toISOString(),
+        content: CONTENT,
+        failureReason: '저장소는 열렸지만 분석할 코드를 찾지 못했습니다.',
+      }
+    case 'SUBMISSION_CLOSED':
+      return {
+        status,
+        roundLabel,
+        submissionDueAt: new Date(now - 2 * HOUR).toISOString(),
+      }
+  }
+}

--- a/src/features/trainee/submission/types.ts
+++ b/src/features/trainee/submission/types.ts
@@ -1,0 +1,48 @@
+/*
+  TR-02 계약(api-boundary.md 갈래③). `trainee/home/types.ts`의 `RoundMeta`를 import하지
+  않는다 — `.oxlintrc.json`의 `no-restricted-imports`가 features 아래 도메인 간 교차
+  import를 막는다(trainee/home과 trainee/submission은 서로 다른 도메인 폴더). 3줄짜리라
+  로컬 복제가 싸다.
+
+  `#page-closed`가 `#page-locked`를 그대로 복붙해 "마감 지남"인데 "세션 시작 후 잠김"
+  문구를 보여주는 목업 버그가 있었다 — 케이스표(`DEADLINE_PASSED`="미제출로 기록")를
+  계약으로 채택해 LOCKED와 SUBMISSION_CLOSED를 별개 상태로 뗀다.
+
+  저장소 확인(REPO_NOT_FOUND)·ZIP 용량초과(FILE_TOO_LARGE)는 상태 머신에 넣지 않는다
+  — "제출 버튼을 누르기 전" 막는 폼 검증이라 회차 상태가 아니라 폼 컴포넌트의 로컬
+  상태다(정의서 §6 "막을 것은 누르기 전에 막는다").
+*/
+
+export type SubmissionMethod = 'GITHUB' | 'ZIP'
+
+export type SubmittedContent = {
+  repoUrl: string
+  branch: string
+  lastCommit: { sha: string; message: string; at: string }
+}
+
+type Base = { roundLabel: string; submissionDueAt: string }
+
+export type SubmissionView =
+  | (Base & { status: 'DRAFT' })
+  | (Base & { status: 'ANALYZING'; submittedAt: string; content: SubmittedContent })
+  | (Base & {
+      status: 'READY'
+      analyzedAt: string
+      verifyClosesAt: string
+      content: SubmittedContent
+    })
+  | (Base & { status: 'LOCKED'; analyzedAt: string; content: SubmittedContent })
+  | (Base & {
+      status: 'ANALYSIS_FAILED'
+      content: SubmittedContent
+      failureReason: string
+    })
+  | { status: 'SUBMISSION_CLOSED'; roundLabel: string; submissionDueAt: string }
+
+export type RepoCheckResult = { ok: true } | { ok: false; code: 'REPO_NOT_FOUND'; message: string }
+
+export type ZipCheckResult = { ok: true } | { ok: false; code: 'FILE_TOO_LARGE'; message: string }
+
+export type SubmitInput =
+  { method: 'GITHUB'; repoUrl: string; branch: string } | { method: 'ZIP'; file: File }


### PR DESCRIPTION
## 작업 내용

TR-02 코드 제출 화면 신규 구현. 플레이스홀더 자리를 채웁니다.

커밋 2개로 갈랐습니다.

| 커밋 | 무엇 |
|---|---|
| `feat: add TR-02 code submission contract and mock data` | `api.ts`/`mockDb.ts`/`types.ts`/`labels.ts` |
| `feat: build TR-02 code submission screen` | `SubmissionScreen.tsx` + `StateBanner`/`SubmissionForm`/`SubmittedContentCard` |

## 리뷰 포인트

### 상태 배너 긴급도 — `weight`로 카드/인라인 분기

분석 중·잠김(참고만 하면 되는 진행/과거 사실)까지 완료·실패와 같은 색칠 카드로 그리면, "이 화면에 색칠된 게 뜨면 신경 써야 한다"는 신호가 죽습니다. `labels.ts`의 `StateBannerContent.weight`로 나눠서, 분석 중·잠김은 배경 없는 얇은 인라인 줄로, 완료(좋은 소식)·실패(진짜 에러)만 색칠 카드(`Alert`)를 씁니다.

### 폭 통일 — 목업과 다르게 860px

목업은 홈 860 · 제출 620으로 서로 다르게 그렸지만, 실제로 나란히 써 보면 한 플로우(홈→제출→홈) 안에서 폭이 화면마다 바뀌는 게 더 어색합니다. 제출 폼의 입력칸(저장소 URL·브랜치)은 한두 줄이라 넓어져도 가독성 손해가 없어 TR-01(#97) 값으로 맞췄습니다.

## 확인

- [x] 로컬에서 동작 확인
  - `tsc -b` · `vite build` · `oxlint` · `check:design` 통과
  - 상태 전종 렌더 확인(`?state=` dev 오버라이드)
- [x] 하나의 PR = 하나의 기능

closes #99