### PR TITLE
[Chore] Add Dev-Only Role Switcher to Header

### DIFF
--- a/src/features/auth/LoginScreen.tsx
+++ b/src/features/auth/LoginScreen.tsx
@@ -8,6 +8,7 @@ import { resolveAuthState } from './authStates'
 import type { AuthState } from './authStates'
 import type { ApiError } from './authTypes'
 import { useCapsLockWarning } from './useCapsLockWarning'
+import { QUICK_LOGIN_ACCOUNTS } from './quickLoginAccounts'
 import BrandPanel from './components/BrandPanel'
 import AuthForm from './components/AuthForm'
 import TextLink from './components/TextLink'
@@ -83,14 +84,8 @@ export default function LoginScreen() {
 
   // 발표용 임시 — 실제 배포 시 이 함수와 아래 버튼 블록을 통째로 제거
   // 역할 선택 UI는 정책상 없음(§34 주석) — 이건 폼을 우회하는 데모 지름길일 뿐,
-  // 서버가 역할을 판정하는 로그인 흐름 자체는 그대로 재사용한다
-  const QUICK_LOGIN_ACCOUNTS: { label: string; email: string }[] = [
-    { label: '교육생', email: 'trainee@org.com' },
-    { label: '매니저', email: 'manager@org.com' },
-    { label: '오퍼레이터', email: 'operator@iz-get.com' },
-    { label: '슈퍼 어드민', email: 'admin@iz-get.com' },
-  ]
-
+  // 서버가 역할을 판정하는 로그인 흐름 자체는 그대로 재사용한다. 로그인 후에는
+  // 헤더의 같은 목록(dev 전용, Header.tsx)으로 화면 전환 없이 역할을 바꿀 수 있다.
   async function handleQuickLogin(quickEmail: string) {
     setAlert(null)
     setResendDone(false)

--- a/src/features/auth/quickLoginAccounts.ts
+++ b/src/features/auth/quickLoginAccounts.ts
@@ -1,0 +1,11 @@
+/**
+ * 발표용 계정 — dev 전용 역할 전환(Header)에서 씀. 비밀번호는 전부 pass1234.
+ * 역할 선택 UI는 정책상 화면엔 없음(LoginScreen 주석) — 이건 폼을 우회하는
+ * 데모 지름길일 뿐, 서버가 역할을 판정하는 로그인 흐름 자체는 그대로 재사용한다.
+ */
+export const QUICK_LOGIN_ACCOUNTS: { label: string; email: string }[] = [
+  { label: '슈퍼 어드민', email: 'admin@iz-get.com' },
+  { label: '오퍼레이터', email: 'operator@iz-get.com' },
+  { label: '매니저', email: 'manager@org.com' },
+  { label: '교육생', email: 'trainee@org.com' },
+]

--- a/src/shells/Header.tsx
+++ b/src/shells/Header.tsx
@@ -1,7 +1,16 @@
 import { useState } from 'react'
-import { Link, useLocation } from 'react-router'
-import { SettingsIcon } from 'lucide-react'
+import { Link, useLocation, useNavigate } from 'react-router'
+import { SettingsIcon, UserCogIcon } from 'lucide-react'
 import { Avatar, AvatarFallback } from '@/components/ui/Avatar'
+import { Button } from '@/components/ui/Button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from '@/components/ui/DropdownMenu'
 import {
   Select,
   SelectContent,
@@ -11,7 +20,54 @@ import {
 } from '@/components/ui/Select'
 import Wordmark from '@/components/common/Wordmark'
 import { cn } from '@/lib/utils/cn'
+import { useAuth } from '@/features/auth/AuthContext'
+import { login } from '@/features/auth/authApi'
+import { QUICK_LOGIN_ACCOUNTS } from '@/features/auth/quickLoginAccounts'
 import type { Role } from './sidebarConfig'
+
+// dev 전용 역할 전환(헤더) — import.meta.env.DEV는 프로덕션 빌드(vite build)에서
+// 항상 false라 develop Vercel 프리뷰 배포도 걸러진다. __GIT_BRANCH__(vite.config.ts
+// define, sidebarConfig.ts와 같은 패턴)로 "로컬이거나 develop 배포"일 때만 보이고
+// main 배포에서는 숨긴다.
+const SHOW_DEV_ROLE_SWITCHER = import.meta.env.DEV || __GIT_BRANCH__ === 'develop'
+
+function DevRoleSwitcher() {
+  const navigate = useNavigate()
+  const { signIn } = useAuth()
+
+  async function handleQuickLogin(email: string) {
+    try {
+      const res = await login({ email, password: 'pass1234' })
+      signIn(res)
+      navigate(res.initialScreen)
+    } catch (err) {
+      // dev 전용 지름길이라 실패해도 화면에 알릴 알림 자리가 없다 — 콘솔로 충분
+      console.error('quick login failed', err)
+    }
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <Button variant="ghost" size="sm" aria-label="역할 전환 (dev)">
+            <UserCogIcon className="size-4" aria-hidden="true" />
+          </Button>
+        }
+      />
+      <DropdownMenuContent align="end">
+        <DropdownMenuGroup>
+          <DropdownMenuLabel>역할 전환 (dev)</DropdownMenuLabel>
+          {QUICK_LOGIN_ACCOUNTS.map(({ label, email }) => (
+            <DropdownMenuItem key={email} onClick={() => handleQuickLogin(email)}>
+              {label}
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
 
 /*
   상단바 — 브랜드 + 스코프 선택기 + 사용자. 54px 고정 높이(목업 `.topbar{height:54px}`
@@ -66,6 +122,7 @@ export default function Header({ user, scope, role }: Props) {
       </div>
 
       <div className="text-fg-muted flex shrink-0 items-center gap-3 text-sm">
+        {SHOW_DEV_ROLE_SWITCHER && <DevRoleSwitcher />}
         {role === 'superadmin' && (
           <Link
             to="/superadmin/settings"


### PR DESCRIPTION
## 작업 내용

발표용 "역할별 바로 입장"을 헤더로 올려, 어느 화면에서든 로그아웃 없이 역할을 바꿀 수 있게 했습니다.

- `quickLoginAccounts.ts` — 로그인 화면 안에만 있던 계정 4개 목록을 추출. 로그인 화면과 헤더가 같은 목록을 씁니다.
- `Header.tsx` — 역할 전환 드롭다운 추가. 노출 조건은 #107이 만든 `import.meta.env.DEV || __GIT_BRANCH__ === 'develop'`를 그대로 재사용합니다.
- `LoginScreen.tsx` — 기존 버튼은 그대로 두고 목록만 공용 모듈에서 가져옵니다.

## 리뷰 포인트

- **로그인 화면 버튼을 왜 안 지웠나** — 로그인 전에는 셸(헤더)이 렌더되지 않아서, 지우면 최초 진입 수단이 없어집니다. 둘이 같은 목록을 쓰므로 계정이 바뀌어도 한 곳만 고칩니다.
- **`DropdownMenuLabel`을 `DropdownMenuGroup`으로 감싼 이유** — base-ui는 label을 `Menu.Group` 안에서만 허용합니다. 감싸지 않으면 드롭다운을 여는 순간 `MenuGroupContext is missing`으로 화면이 죽습니다(Playwright로 재현·수정 확인).
- **실패 처리** — 헤더에는 Alert 자리가 없어 `console.error`만 남깁니다. dev 전용이라 이 정도로 두는 게 맞다고 봤는데, 다르게 보시면 알려주세요.

## 확인

- [x] 로컬에서 동작 확인 — Playwright로 `/trainee/home` → 드롭다운 → 매니저 선택 → `/manager/dashboard` 전환, 콘솔 에러 없음
- [x] `VERCEL_GIT_COMMIT_REF`를 없음/`develop`/`main`으로 각각 빌드해 번들에 문자열이 develop에만 들어가는 것 확인
- [x] 하나의 PR = 하나의 기능

closes #110
