### PR TITLE
[Fix] Add SPA Fallback Rewrite for Vercel Deploy

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
## 작업 내용

배포본에서 `/trainee/home` 등 클라이언트 라우트를 새로고침하면 404가 뜨던 문제 수정. `vercel.json`이 아예 없어 SPA fallback 규칙이 없었습니다.

## 리뷰 포인트

`createBrowserRouter`는 클라이언트 쪽 라우팅만 합니다 — 서버는 `/trainee/home` 같은 경로를 실제 파일로 갖고 있지 않아, 새로고침·직접 URL 입력처럼 서버에 진짜 요청이 가는 경우 404가 났습니다. 매칭되는 정적 파일이 없는 모든 경로를 `index.html`로 rewrite(200)하도록 설정 파일 하나를 추가했습니다 — Vercel 정적/SPA 배포의 표준 해법입니다. `/assets/*` 같은 실제 파일은 rewrite보다 우선 매칭되어 영향 없습니다.

## 확인

- [x] 로컬에서 동작 확인 (`format:check` 통과 — 파일 하나짜리 설정이라 빌드·타입체크 영향 없음)
- [x] 하나의 PR = 하나의 기능

closes #105