### PR TITLE
[Fix] Scope Dev-Only Trainee Case Link to Develop Deploys

### DIFF
--- a/src/shells/sidebarConfig.ts
+++ b/src/shells/sidebarConfig.ts
@@ -80,8 +80,10 @@ export const TRAINEE_SIDEBAR: SidebarGroup[] = [
   ],
   // dev 전용 — /trainee/__cases(TraineeCaseIndex)는 상태 9종·케이스별 확인용이라
   // 같이 개발하는 사람이 매번 주소를 외워 치지 않아도 되게 여기 붙인다.
-  // import.meta.env.DEV라 프로덕션 빌드에는 이 그룹 자체가 안 들어간다.
-  ...(import.meta.env.DEV
+  // import.meta.env.DEV만 보면 프로덕션 빌드(vite build)는 항상 false라 develop
+  // Vercel 프리뷰 배포도 걸러진다 — __GIT_BRANCH__(vite.config.ts define)로
+  // "로컬이거나 develop 배포"일 때만 보이게 하고, main 배포에서는 숨긴다.
+  ...(import.meta.env.DEV || __GIT_BRANCH__ === 'develop'
     ? [[{ icon: FlaskConicalIcon, label: '케이스 보기', to: '/trainee/__cases' }]]
     : []),
 ]

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="vite/client" />
+
+// vite.config.ts의 define — Vercel 빌드 시점의 배포 브랜치명("" = 로컬/알 수 없음)
+declare const __GIT_BRANCH__: string

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,4 +11,10 @@ export default defineConfig({
       '@': path.resolve(import.meta.dirname, './src'),
     },
   },
+  define: {
+    // Vercel이 빌드 시점에 심어주는 배포 브랜치 — import.meta.env.DEV는 프로덕션
+    // 빌드(vite build)에서 항상 false라 develop 프리뷰 배포도 걸러진다. dev 전용
+    // UI를 "로컬이거나 develop 배포"로 보이려면 브랜치 이름이 따로 필요하다.
+    __GIT_BRANCH__: JSON.stringify(process.env.VERCEL_GIT_COMMIT_REF ?? ''),
+  },
 })


### PR DESCRIPTION
## 작업 내용

사이드바의 dev 전용 "케이스 보기" 링크(#103)가 `import.meta.env.DEV`로만 걸려 있어, Vercel의 develop 프리뷰 배포(프로덕션 빌드라 DEV=false)에서도 안 보였습니다. develop 배포에서는 보이고 main에서는 안 보이도록 고쳤습니다.

## 리뷰 포인트

Vercel이 빌드 시점에 주는 `VERCEL_GIT_COMMIT_REF`를 `vite.config.ts`의 `define`으로 클라이언트에 `__GIT_BRANCH__`로 노출했습니다. 조건을 `import.meta.env.DEV || __GIT_BRANCH__ === 'develop'`로 바꿔 "로컬이거나 develop 배포"일 때만 보이게 했습니다.

로컬에서 세 경우(브랜치 환경변수 없음·`develop`·`main`)로 각각 `vite build`한 뒤 번들 안에 "케이스 보기" 문자열 유무로 검증했습니다 — 없음/main은 0건, develop은 1건.

## 확인

- [x] 로컬에서 동작 확인
  - `format:check` · `check:design` · `design-doc --check` · `component-doc --check` · `lint` · `typecheck` · `build` 전부 통과
  - 세 경우(없음/develop/main) 빌드 번들 검증
- [x] 하나의 PR = 하나의 기능

closes #107