### PR TITLE
[Feat] Add TR-04 My Report Screen

### DIFF
--- a/src/app/TraineeCaseIndex.tsx
+++ b/src/app/TraineeCaseIndex.tsx
@@ -1,0 +1,152 @@
+import { Link } from 'react-router'
+import { Badge } from '@/components/ui/Badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card'
+
+/*
+  dev 전용 — 트레이니 4화면(TR-01~04)의 목 상태를 전부 한 번에 클릭해서 재현하는
+  체크리스트다. 목업의 `#cases` 표(케이스 계약 · 클릭하면 그 상태로)와 같은 역할을
+  실제 앱 URL에 대해 한다 — 화면마다 `?state=` 문법이 달라(대소문자·파라미터 조합)
+  손으로 치면 실수하기 쉽다.
+
+  `/ui-preview`처럼 라우트에 직접 등록한다(features/*.route.tsx 글롭 대상이 아니다
+  — 실제 화면이 아니라 QA 도구다).
+*/
+
+type CaseLink = { label: string; to: string; note?: string }
+type ScreenSection = { title: string; liveFlowTo: string; cases: CaseLink[]; manual?: string[] }
+
+const SECTIONS: ScreenSection[] = [
+  {
+    title: 'TR-01 홈',
+    liveFlowTo: '/trainee/home',
+    cases: [
+      { label: '미제출', to: '/trainee/home?state=todo' },
+      { label: '분석 중', to: '/trainee/home?state=analyzing' },
+      { label: '응시 가능', to: '/trainee/home?state=ready' },
+      { label: '응시 완료', to: '/trainee/home?state=done' },
+      { label: '다시 보기 대상', to: '/trainee/home?state=retry' },
+      { label: '분석 실패', to: '/trainee/home?state=failed' },
+      { label: '응시 창 마감', to: '/trainee/home?state=closed' },
+      { label: '제출 마감 지남', to: '/trainee/home?state=missed' },
+      { label: '진행 중인 회차 없음', to: '/trainee/home?state=none' },
+      { label: '조회 실패', to: '/trainee/home?state=error' },
+    ],
+  },
+  {
+    title: 'TR-02 코드 제출',
+    liveFlowTo: '/trainee/submission',
+    cases: [
+      { label: '작성 중(빈 폼)', to: '/trainee/submission?state=draft' },
+      { label: '분석 중', to: '/trainee/submission?state=analyzing' },
+      { label: '분석 완료 · 재제출 가능', to: '/trainee/submission?state=ready' },
+      { label: '세션 시작 후 잠김', to: '/trainee/submission?state=locked' },
+      { label: '분석 실패', to: '/trainee/submission?state=analysis_failed' },
+      { label: '제출 마감 지남', to: '/trainee/submission?state=submission_closed' },
+      { label: '조회 실패', to: '/trainee/submission?state=error' },
+    ],
+    manual: [
+      '저장소 확인 실패 — draft에서 저장소 주소에 "notfound" 포함해 입력 후 포커스 아웃',
+      'ZIP 용량 초과 — ZIP 업로드 탭에서 50MB 넘는 파일 선택',
+    ],
+  },
+  {
+    title: 'TR-03 검증 세션 (전체화면)',
+    liveFlowTo: '/trainee/session',
+    cases: [
+      { label: '시작 전 안내', to: '/trainee/session?state=intro' },
+      { label: '문제 진입 · 첫 질문', to: '/trainee/session?state=ask' },
+      { label: '답변 후 스레드', to: '/trainee/session?state=thread' },
+      { label: '다시 설명 1회 사용', to: '/trainee/session?state=again' },
+      { label: '다시 설명 2회 소진', to: '/trainee/session?state=hintgone' },
+      { label: '다음 질문 대기', to: '/trainee/session?state=waiting' },
+      { label: '세 번째 질문(대안 비교)', to: '/trainee/session?state=deeper' },
+      { label: '마지막 문제의 마지막 답변', to: '/trainee/session?state=last' },
+      { label: '이 문제 종료(STOP)', to: '/trainee/session?state=stop' },
+      { label: '다음 문제 예고', to: '/trainee/session?state=next' },
+      { label: '정상 종료', to: '/trainee/session?state=end' },
+      { label: '70분 초과 종료', to: '/trainee/session?state=timeout' },
+      { label: '다시 보기 · 시작 전 안내', to: '/trainee/session?retry=1&state=r-intro' },
+      { label: '다시 보기 · 막힌 질문', to: '/trainee/session?retry=1&state=r-ask' },
+      { label: '다시 보기 · 통과', to: '/trainee/session?retry=1&state=r-pass' },
+      { label: '다시 보기 · 종료', to: '/trainee/session?retry=1&state=r-end' },
+    ],
+    manual: [
+      '창 이탈 토스트 — 세션 진입 후 다른 탭으로 갔다가 2초 뒤 돌아오기',
+      '네트워크 끊김 오버레이 — 개발자 도구 › Network › Throttling을 Offline으로',
+    ],
+  },
+  {
+    title: 'TR-04 내 리포트',
+    liveFlowTo: '/trainee/report',
+    cases: [
+      { label: '발행 · 다시 볼 문제 있음', to: '/trainee/report?state=locked' },
+      { label: '다시 보기 마친 뒤', to: '/trainee/report?state=after' },
+      { label: '발행 전', to: '/trainee/report?state=pre' },
+      { label: '공개 범위 미지정', to: '/trainee/report?state=private' },
+      { label: '미응시', to: '/trainee/report?state=missed' },
+      { label: '무효 응시(확인 필요)', to: '/trainee/report?state=void' },
+      { label: '중단', to: '/trainee/report?state=stopped' },
+      { label: '조회 실패', to: '/trainee/report?state=error' },
+      { label: '리포트 하나도 없음', to: '/trainee/report?state=empty' },
+    ],
+    manual: [
+      '다시 볼 문제 없음(클리어) · 개념별 문답 펼치기는 locked 상태에서 레일의 미프 1·2차를 클릭',
+    ],
+  },
+]
+
+export default function TraineeCaseIndex() {
+  return (
+    <div className="mx-auto max-w-4xl p-8">
+      <h1 className="mb-1 text-2xl font-bold text-fg">트레이니 화면 케이스 인덱스</h1>
+      <p className="mb-6 text-sm text-fg-subtle">
+        dev 전용. 실제 화면엔 이 페이지로 오는 링크가 없다 — 주소를 기억해 두거나 즐겨찾기에 둔다.
+        연동 시 각 화면의 <code className="rounded bg-surface-2 px-1">?state=</code> 분기와 함께
+        지운다.
+      </p>
+
+      <div className="flex flex-col gap-6">
+        {SECTIONS.map((section) => (
+          <Card key={section.title}>
+            <CardHeader>
+              <CardTitle className="flex items-center justify-between">
+                {section.title}
+                <Link
+                  to={section.liveFlowTo}
+                  className="text-xs font-normal text-primary hover:underline"
+                >
+                  실제 흐름으로 열기 →
+                </Link>
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="flex flex-wrap gap-2">
+                {section.cases.map((c) => (
+                  <Link
+                    key={c.to}
+                    to={c.to}
+                    className="rounded-md border border-border px-2.5 py-1.5 text-xs text-fg hover:border-primary hover:bg-primary-soft hover:text-primary"
+                  >
+                    {c.label}
+                  </Link>
+                ))}
+              </div>
+              {section.manual && (
+                <div className="mt-3 flex flex-col gap-1 border-t border-border pt-3">
+                  {section.manual.map((m) => (
+                    <div key={m} className="flex items-start gap-2 text-xs text-fg-subtle">
+                      <Badge variant="warning" className="shrink-0">
+                        수동
+                      </Badge>
+                      {m}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -1,6 +1,7 @@
 import { createBrowserRouter, Navigate } from 'react-router'
 import type { RouteObject } from 'react-router'
 import UiPreviewScreen from '@/app/UiPreviewScreen'
+import TraineeCaseIndex from '@/app/TraineeCaseIndex'
 import RouteNotFound from '@/app/RouteNotFound'
 
 /*
@@ -33,6 +34,7 @@ export const router = createBrowserRouter([
   // 클라이언트는 역할→화면 매핑을 갖지 않는다.
   { path: '/', element: <Navigate to="/shared/login" replace /> },
   { path: '/ui-preview', element: <UiPreviewScreen /> },
+  { path: '/trainee/__cases', element: <TraineeCaseIndex /> },
 
   // 없는 경로를 조용히 로그인으로 보내지 않는다. 그러면 "라우트를 등록 안 한 것"과
   // "코드가 틀린 것"을 구분할 수 없어 개발 중에 시간을 잃는다.

--- a/src/features/trainee/report/MyReportScreen.tsx
+++ b/src/features/trainee/report/MyReportScreen.tsx
@@ -1,11 +1,252 @@
+import {
+  CheckIcon,
+  CircleHelpIcon,
+  ClockIcon,
+  InboxIcon,
+  LockIcon,
+  MinusCircleIcon,
+  PauseCircleIcon,
+  RotateCcwIcon,
+} from 'lucide-react'
+import { useCallback, useState } from 'react'
+import { Link, useSearchParams } from 'react-router'
+import StatusMessageCard from '@/components/common/StatusMessageCard'
+import { Button } from '@/components/ui/Button'
+import { Card } from '@/components/ui/Card'
+import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from '@/components/ui/Empty'
+import { Spinner } from '@/components/ui/Spinner'
+import { useAsync } from '@/lib/useAsync'
 import ConsoleShell from '@/shells/ConsoleShell'
-import PlaceholderScreen from '@/app/PlaceholderScreen'
+import { getReports } from './api'
+import { buildRailNote, formatDate, formatRelativeMonths } from './labels'
+import ConceptCard from './components/ConceptCard'
+import RoundRail from './components/RoundRail'
+import type { ReportsData, RoundReport } from './types'
 
-/** TR-04 내 리포트 — 화면 이식 전 자리표시. 실제 화면이 들어오면 이 파일 내용만 바뀐다. */
+/*
+  StatusMessage(카드 없는 플로팅 텍스트)를 지운다 — 아이콘도 유니코드 손글씨
+  글리프(◴ 🔒 – ? ◷)였다. 공용 StatusMessageCard(components/common)로 바꾸고
+  Card로 감싸 TR-01·02가 이미 쓰는 "카드 안에 상태" 모양과 맞춘다.
+*/
+function ReportStatusCard(props: React.ComponentProps<typeof StatusMessageCard>) {
+  return (
+    <Card className="flex min-h-[360px] items-center justify-center p-10">
+      <StatusMessageCard className="max-w-[560px]" {...props} />
+    </Card>
+  )
+}
+
+/*
+  TR-04 내 리포트 — 좌 회차 목록 / 우 본문 마스터-디테일. 별도 아카이브 화면을 두지
+  않는다(정의서 §3 "좌측 회차 목록이 곧 아카이브다").
+
+  ?round= 은 TR-01 홈의 "리포트 보기" 링크가 넘기는 값이다 — 과거 회차를 눌렀는데
+  최신이 열리면 링크가 거짓말이 된다.
+  ?state= 는 API 명세가 없는 지금 12개 상태를 확인하기 위한 dev 오버라이드다 — 미프
+  3차 한 라운드만 바꿔치기하고 나머지 두 라운드는 배경으로 남겨 마스터-디테일이 항상
+  살아있게 한다.
+*/
 export default function MyReportScreen() {
+  const [searchParams] = useSearchParams()
+  const previewStatus = searchParams.get('state') ?? undefined
+  const initialRoundId = searchParams.get('round') ?? undefined
+
+  const load = useCallback(() => getReports(previewStatus), [previewStatus])
+  const page = useAsync(load)
+
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const effectiveSelectedId = selectedId ?? initialRoundId ?? page.data?.rounds[0]?.id ?? null
+
   return (
     <ConsoleShell role="trainee">
-      <PlaceholderScreen code="TR-04" title="내 리포트" />
+      {page.loading ? (
+        <div className="flex justify-center py-16">
+          <Spinner className="size-6" aria-label="리포트를 불러오는 중" />
+        </div>
+      ) : page.failed || !page.data ? (
+        <Empty className="border-solid bg-danger-soft border-danger-border">
+          <EmptyHeader>
+            <EmptyTitle>리포트를 불러오지 못했습니다</EmptyTitle>
+            <EmptyDescription>잠시 후 다시 시도해 주세요.</EmptyDescription>
+          </EmptyHeader>
+          <Button variant="ghost" onClick={page.reload}>
+            다시 시도
+          </Button>
+        </Empty>
+      ) : page.data.rounds.length === 0 ? (
+        <ReportStatusCard
+          variant="default"
+          icon={<InboxIcon className="size-5" />}
+          title="아직 받은 리포트가 없어요"
+          description="이해도 확인을 마치고 회차가 끝나면 여기에 쌓입니다."
+        />
+      ) : (
+        <ReportsBody data={page.data} selectedId={effectiveSelectedId!} onSelect={setSelectedId} />
+      )}
     </ConsoleShell>
+  )
+}
+
+function ReportsBody({
+  data,
+  selectedId,
+  onSelect,
+}: {
+  data: ReportsData
+  selectedId: string
+  onSelect: (id: string) => void
+}) {
+  const report = data.reportsById[selectedId]
+
+  return (
+    <div className="flex flex-col gap-4 md:flex-row md:gap-8">
+      <RoundRail
+        items={data.rounds.map((r) => ({
+          id: r.id,
+          label: r.label,
+          note: buildRailNote(data.reportsById[r.id]),
+          hasDot: r.hasPendingRetry,
+        }))}
+        selectedId={selectedId}
+        onSelect={onSelect}
+      />
+      <div className="min-w-0 flex-1">
+        <RoundBody report={report} />
+      </div>
+    </div>
+  )
+}
+
+function RoundBody({ report }: { report: RoundReport }) {
+  switch (report.status) {
+    case 'PENDING_PUBLISH':
+      return (
+        <ReportStatusCard
+          variant="default"
+          icon={<ClockIcon className="size-5" />}
+          title="아직 발행 전이에요"
+          description="리포트는 회차 마감 후 한꺼번에 발행됩니다."
+          aux={`발행되면 알려드릴게요 · 발행 예정 ${formatDate(report.publishAfter)} 이후`}
+        />
+      )
+    case 'PENDING_VISIBILITY':
+      return (
+        <ReportStatusCard
+          variant="default"
+          icon={<LockIcon className="size-5" />}
+          title="아직 공개되지 않았어요"
+          description="담당 매니저가 공개 범위를 정하면 확인할 수 있어요."
+          aux="회차는 끝났고 결과도 나와 있습니다 — 여는 시점만 남았어요"
+        />
+      )
+    case 'NOT_ATTEMPTED':
+      return (
+        <ReportStatusCard
+          variant="default"
+          icon={<MinusCircleIcon className="size-5" />}
+          title="이 회차는 리포트가 없어요"
+          description="이해도 확인에 응시하지 않아 만들 내용이 없습니다."
+          aux="사정이 있었다면 매니저에게 알려 주세요"
+        />
+      )
+    case 'VOID_ATTEMPT':
+      return (
+        <ReportStatusCard
+          variant="warning"
+          icon={<CircleHelpIcon className="size-5" />}
+          title="응시 기록을 확인하고 있어요"
+          description="답변이 거의 남지 않아 결과를 만들지 못했습니다. 매니저가 확인한 뒤 다시 응시할 수 있어요."
+          aux="연결 문제였거나 실수로 넘어갔을 수 있어요 — 확인되면 알려드립니다"
+        />
+      )
+    case 'STOPPED':
+      return (
+        <ReportStatusCard
+          variant="warning"
+          icon={<PauseCircleIcon className="size-5" />}
+          title="답한 데까지만 기록됐어요"
+          description={
+            <>
+              이해도 확인을 끝까지 마치지 못했어요.
+              <br />
+              답한 문제까지는 그대로 결과에 들어가고, 남은 문제는 답하지 않은 것으로 남습니다.
+            </>
+          }
+          aux="사정이 있었다면 매니저에게 알려 주세요 — 다시 응시할지는 매니저가 정합니다"
+        />
+      )
+    case 'PUBLISHED':
+      return <PublishedBody report={report} />
+  }
+}
+
+function PublishedBody({ report }: { report: Extract<RoundReport, { status: 'PUBLISHED' }> }) {
+  const retryCount = report.concepts.filter((c) => c.isRetryTarget).length
+  const relative = formatRelativeMonths(report.publishedAt, Date.now())
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div>
+        <h2 className="text-xl font-bold text-fg">{report.label}</h2>
+        <p className="text-sm text-fg-subtle">
+          발행 {formatDate(report.publishedAt)}
+          {report.retryState === 'DONE' &&
+            report.retryCompletedAt &&
+            ` · 다시 보기 ${formatDate(report.retryCompletedAt)}`}{' '}
+          · 교안 {report.curriculum}
+          {relative && ` · ${relative}`}
+        </p>
+      </div>
+
+      {report.retryState === 'PENDING' && report.retryDueAt && (
+        <div className="flex flex-wrap items-center justify-between gap-4 rounded-md bg-warning-soft px-4 py-3">
+          <div className="flex min-w-0 items-center gap-3">
+            <RotateCcwIcon className="size-5 shrink-0 text-warning" />
+            <div>
+              <b className="text-warning">다시 볼 수 있는 문제가 {retryCount}개 있어요</b>
+              <div className="text-xs text-fg-subtle">
+                {formatDate(report.retryDueAt)}까지 · 결과는 기록에만 남고 지금 결과는 그대로예요
+              </div>
+            </div>
+          </div>
+          <Button
+            size="sm"
+            className="shrink-0"
+            nativeButton={false}
+            render={<Link to="/trainee/session?retry=1" />}
+          >
+            다시 보기
+          </Button>
+        </div>
+      )}
+
+      {report.retryState === 'DONE' && (
+        <div className="flex items-center gap-3 rounded-md bg-info-soft px-4 py-3 text-info">
+          <CheckIcon className="size-5 shrink-0" />
+          <div>
+            <b>다시 보기를 마쳤어요</b>
+            <div className="text-xs text-fg-subtle">
+              자세한 해설이 열렸습니다 · 다시 본 결과는 <b>성적에 반영되지 않아요</b>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/*
+        gap 대신 각 카드가 자기 아래쪽 여백(pb)을 갖는다 — 타임라인 선이 그 여백을
+        뚫고 다음 카드까지 이어져야 해서다. flex gap은 형제 "사이" 공간이라 어느
+        카드도 그 공간의 선을 그릴 수 없다(실제로 겪은 정렬 어긋남의 원인).
+      */}
+      <div className="flex flex-col">
+        {report.concepts.map((concept, i) => (
+          <ConceptCard
+            key={concept.name}
+            concept={concept}
+            locked={concept.isRetryTarget && report.retryState === 'PENDING'}
+            isLast={i === report.concepts.length - 1}
+          />
+        ))}
+      </div>
+    </div>
   )
 }

--- a/src/features/trainee/report/api.ts
+++ b/src/features/trainee/report/api.ts
@@ -1,0 +1,23 @@
+import { buildEmptyFixture, buildReportsFixture } from './mockDb'
+import type { ReportsData } from './types'
+
+/*
+  경계 — 화면이 유일하게 의존하는 곳(api-boundary.md §3).
+  @param previewStatus dev 전용 오버라이드(`?state=`) — 연동 시 지운다.
+*/
+const LATENCY_MS = 250
+
+const delay = <T>(value: T): Promise<T> =>
+  new Promise((resolve) => setTimeout(() => resolve(value), LATENCY_MS))
+
+export function getReports(previewStatus?: string, now = Date.now()): Promise<ReportsData> {
+  // ===== Mock 버전 (현재 활성) =====
+  if (previewStatus === 'error') {
+    return Promise.reject(new Error('REPORTS_FETCH_FAILED'))
+  }
+  if (previewStatus === 'empty') {
+    return delay(buildEmptyFixture())
+  }
+  return delay(buildReportsFixture(now, previewStatus))
+  // return http<ReportsData>('/reports')
+}

--- a/src/features/trainee/report/components/ConceptCard.tsx
+++ b/src/features/trainee/report/components/ConceptCard.tsx
@@ -1,0 +1,123 @@
+import { BookOpenIcon, LockIcon, LockOpenIcon } from 'lucide-react'
+import { cn } from '@/lib/utils/cn'
+import { REACH_LABEL } from '../labels'
+import type { ConceptReport, LadderLevel } from '../types'
+import QaList from './QaList'
+
+/*
+  레일 핀과 레벨 배지가 같은 --color-reach-1~4를 쓴다(둘 다 같은 레벨을 말하므로
+  색도 하나여야 한다 — 실사용 피드백으로 발견). 5단 그라디언트를 그대로 쓰기로
+  확정했다 — 매니저 쪽 도달단계 배지(MG-05)가 이미 쓰는 원색 스케일이라 도메인
+  교차 import 없이 같은 전역 토큰만 가져다 쓴다. text-reach-fg/white 페어링도
+  그쪽과 같다(index.css "1~3단 위 어두운 글자. 0·4단은 흰 글자").
+*/
+const PIN_CLASS: Record<LadderLevel, string> = {
+  1: 'bg-reach-1',
+  2: 'bg-reach-2',
+  3: 'bg-reach-3',
+  4: 'bg-reach-4',
+}
+
+const BADGE_CLASS: Record<LadderLevel, string> = {
+  1: 'bg-reach-1 text-reach-fg',
+  2: 'bg-reach-2 text-reach-fg',
+  3: 'bg-reach-3 text-reach-fg',
+  4: 'bg-reach-4 text-white',
+}
+
+type Props = {
+  concept: ConceptReport
+  /** isRetryTarget && retryState==='PENDING' — 화면이 계산해서 넘긴다 */
+  locked: boolean
+  /** 마지막 카드는 선이 다음 카드로 안 이어지니 꼬리를 남기지 않는다 */
+  isLast: boolean
+}
+
+/*
+  개념 하나 — 번호가 아니라 좌측 레일 점으로 구분한다(정의서 §3 "번호가 아니라 레일").
+  4단 전부 다른 reach 색을 쓴다(BADGE_CLASS 참고).
+
+  핀(원)과 선의 중심이 실제로 맞도록 수치를 맞춘다 — 핀 10px(size-2.5)이 left-0에서
+  시작하면 중심은 5px, 선은 left-1(4px) 위치에 2px 폭(w-0.5)이면 중심도 5px로 같다.
+  이전엔 선을 부모 wrapper의 border-l로(카드마다 다른 pl 기준과 안 맞음) 그려서
+  핀과 어긋났다(실제로 발견된 문제).
+
+  선은 각 카드 "자신의" 아래쪽 padding(pb-8) 안까지 뻗어 다음 카드 핀까지 이어진다
+  — flex gap은 형제 사이 공간이라 어느 카드도 그 구간의 선을 못 그린다. 마지막
+  카드는 다음 핀이 없어 padding도 짧고(pb-3) 선도 그 안에서 멈춘다.
+
+  다시 보기 전/후 레벨은 예전엔 explain 박스 안에 별도 2열 박스로 또 있었다 — 카드
+  맨 위 레벨 배지와 같은 정보(레벨)를 두 자리에서 다른 모양으로 보여줘서 같은 걸
+  말하는지 재차 확인해야 했다(실사용 피드백으로 발견). 배지 바로 아래 "처음엔 …"
+  한 줄로 합친다 — L2·L3 같은 내부 등급 표기는 화면에 쓰지 않는다는 규칙(세션
+  정의서)을 그대로 따라 REACH_LABEL 사람 말만 쓴다.
+*/
+export default function ConceptCard({ concept, locked, isLast }: Props) {
+  return (
+    <div className={cn('relative pl-5', isLast ? 'pb-3' : 'pb-8')}>
+      {/* top-[11px] = 핀(top-1.5=6px, size-2.5=10px)의 세로 중심 — 선이 핀 가운데서 뻗어나온다 */}
+      <span
+        aria-hidden="true"
+        className={cn('absolute top-[11px] bottom-0 left-1 w-0.5 bg-border', isLast && 'bottom-3')}
+      />
+      <span
+        className={cn('absolute top-1.5 left-0 size-2.5 rounded-full', PIN_CLASS[concept.level])}
+      />
+
+      <div className="mb-2 flex items-baseline justify-between gap-3">
+        <span className="text-lg font-bold text-fg">{concept.name}</span>
+        <div className="flex shrink-0 flex-col items-end gap-1">
+          <span
+            className={cn('rounded-full px-2.5 py-1 text-xs font-bold', BADGE_CLASS[concept.level])}
+          >
+            {REACH_LABEL[concept.level]}
+          </span>
+          {concept.comparedReach && (
+            <span className="text-2xs text-fg-subtle">
+              처음엔 {REACH_LABEL[concept.comparedReach.before]}
+            </span>
+          )}
+        </div>
+      </div>
+
+      <p className="text-sm leading-relaxed text-fg-muted">{concept.said}</p>
+
+      {concept.explain &&
+        (locked ? (
+          // 잠김 — 중립 회색 + 점선. "아직 못 본다"는 상태 자체가 신호라 색을 안 쓴다.
+          <div className="mt-3 flex items-center gap-2 rounded-md border border-dashed border-border-strong bg-surface-2 p-3 text-sm">
+            <LockIcon className="size-4 shrink-0 text-fg-subtle" />
+            <b className="text-fg">자세한 해설은 다시 보기를 마치면 열려요</b>
+          </div>
+        ) : (
+          // 열림 — 잠금 박스와 정반대로 보이게 한다: 회색 대신 primary 색, 점선 대신
+          // 실선, 자물쇠 대신 열린 자물쇠. 무게(배경+테두리)는 같게 둬서 옆 잠금
+          // 박스보다 오히려 흐려 보이는 일이 없게 한다(실사용 피드백으로 발견 —
+          // 왼쪽 포인트 선만 있던 이전 버전은 잠금 박스보다 존재감이 약했다).
+          <div className="mt-3 rounded-md border border-primary-border bg-primary-soft p-3 text-sm">
+            <div className="mb-1.5 flex items-center gap-1.5 text-xs font-bold text-primary">
+              <LockOpenIcon className="size-3.5 shrink-0" />
+              어디서 막혔나
+            </div>
+            {concept.explain.map((p, i) => (
+              <p key={i} className={cn('leading-relaxed text-fg', i > 0 && 'mt-2')}>
+                {p}
+              </p>
+            ))}
+          </div>
+        ))}
+
+      {concept.curriculumRef && (
+        <div className="mt-2 inline-flex items-center gap-1.5 rounded-full bg-surface-2 px-2.5 py-1 text-xs text-fg-subtle">
+          <BookOpenIcon aria-hidden="true" className="size-3.5 shrink-0" />
+          <span>
+            교안 {concept.curriculumRef.chapter} · {concept.curriculumRef.pages} ·{' '}
+            {concept.curriculumRef.title}
+          </span>
+        </div>
+      )}
+
+      <QaList qa={concept.qa} />
+    </div>
+  )
+}

--- a/src/features/trainee/report/components/QaList.tsx
+++ b/src/features/trainee/report/components/QaList.tsx
@@ -1,0 +1,52 @@
+import { ChevronRightIcon } from 'lucide-react'
+import { useState } from 'react'
+import { cn } from '@/lib/utils/cn'
+import type { QaEntry } from '../types'
+
+/*
+  질문·답변이 같은 회색 박스에 같은 굵기로 쌓이면 뭘 먼저 읽어야 할지 안 보인다
+  (실사용 피드백으로 발견) — 질문은 맥락이라 작고 옅게, 내 답변은 실제로 읽어야 할
+  내용이라 라벨을 따로 얹고 본문 대비를 올렸다.
+
+  토글 버튼은 원래 맨 텍스트라 눌러야 하는 요소로 안 읽혔다(실사용 피드백으로 발견)
+  — 배경·테두리를 얹어 "행"으로 만들고, 회전하는 화살표(아코디언 관용구)로 지금
+  열림/닫힘 상태를 즉시 보이게 한다.
+*/
+export default function QaList({ qa }: { qa: QaEntry[] }) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <div className="mt-3 border-t border-border pt-2">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="flex w-full items-center gap-2 rounded-md border border-border bg-surface-2 px-3 py-2 text-sm text-fg-subtle transition-colors hover:border-border-strong hover:bg-canvas hover:text-fg"
+      >
+        <ChevronRightIcon
+          aria-hidden="true"
+          className={cn('size-3.5 shrink-0 transition-transform', open && 'rotate-90')}
+        />
+        <span className="flex-1 text-left">
+          내 답변 <span className="text-fg-subtle">{qa.length}개</span>
+        </span>
+        <span className="text-xs">{open ? '접기' : '펼치기'}</span>
+      </button>
+      {open && (
+        <div className="mt-2 flex flex-col gap-3">
+          {qa.map((row, i) => (
+            <div key={i} className="flex flex-col gap-2 rounded-md bg-surface-2 p-3">
+              <p className="text-xs text-fg-subtle">
+                <span className="font-medium">{row.questionLabel}</span> {row.question}
+              </p>
+              <div>
+                <div className="mb-0.5 text-xs font-semibold text-fg-subtle">내 답변</div>
+                <p className="text-sm leading-relaxed text-fg">{row.answer}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/features/trainee/report/components/RoundRail.tsx
+++ b/src/features/trainee/report/components/RoundRail.tsx
@@ -1,0 +1,45 @@
+import { cn } from '@/lib/utils/cn'
+
+type RailItem = { id: string; label: string; note?: string; hasDot: boolean }
+
+/** 좌측 회차 목록 — 마스터-디테일의 마스터. 별도 아카이브 화면을 만들지 않는다(정의서 §3) */
+export default function RoundRail({
+  items,
+  selectedId,
+  onSelect,
+}: {
+  items: RailItem[]
+  selectedId: string
+  onSelect: (id: string) => void
+}) {
+  return (
+    // 220px 고정 폭에 반응형 분기가 없어서 375px 화면에서 본문이 123px로 눌렸다
+    // (Sidebar.tsx가 이미 쓰는 md: 접기 관례를 그대로 따른다 — 좁은 화면엔 위쪽
+    // 전체 폭 목록, md 이상에서만 옆 레일).
+    <nav className="w-full border-b border-border pb-4 md:w-[220px] md:shrink-0 md:border-r md:border-b-0 md:pr-4 md:pb-0">
+      <div className="mb-2 text-xs font-semibold text-fg-subtle">회차</div>
+      <ul className="flex flex-col">
+        {items.map((item) => (
+          <li key={item.id}>
+            <button
+              type="button"
+              onClick={() => onSelect(item.id)}
+              className={cn(
+                'w-full rounded-md px-2 py-2 text-left text-sm',
+                item.id === selectedId
+                  ? 'bg-primary-soft text-primary'
+                  : 'text-fg hover:bg-surface-2',
+              )}
+            >
+              <div className="flex items-center gap-1.5 font-medium">
+                {item.label}
+                {item.hasDot && <span className="size-1.5 rounded-full bg-warning" />}
+              </div>
+              {item.note && <div className="text-xs text-fg-subtle">{item.note}</div>}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  )
+}

--- a/src/features/trainee/report/labels.ts
+++ b/src/features/trainee/report/labels.ts
@@ -1,0 +1,50 @@
+import { formatDate } from '@/lib/format'
+import type { LadderLevel, RoundReport } from './types'
+
+/*
+  표시 라벨 — **화면 것**(api-boundary §1-⑤). 숫자 계단을 학생 언어로 바꾸는 것도
+  전부 여기다 — 서버는 level: 1~4만 준다.
+
+  색은 여기서 만들지 않는다 — 레벨 배지·레일 핀 둘 다 컴포넌트가 --color-reach-1~4를
+  직접 쓴다(ConceptCard.tsx 머리 주석. 5단 그라디언트를 그대로 쓰기로 결정 — 문서
+  초안의 3색 폭보다 이쪽이 낫다는 판단, 실사용 피드백으로 확정).
+*/
+
+export const REACH_LABEL: Record<LadderLevel, string> = {
+  1: '무엇을 하는지까지',
+  2: '왜 그렇게 했는지까지',
+  3: '다른 방법까지',
+  4: '언제 깨지는지까지',
+}
+
+/** 레일의 회차 한 줄 보조문구 — report의 실제 상태에서 계산한다(문장을 서버에서 받지 않는다, A7) */
+export function buildRailNote(report: RoundReport | undefined): string | undefined {
+  if (!report) return undefined
+  switch (report.status) {
+    case 'PUBLISHED': {
+      if (report.retryState === 'PENDING') {
+        const count = report.concepts.filter((c) => c.isRetryTarget).length
+        return `다시 볼 문제 ${count}개`
+      }
+      if (report.retryState === 'DONE') return '다시 보기 1개 완료'
+      return undefined
+    }
+    case 'NOT_ATTEMPTED':
+      return '미응시'
+    case 'STOPPED':
+      return '중단'
+    case 'VOID_ATTEMPT':
+      return '확인 필요'
+    case 'PENDING_PUBLISH':
+    case 'PENDING_VISIBILITY':
+      return '응시 완료'
+  }
+}
+
+/** "3개월 전" — 아카이브(오래된 회차)에서만 붙인다 */
+export function formatRelativeMonths(publishedAtIso: string, now: number): string | null {
+  const months = Math.floor((now - new Date(publishedAtIso).getTime()) / (30 * 86_400_000))
+  return months >= 1 ? `${months}개월 전` : null
+}
+
+export { formatDate }

--- a/src/features/trainee/report/mockDb.ts
+++ b/src/features/trainee/report/mockDb.ts
@@ -1,0 +1,232 @@
+import type { ConceptReport, PublishedReport, ReportsData, RoundReport } from './types'
+
+/*
+  ⚠️ Mock 전용 데이터 — 백엔드 연동 시 이 파일을 통째로 삭제하세요.
+
+  개념 순서·문항 텍스트는 `trainee/session/script.ts`(TR-03)의 실제 시나리오에서
+  가져왔다 — 같은 세션 결과를 두 화면이 각자 다른 말로 지어내면 연동 전부터 어긋난다
+  (TR-04 재검증 발견 #4). 마감·발행일은 now + 오프셋(trainee/home 패턴과 동일).
+*/
+
+const DAY = 86_400_000
+
+function mif3(now: number): PublishedReport {
+  const concepts: ConceptReport[] = [
+    {
+      name: 'Graph 구성',
+      level: 2,
+      said: '왜 그렇게 만들었는지까지 설명했어요. 다른 방법이 있는지는 확인되지 않았습니다.',
+      isRetryTarget: true,
+      curriculumRef: { chapter: '2장', pages: '28~35쪽', title: '그래프 구성하기' },
+      explain: [
+        '조건부 분기 말고 Supervisor 구조로도 만들 수 있습니다. 교안 2장 뒷부분에서 둘을 견줍니다.',
+      ],
+      qa: [
+        {
+          questionLabel: '질문 1',
+          question: '이 그래프는 노드를 어떤 순서로 연결하나요? 전체 흐름을 설명해 주세요.',
+          answer: '이 그래프는 agent와 human 노드를 연결합니다.',
+        },
+        {
+          questionLabel: '질문 2',
+          question: 'conditional_edges에서 분기 조건은 무엇을 기준으로 정해지나요?',
+          answer: 'should_trigger_hitl 함수가 True/False를 돌려주는 값으로 분기합니다.',
+        },
+      ],
+    },
+    {
+      name: 'HITL Trigger 조건',
+      level: 1,
+      said: '이 함수가 무엇을 하는지는 설명했어요. 다만 교안에 있던 세 번째 조건을 왜 넣지 않았는지는 확인되지 않았습니다.',
+      isRetryTarget: true,
+      curriculumRef: { chapter: '3장', pages: '36~46쪽', title: '사람 확인이 필요한 순간' },
+      // comparedReach 없음 — 이 회차는 retryState: 'PENDING'(다시 보기 전)이라 "다시
+      // 봤을 때" 레벨이 아직 없다. comparedReach는 retryState: 'DONE'일 때만 존재한다
+      // (types.ts 계약). mif2 쪽 예시가 DONE 케이스를 담당한다.
+      explain: [
+        '교안 3장에서는 사람이 확인해야 하는 경우를 세 가지로 나눕니다 — 재시도 상한, 거절 결정, 그리고 위험 키워드가 들어온 경우입니다.',
+        '앞의 두 가지는 코드에 있었지만 세 번째는 없었어요. 이런 조건이 빠지면 위험한 요청이 사람 확인 없이 지나갑니다.',
+      ],
+      qa: [
+        {
+          questionLabel: '질문 1',
+          question:
+            '이 함수는 무슨 일을 하나요? 어떤 값이 들어오고, 어디에서 쓰이는지도 같이 이야기해 주세요.',
+          answer:
+            'state를 받아서 사람이 확인해야 하는 상황인지 True/False로 알려주는 함수입니다. 재시도가 3번을 넘거나 결정이 REJECTED면 True를 돌려줍니다.',
+        },
+        {
+          questionLabel: '질문 2',
+          question:
+            '교안에서는 사람이 확인해야 하는 조건을 세 가지로 봤는데, 여기서는 두 가지만 보고 있어요. 왜 그렇게 하셨나요?',
+          answer:
+            'retry 횟수가 넘거나 REJECTED가 오면 사람이 봐야 한다고 생각해서 두 개만 넣었습니다.',
+        },
+        {
+          questionLabel: '질문 2 · 다시 설명',
+          question:
+            '이 함수가 True를 돌려주는 경우를 먼저 짚어 보고, 교안에 있던 나머지 한 가지를 여기서는 왜 넣지 않았는지 이야기해 주세요.',
+          answer: '세 번째 조건은 잘 기억이 안 납니다.',
+        },
+      ],
+    },
+    {
+      name: 'State 관리',
+      level: 4,
+      said: '언제 문제가 되는지까지 이야기했어요. add_messages를 쓰지 않았을 때 어디가 깨지는지 조건을 짚었습니다.',
+      isRetryTarget: false,
+      qa: [
+        {
+          questionLabel: '질문 1',
+          question: 'messages에 add_messages를 붙인 이유가 뭔가요?',
+          answer: '그냥 리스트로 두면 노드마다 덮어써져서, 이어 붙이도록 하려고 썼습니다.',
+        },
+        {
+          questionLabel: '질문 2',
+          question: '이걸 쓰지 않았다면 어디에서 문제가 생겼을까요?',
+          answer:
+            'HITL 노드에서 사람 답을 받아 다시 agent로 돌아갈 때, 앞 대화가 사라져서 같은 질문을 반복했을 것 같습니다.',
+        },
+      ],
+    },
+  ]
+
+  return {
+    id: 'mif-3',
+    label: '미프 3차',
+    status: 'PUBLISHED',
+    publishedAt: new Date(now - DAY).toISOString(),
+    curriculum: 'AI_LLMOps',
+    concepts,
+    retryState: 'PENDING',
+    retryDueAt: new Date(now + 6 * DAY).toISOString(),
+  }
+}
+
+function mif2(now: number): RoundReport {
+  return {
+    id: 'mif-2',
+    label: '미프 2차',
+    status: 'PUBLISHED',
+    publishedAt: new Date(now - 10 * DAY).toISOString(),
+    curriculum: 'AI_LLMOps',
+    retryState: 'DONE',
+    retryCompletedAt: new Date(now - 6 * DAY).toISOString(),
+    concepts: [
+      {
+        name: 'Service 역할 분리',
+        level: 4,
+        said: '다른 방법이 있다는 것까지 이야기했어요. NodePort와 Ingress를 견주고 왜 지금 방식을 골랐는지 설명했습니다.',
+        isRetryTarget: false,
+        qa: [
+          {
+            questionLabel: '질문 1',
+            question: '이 Service는 왜 ClusterIP로 만들었나요?',
+            answer: '외부에 직접 노출할 필요가 없고, Ingress가 앞에서 라우팅을 맡아서요.',
+          },
+        ],
+      },
+      {
+        name: 'Deployment 구성',
+        level: 4,
+        said: '언제 문제가 되는지까지 이야기했어요. replica를 늘렸을 때 어디가 먼저 막히는지 짚었습니다.',
+        isRetryTarget: true,
+        curriculumRef: { chapter: '4장', pages: '50~58쪽', title: '배포 전략' },
+        comparedReach: { before: 2, after: 4 },
+        explain: [
+          '교안에서는 replica 수를 늘리기 전에 리소스 한도를 먼저 정합니다. 한도가 없으면 노드 하나가 감당하지 못할 때 전체가 같이 죽습니다.',
+        ],
+        qa: [
+          {
+            questionLabel: '질문 1',
+            question: 'replica를 3으로 둔 이유가 있나요?',
+            answer: '하나가 죽어도 서비스가 이어지게 하려고 3으로 뒀습니다.',
+          },
+          {
+            questionLabel: '질문 2',
+            question: '리소스 한도 없이 replica만 늘리면 어디서 문제가 생길까요?',
+            answer: '노드 하나에 여러 pod가 몰리면 메모리를 다 써서 전체가 같이 죽을 수 있습니다.',
+          },
+        ],
+      },
+    ],
+  }
+}
+
+function mif1(now: number): RoundReport {
+  return {
+    id: 'mif-1',
+    label: '미프 1차',
+    status: 'PUBLISHED',
+    publishedAt: new Date(now - 40 * DAY).toISOString(),
+    curriculum: 'AI_LLMOps',
+    retryState: 'NONE',
+    concepts: [
+      {
+        name: 'LangGraph 기본 구조',
+        level: 2,
+        said: '왜 그렇게 만들었는지까지 설명했어요.',
+        isRetryTarget: false,
+        curriculumRef: { chapter: '1장', pages: '12~20쪽', title: '그래프와 노드' },
+        explain: ['노드를 함수로 나누면 테스트가 쉬워집니다. 교안 1장에서 같은 이유로 나눕니다.'],
+        qa: [
+          {
+            questionLabel: '질문 1',
+            question: '노드를 이렇게 나눈 이유가 있나요?',
+            answer: '각 단계를 따로 테스트하고 싶어서 함수로 나눴습니다.',
+          },
+        ],
+      },
+    ],
+  }
+}
+
+/** @param previewStatus dev 전용 — 미프 3차 한 라운드만 다른 상태로 바꿔치기한다 */
+export function buildReportsFixture(now: number, previewStatus?: string): ReportsData {
+  let mif3Report: RoundReport = mif3(now)
+
+  switch (previewStatus) {
+    case 'pre':
+      mif3Report = {
+        id: 'mif-3',
+        label: '미프 3차',
+        status: 'PENDING_PUBLISH',
+        publishAfter: new Date(now + DAY).toISOString(),
+      }
+      break
+    case 'private':
+      mif3Report = { id: 'mif-3', label: '미프 3차', status: 'PENDING_VISIBILITY' }
+      break
+    case 'missed':
+      mif3Report = { id: 'mif-3', label: '미프 3차', status: 'NOT_ATTEMPTED' }
+      break
+    case 'void':
+      mif3Report = { id: 'mif-3', label: '미프 3차', status: 'VOID_ATTEMPT' }
+      break
+    case 'stopped':
+      mif3Report = { id: 'mif-3', label: '미프 3차', status: 'STOPPED' }
+      break
+    case 'after':
+      mif3Report = {
+        ...mif3(now),
+        retryState: 'DONE',
+        retryCompletedAt: new Date(now - 60_000).toISOString(),
+      }
+      break
+  }
+
+  const reports = [mif3Report, mif2(now), mif1(now)]
+  return {
+    rounds: reports.map((r) => ({
+      id: r.id,
+      label: r.label,
+      hasPendingRetry: r.status === 'PUBLISHED' && r.retryState === 'PENDING',
+    })),
+    reportsById: Object.fromEntries(reports.map((r) => [r.id, r])),
+  }
+}
+
+/** "리포트가 하나도 없음" — 회차 배열 자체가 없는 별도 프리뷰 */
+export function buildEmptyFixture(): ReportsData {
+  return { rounds: [], reportsById: {} }
+}

--- a/src/features/trainee/report/types.ts
+++ b/src/features/trainee/report/types.ts
@@ -1,0 +1,60 @@
+/*
+  TR-04 계약(api-boundary.md 갈래③). `trainee/session/types.ts`의 `LadderLevel`을
+  import하지 않는다 — features 간 교차 import 금지 규칙(oxlintrc)이 여기도 걸린다.
+  숫자 하나짜리 타입이라 로컬 복제가 싸다.
+
+  발행 상태는 `PUBLISHED` 하나뿐이고, 그 안에서 `retryState`(NONE/PENDING/DONE)가
+  갈린다 — 목업의 `locked`·`after`·`clear` 3페이지는 서로 다른 라운드 상태가 아니라
+  **같은 발행 화면의 변형**이다(정의서 재검증 발견 #3).
+*/
+
+export type LadderLevel = 1 | 2 | 3 | 4
+
+export type CurriculumRef = { chapter: string; pages: string; title: string }
+
+export type QaEntry = { questionLabel: string; question: string; answer: string }
+
+export type ConceptReport = {
+  name: string
+  level: LadderLevel
+  said: string
+  isRetryTarget: boolean
+  curriculumRef?: CurriculumRef
+  qa: QaEntry[]
+  /** `isRetryTarget`일 때만 존재 — 막힌 이유 상세 해설. 잠금 여부는 retryState가 결정한다 */
+  explain?: string[]
+  /** retryState가 DONE일 때만 — 처음/다시 나란히 */
+  comparedReach?: { before: LadderLevel; after: LadderLevel }
+}
+
+export type RoundListItem = {
+  id: string
+  label: string
+  /** 아직 안 한 다시 보기가 있다 — 레일에 점으로 표시(선택 여부와 무관) */
+  hasPendingRetry: boolean
+}
+
+type RoundBase = { id: string; label: string }
+
+export type PublishedReport = RoundBase & {
+  status: 'PUBLISHED'
+  publishedAt: string
+  curriculum: string
+  concepts: ConceptReport[]
+  retryState: 'NONE' | 'PENDING' | 'DONE'
+  retryDueAt?: string // PENDING
+  retryCompletedAt?: string // DONE
+}
+
+export type RoundReport =
+  | PublishedReport
+  | (RoundBase & { status: 'PENDING_PUBLISH'; publishAfter: string })
+  | (RoundBase & { status: 'PENDING_VISIBILITY' })
+  | (RoundBase & { status: 'NOT_ATTEMPTED' })
+  | (RoundBase & { status: 'VOID_ATTEMPT' })
+  | (RoundBase & { status: 'STOPPED' })
+
+export type ReportsData = {
+  rounds: RoundListItem[]
+  reportsById: Record<string, RoundReport>
+}

--- a/src/shells/sidebarConfig.ts
+++ b/src/shells/sidebarConfig.ts
@@ -3,6 +3,7 @@ import {
   LayoutDashboardIcon,
   ChartLineIcon,
   FileTextIcon,
+  FlaskConicalIcon,
   FolderKanbanIcon,
   SettingsIcon,
   Grid3x3Icon,
@@ -77,6 +78,12 @@ export const TRAINEE_SIDEBAR: SidebarGroup[] = [
     { icon: HomeIcon, label: '홈', to: '/trainee/home' },
     { icon: FileTextIcon, label: '내 리포트', to: '/trainee/report' },
   ],
+  // dev 전용 — /trainee/__cases(TraineeCaseIndex)는 상태 9종·케이스별 확인용이라
+  // 같이 개발하는 사람이 매번 주소를 외워 치지 않아도 되게 여기 붙인다.
+  // import.meta.env.DEV라 프로덕션 빌드에는 이 그룹 자체가 안 들어간다.
+  ...(import.meta.env.DEV
+    ? [[{ icon: FlaskConicalIcon, label: '케이스 보기', to: '/trainee/__cases' }]]
+    : []),
 ]
 
 export const SIDEBAR_BY_ROLE: Record<Role, SidebarGroup[]> = {


### PR DESCRIPTION
## 작업 내용

TR-04 내 리포트 화면 신규 구현. 플레이스홀더 자리를 채웁니다. TR-01~04 중 마지막 화면입니다(#97·#99·#101).

커밋 3개로 갈랐습니다.

| 커밋 | 무엇 |
|---|---|
| `feat: add TR-04 my report contract and mock data` | `api.ts`/`mockDb.ts`/`types.ts`/`labels.ts` |
| `feat: build TR-04 my report screen` | `MyReportScreen.tsx` + `RoundRail`/`ConceptCard`/`QaList` |
| `chore: add dev-only trainee case index` | `TraineeCaseIndex.tsx`(`/trainee/__cases`) + 라우트 + 사이드바 링크 |

## 리뷰 포인트

### 1. 색 통일 — 핀과 배지가 같은 `--color-reach-1~4`를 씁니다

레벨 배지와 좌측 레일 점이 같은 레벨을 말하는데 예전엔 서로 다른 색 체계를 썼습니다. 매니저 쪽 도달단계 배지(MG-05)가 이미 쓰는 5단 원색 스케일을 그대로 가져다 씁니다(도메인 교차 import 없이 같은 전역 토큰만).

### 2. 해설 잠김/열림 — 무게·형태 둘 다로 명확히 구분

잠김은 중립 회색+점선(대기 신호, 에너지 없음), 열림은 primary색 실선+연한 배경+열린 자물쇠 아이콘으로 정반대 취급을 줬습니다. 예전엔 열린 해설이 왼쪽 포인트 선 하나뿐이라 잠긴 박스보다 오히려 존재감이 약했습니다.

### 3. dev 전용 케이스 인덱스 — 이 PR에 접어 넣었습니다

`TraineeCaseIndex.tsx`는 TR-01~04 전 화면의 케이스를 참조해서 4번째(마지막) 화면 전에는 완성될 수 없었습니다. 별도 이슈/PR을 새로 열기엔 파일 3개짜리 dev 전용 도구라, 이 PR 마지막 커밋으로 접었습니다 — 이슈 #103에도 그 이유를 적어 뒀습니다.

## 확인

- [x] 로컬에서 동작 확인
  - `format:check` · `check:design` · `design-doc --check` · `component-doc --check` · `lint` · `check:project` · `check:pagination` · `check:admin` · `build` 전부 통과(CI 파이프라인 그대로 로컬 재현)
  - 상태 전종 렌더 확인(`?state=` dev 오버라이드)
  - `/trainee/__cases`에서 4개 화면 케이스 전부 링크로 열림 확인
- [x] 하나의 PR = 하나의 기능

closes #103