### PR TITLE
[Feat] Add Manager Interview List Screen

### DIFF
--- a/src/features/manager/interviews/InterviewListScreen.tsx
+++ b/src/features/manager/interviews/InterviewListScreen.tsx
@@ -1,11 +1,417 @@
+import { useCallback, useState } from 'react'
+import { Link, useNavigate } from 'react-router'
 import ConsoleShell from '@/shells/ConsoleShell'
-import PlaceholderScreen from '@/app/PlaceholderScreen'
+import PageHeader from '@/components/common/PageHeader'
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from '@/components/ui/Table'
+import { Empty, EmptyHeader, EmptyTitle, EmptyDescription } from '@/components/ui/Empty'
+import { Alert, AlertTitle, AlertDescription, AlertAction } from '@/components/ui/Alert'
+import { Button } from '@/components/ui/Button'
+import { Spinner } from '@/components/ui/Spinner'
+import { useAsync } from '@/lib/useAsync'
+import {
+  excludeCase,
+  listInterviews,
+  shortDateLabel,
+  undoExclude,
+  type CaseRisk,
+  type ClassName,
+  type InterviewCase,
+} from './mockData'
+import { ALL, INITIAL_FILTERS, isNarrowed, type FilterValues } from './filterState'
+import InterviewStatusBadge from './components/InterviewStatusBadge'
+import RiskBadge, { RiskReason } from './components/RiskBadge'
+import InterviewFilters from './components/InterviewFilters'
+import VoidConfirmDialog from './components/VoidConfirmDialog'
 
-/** MG-03 면담 목록 — 화면 이식 전 자리표시. 실제 화면이 들어오면 이 파일 내용만 바뀐다. */
+/*
+  MG-03 면담 목록 — "위험 판정이 켜진 학생의 작업 큐"(정의서 §1). 조회 화면이
+  아니라 처리하는 화면이라, MG-07처럼 조립만 하고 셀 분기는 `RiskBadge`·
+  `InterviewStatusBadge`가, 목 데이터·정렬·mock API는 `mockData.ts`가 갖는다.
+
+  **체크박스가 없다**(정의서 §3) — 위험 판정이 켜지면 자동 등재되므로 여기 있는
+  사람이 곧 대상이다. 빼는 것은 행의 `[제외]` 버튼 하나뿐이다.
+
+  **행 전체 클릭을 만들지 않는다** — 이름 클릭(MG-06 조회)과 `[브리프 열기]`
+  (MG-04 작업)은 목적지가 다른 별개 동작이다(정의서 §5).
+
+  ⚠ 제외는 확인 다이얼로그 없이 즉시 실행된다(목업 `#exclude` 장면 — 클릭 즉시
+  상태가 바뀌고 인라인 배너로 되돌리기를 남긴다). 정의서 §6 "제외는 되돌릴 수
+  있다"가 이미 안전장치라 판단해, 되돌릴 수 없는 조작에나 쓰는 확인 모달을 여기
+  또 얹지 않았다(TeamTab 팀 삭제·ResultTab 마감 전 발행처럼 **되돌릴 수 없는**
+  조작에만 AlertDialog를 쓰는 이 레포 관례와 일관된다).
+*/
+
+const briefPath = (caseId: string) => `/manager/interviews/${caseId}/brief`
+const traineePath = (traineeId: string) => `/manager/trainees/${traineeId}`
+
 export default function InterviewListScreen() {
+  const navigate = useNavigate()
+  const [filters, setFilters] = useState<FilterValues>(INITIAL_FILTERS)
+  const [voidTarget, setVoidTarget] = useState<InterviewCase | null>(null)
+  const [undoBanner, setUndoBanner] = useState<{ caseId: string; name: string } | null>(null)
+  const [rowPending, setRowPending] = useState<string | null>(null)
+  const [rowFailed, setRowFailed] = useState<string | null>(null)
+
+  const loadInterviews = useCallback(
+    () =>
+      listInterviews({
+        round: filters.round,
+        search: filters.search || undefined,
+        status: filters.status === ALL ? undefined : filters.status,
+        riskType: filters.riskType === ALL ? undefined : (filters.riskType as CaseRisk['type']),
+        classFilter: filters.classFilter === ALL ? undefined : (filters.classFilter as ClassName),
+      }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [filters],
+  )
+  const page = useAsync(loadInterviews)
+  const narrowed = isNarrowed(filters)
+
+  function changeFilters(patch: Partial<FilterValues>) {
+    if (patch.round) setUndoBanner(null)
+    setFilters((f) => ({ ...f, ...patch }))
+  }
+
+  async function handleExclude(c: InterviewCase) {
+    setRowPending(c.id)
+    setRowFailed(null)
+    try {
+      await excludeCase(filters.round, c.id)
+      setUndoBanner({ caseId: c.id, name: c.name })
+      page.reload()
+    } catch {
+      setRowFailed(c.id)
+    } finally {
+      setRowPending(null)
+    }
+  }
+
+  /**
+   * 되돌리기 — id만 받는다(케이스 객체를 받지 않는다). 되돌리기 배너는 필터로
+   * 좁혀진 현재 목록(`data.items`)에 그 케이스가 없을 수 있다(예: 반 필터를 다른
+   * 반으로 바꾼 채 배너의 되돌리기를 누르는 경우) — 목록에서 다시 찾아 누르는
+   * 방식이었을 때 못 찾으면 조용히 아무 일도 안 일어나는 버그가 있었다(사용자
+   * 지적). id로 바로 mock API를 부르면 현재 화면에 그 케이스가 보이는지와
+   * 무관하게 항상 동작한다.
+   */
+  async function handleUndo(caseId: string) {
+    setRowPending(caseId)
+    setRowFailed(null)
+    try {
+      await undoExclude(filters.round, caseId)
+      setUndoBanner((b) => (b?.caseId === caseId ? null : b))
+      page.reload()
+    } catch {
+      setRowFailed(caseId)
+    } finally {
+      setRowPending(null)
+    }
+  }
+
+  const data = page.data
+  const round = data?.round
+  const showOverdueBar =
+    !!round &&
+    !round.isFirstRound &&
+    round.resultStatus === 'READY' &&
+    (data?.counts.PLANNED ?? 0) > 0
+  const showFirstRoundBar =
+    !!round && round.isFirstRound && round.resultStatus === 'READY' && (data?.total ?? 0) > 0
+
   return (
     <ConsoleShell role="manager">
-      <PlaceholderScreen code="MG-03" title="면담 목록" />
+      <PageHeader
+        breadcrumb="면담 › 7기 › 담당 반"
+        title="면담"
+        count={data ? `${data.total}명` : undefined}
+        breakdown={
+          data && (
+            <span className="text-fg-muted flex items-center gap-3">
+              <span>
+                예정 <b className="text-fg font-bold">{data.counts.PLANNED}</b>
+              </span>
+              <span>
+                종결 <b className="text-fg font-bold">{data.counts.DONE}</b>
+              </span>
+              <span className={data.counts.EXCLUDED === 0 ? 'text-fg-subtle' : undefined}>
+                제외 <b className="text-fg font-bold">{data.counts.EXCLUDED}</b>
+              </span>
+            </span>
+          )
+        }
+      />
+
+      <InterviewFilters
+        {...filters}
+        counts={data?.counts}
+        riskCounts={data?.riskCounts}
+        onChange={changeFilters}
+      />
+
+      {showOverdueBar && round && data && (
+        <Alert variant="warning" className="mb-3">
+          <AlertTitle>
+            {round.label} 면담이 {round.daysSincePublish}일째 안 끝났습니다
+          </AlertTitle>
+          <AlertDescription>
+            {round.publishedAtLabel} 리포트 발행과 함께 등재 — <b>{data.counts.PLANNED}명</b>이 아직
+            예정입니다
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {showFirstRoundBar && (
+        <Alert variant="info" className="mb-3">
+          <AlertTitle>1차는 비교할 직전 회차가 없어 위험 유형이 붙지 않습니다</AlertTitle>
+          <AlertDescription>
+            단계 하락·지속 저점은 2차부터 확정됩니다. 지금은 2단 이하 개념 개수만 보입니다.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {undoBanner && (
+        <Alert variant="info" className="mb-3">
+          <AlertTitle>{undoBanner.name}을(를) 이번 회차 대상에서 뺐습니다.</AlertTitle>
+          <AlertAction>
+            <Button variant="ghost" size="sm" onClick={() => void handleUndo(undoBanner.caseId)}>
+              되돌리기
+            </Button>
+          </AlertAction>
+        </Alert>
+      )}
+
+      {page.loading ? (
+        <div className="flex justify-center py-16">
+          <Spinner className="size-6" aria-label="목록을 불러오는 중" />
+        </div>
+      ) : page.failed ? (
+        <Empty>
+          <EmptyHeader>
+            <EmptyTitle>목록을 불러오지 못했습니다</EmptyTitle>
+            <EmptyDescription>잠시 후 다시 시도해 주세요.</EmptyDescription>
+          </EmptyHeader>
+          <Button variant="ghost" onClick={page.reload}>
+            다시 시도
+          </Button>
+        </Empty>
+      ) : round?.resultStatus === 'PENDING' ? (
+        <Empty>
+          {/* max-w-sm 기본값이면 첫 문장이 폭에 걸려 줄바꿈이 두 줄이 아니라
+              세 줄로 보인다(사용자 지적) — 문장이 한 줄에 들어가도록 넓힌다 */}
+          <EmptyHeader className="max-w-md">
+            <EmptyTitle>이 회차는 아직 결과가 없어요</EmptyTitle>
+            <EmptyDescription>
+              이해도 확인이 끝나면 위험 판정이 켜진 사람이 자동으로 등재됩니다.
+              <br />
+              지난 회차를 보려면 위에서 회차를 바꾸세요.
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      ) : data && data.counts.PLANNED + data.counts.DONE + data.counts.EXCLUDED === 0 ? (
+        // 회차 전체가 비어 있다(필터와 무관) — "필터에 안 걸림"과 다른 문구(정의서 §6)
+        <Empty className="border-solid bg-surface">
+          <EmptyHeader>
+            <EmptyTitle>이번 회차 면담 대상이 없습니다</EmptyTitle>
+            <EmptyDescription>
+              2단 이하 개념이 2개 이상인 사람이 없어요.
+              <br />
+              1개인 사람은 그 개념만 다시 보기로 처리됩니다.
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      ) : data?.items.length === 0 ? (
+        narrowed && (
+          <Empty>
+            <EmptyHeader>
+              <EmptyTitle>
+                {filters.search
+                  ? `"${filters.search}"와 맞는 대상이 없습니다`
+                  : '조건에 맞는 대상이 없습니다'}
+              </EmptyTitle>
+            </EmptyHeader>
+          </Empty>
+        )
+      ) : (
+        data && (
+          <>
+            <Table className="table-fixed">
+              <TableHeader>
+                <TableRow className="hover:bg-transparent">
+                  <TableHead className="w-20">상태</TableHead>
+                  <TableHead className="w-40">이름</TableHead>
+                  <TableHead className="w-28">위험 유형</TableHead>
+                  <TableHead className="w-44">판정 근거</TableHead>
+                  <TableHead>마지막 활동</TableHead>
+                  <TableHead className="w-44 text-right">액션</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {data.items.map((c) => (
+                  <TableRow
+                    key={c.id}
+                    className={c.status === 'EXCLUDED' ? 'opacity-45' : undefined}
+                  >
+                    <TableCell>
+                      <InterviewStatusBadge status={c.status} />
+                    </TableCell>
+                    <TableCell className="whitespace-nowrap">
+                      <Link to={traineePath(c.traineeId)} className="font-bold hover:underline">
+                        {c.name}
+                      </Link>
+                      <span className="text-fg-subtle ml-1.5 text-2xs">{c.className}</span>
+                    </TableCell>
+                    <TableCell>
+                      <RiskBadge risk={c.risk} />
+                    </TableCell>
+                    <TableCell>
+                      <RiskReason
+                        risk={c.risk}
+                        voidResolved={c.risk.type === 'INVALID' && !c.voidEvidence}
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <LastActivityCell caseItem={c} registeredAtLabel={round?.publishedAtLabel} />
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {rowFailed === c.id ? (
+                        <div className="flex items-center justify-end gap-2">
+                          <span className="text-danger text-2xs">바꾸지 못했습니다</span>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() =>
+                              c.status === 'EXCLUDED' ? handleUndo(c.id) : handleExclude(c)
+                            }
+                          >
+                            다시
+                          </Button>
+                        </div>
+                      ) : (
+                        <RowActions
+                          caseItem={c}
+                          pending={rowPending === c.id}
+                          onOpenBrief={() => navigate(briefPath(c.id))}
+                          onOpenVoid={() => setVoidTarget(c)}
+                          onExclude={() => handleExclude(c)}
+                          onUndo={() => handleUndo(c.id)}
+                        />
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+
+            {/* 페이지가 하나뿐이라 페이저를 그리지 않는다(E7 — 누를 수 없는 컨트롤은 장식) */}
+            <div className="mt-3 grid grid-cols-3 items-center">
+              <p className="text-fg-subtle text-xs">{`1–${data.items.length} / ${data.total}명`}</p>
+              <div />
+              <div />
+            </div>
+          </>
+        )
+      )}
+
+      {voidTarget && (
+        <VoidConfirmDialog
+          roundId={filters.round}
+          caseItem={voidTarget}
+          open={voidTarget !== null}
+          onOpenChange={(open) => !open && setVoidTarget(null)}
+          onResolved={page.reload}
+        />
+      )}
     </ConsoleShell>
+  )
+}
+
+/**
+ * 마지막 활동 열 — 상태별로 다른 값을 한 열에 통합한다(정의서 §3). 예정 상태의
+ * 등재일은 케이스가 아니라 **회차**의 값이다(`mockData.ts` 판단 기록 — 대기는
+ * 개인별이 아니라 회차 경과다) — 그래서 회차의 `publishedAtLabel`을 받는다.
+ */
+function LastActivityCell({
+  caseItem: c,
+  registeredAtLabel,
+}: {
+  caseItem: InterviewCase
+  registeredAtLabel?: string
+}) {
+  if (c.status === 'DONE' && c.interview) {
+    return (
+      <span className="text-fg-muted">
+        {shortDateLabel(c.interview.date)} 면담 ·{' '}
+        <span className="text-fg-subtle">
+          다음에 할 것 — {c.interview.nextAction ? `"${c.interview.nextAction}"` : '없음'}
+        </span>
+      </span>
+    )
+  }
+  if (c.status === 'EXCLUDED') {
+    return (
+      <span className="text-fg-subtle">
+        {c.excludedAt && shortDateLabel(c.excludedAt)} 제외 · {c.excludedBy}
+      </span>
+    )
+  }
+  // PLANNED
+  if (c.risk.type === 'INVALID' && c.voidEvidence) {
+    return <span className="text-warning font-medium">응답 없음 · 매니저 확인 필요</span>
+  }
+  if (c.risk.type === 'INVALID') {
+    return <span className="text-fg-subtle">확인 완료 · 그대로 유지</span>
+  }
+  return <span className="text-fg-subtle">{registeredAtLabel} 등재</span>
+}
+
+function RowActions({
+  caseItem: c,
+  pending,
+  onOpenBrief,
+  onOpenVoid,
+  onExclude,
+  onUndo,
+}: {
+  caseItem: InterviewCase
+  pending: boolean
+  onOpenBrief: () => void
+  onOpenVoid: () => void
+  onExclude: () => void
+  onUndo: () => void
+}) {
+  if (c.status === 'DONE') return null
+
+  if (c.status === 'EXCLUDED') {
+    return (
+      <Button variant="ghost" size="sm" disabled={pending} onClick={onUndo}>
+        되돌리기
+      </Button>
+    )
+  }
+
+  // PLANNED
+  const needsVoidCheck = c.risk.type === 'INVALID' && c.voidEvidence
+  return (
+    <div className="flex justify-end gap-1.5">
+      {needsVoidCheck ? (
+        <Button variant="ghost" size="sm" disabled={pending} onClick={onOpenVoid}>
+          무효 확인
+        </Button>
+      ) : (
+        <Button variant="primary" size="sm" disabled={pending} onClick={onOpenBrief}>
+          브리프 열기
+        </Button>
+      )}
+      <Button variant="ghost" size="sm" disabled={pending} onClick={onExclude}>
+        제외
+      </Button>
+    </div>
   )
 }

--- a/src/features/manager/interviews/components/InterviewFilters.tsx
+++ b/src/features/manager/interviews/components/InterviewFilters.tsx
@@ -1,0 +1,180 @@
+import { SearchIcon, XIcon } from 'lucide-react'
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from '@/components/ui/InputGroup'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/Select'
+import {
+  CLASS_OPTIONS,
+  RISK_LABEL,
+  RISK_TYPE_OPTIONS,
+  ROUND_OPTIONS,
+  STATUS_LABEL,
+  type CaseRisk,
+  type InterviewCounts,
+} from '../mockData'
+import { ALL, type FilterValues } from '../filterState'
+
+/*
+  목록 툴바 — 회차 · 이름 검색 · 상태 · 반 · 위험 유형. MG-07 `ProjectFilters`와
+  같은 조립(트리거 폭 고정, 개수 있는 옵션엔 개수 싣기).
+
+  ⚠ 위험 유형·반 필터 추가(사용자 지시, 렌더 확인 후) — 위험 유형은 상태처럼
+  옵션에 개수를 싣고(`riskCounts`), 반은 MG-07 `ProjectFilters`의 반 필터와 같이
+  개수 없이 이름만(그 필터엔 애초에 개수가 없었다 — 반은 검색 스코프를 좁히는
+  용도지, 분포를 보여주는 용도가 아니라는 판단을 그대로 따랐다). 순서는 상태 →
+  반 → 위험 유형(사용자 지시) — 상태·반은 흔히 같이 좁혀 보는 축이라 붙이고,
+  위험 유형은 옵션 라벨이 길어 맨 끝에 둬도 다른 트리거를 밀지 않는다.
+
+  ⚠ **정렬 안내 고정 문구를 없앴다**(사용자 지시, 렌더 확인 후) — 정렬 자체는
+  여전히 사용자가 못 고른다(정의서 §3, `mockData.ts`의 `sortCases`가 고정 규칙을
+  가짐), 그런데 "정렬 OO 순"이라는 안내 문구는 이 레포 다른 목록 화면(MG-07
+  등)에 없던 것을 이 화면에만 새로 만든 것이었다 — 사용자가 "보여주는 이유가
+  없는 것 같다"고 지적했고 맞는 지적이라 판단해 지웠다(고르지도 못하는 값을
+  굳이 문구로 설명할 필요는 없다 — 이상하면 필요할 때 표에서 직접 확인하면 된다).
+*/
+
+const items = (prefix: string, options: { value: string; label: string }[]) =>
+  Object.fromEntries(options.map((o) => [o.value, `${prefix} · ${o.label}`]))
+
+type Props = FilterValues & {
+  counts?: InterviewCounts
+  riskCounts?: Record<CaseRisk['type'], number>
+  onChange: (patch: Partial<FilterValues>) => void
+}
+
+const sum = (c: InterviewCounts) => c.PLANNED + c.DONE + c.EXCLUDED
+const sumRisk = (c: Record<CaseRisk['type'], number>) =>
+  c.INVALID + c.LOW_PERSISTENT + c.DECLINE + c.OBSERVE
+
+export default function InterviewFilters({
+  round,
+  search,
+  status,
+  riskType,
+  classFilter,
+  counts,
+  riskCounts,
+  onChange,
+}: Props) {
+  const statusOptions = [
+    { value: ALL, label: counts ? `전체 (${sum(counts)})` : '전체' },
+    ...(Object.keys(STATUS_LABEL) as (keyof typeof STATUS_LABEL)[]).map((s) => ({
+      value: s,
+      label: counts ? `${STATUS_LABEL[s]} (${counts[s]})` : STATUS_LABEL[s],
+    })),
+  ]
+
+  const riskOptions = [
+    { value: ALL, label: riskCounts ? `전체 (${sumRisk(riskCounts)})` : '전체' },
+    ...RISK_TYPE_OPTIONS.map((t) => ({
+      value: t,
+      label: riskCounts ? `${RISK_LABEL[t]} (${riskCounts[t]})` : RISK_LABEL[t],
+    })),
+  ]
+
+  const classOptions = [
+    { value: ALL, label: '전체' },
+    ...CLASS_OPTIONS.map((c) => ({ value: c, label: c })),
+  ]
+
+  return (
+    <div className="mb-3 flex flex-wrap items-center gap-2">
+      <FilterSelect
+        label="회차"
+        value={round}
+        options={ROUND_OPTIONS}
+        onChange={(v) => onChange({ round: v as FilterValues['round'] })}
+        className="w-44"
+      />
+
+      <InputGroup className="h-9 w-60">
+        <InputGroupAddon>
+          <SearchIcon />
+        </InputGroupAddon>
+        <InputGroupInput
+          value={search}
+          onChange={(e) => onChange({ search: e.target.value })}
+          placeholder="이름 검색"
+          aria-label="이름 검색"
+        />
+        {search && (
+          <InputGroupAddon align="inline-end">
+            <InputGroupButton
+              size="icon-xs"
+              aria-label="검색어 지우기"
+              onClick={() => onChange({ search: '' })}
+            >
+              <XIcon />
+            </InputGroupButton>
+          </InputGroupAddon>
+        )}
+      </InputGroup>
+
+      <FilterSelect
+        label="상태"
+        value={status}
+        options={statusOptions}
+        onChange={(v) => onChange({ status: v })}
+        className="w-32"
+      />
+
+      <FilterSelect
+        label="반"
+        value={classFilter}
+        options={classOptions}
+        onChange={(v) => onChange({ classFilter: v })}
+        className="w-28"
+      />
+
+      <FilterSelect
+        label="위험 유형"
+        value={riskType}
+        options={riskOptions}
+        onChange={(v) => onChange({ riskType: v })}
+        className="w-60"
+      />
+    </div>
+  )
+}
+
+function FilterSelect({
+  label,
+  value,
+  options,
+  onChange,
+  className = 'w-28',
+}: {
+  label: string
+  value: string
+  options: { value: string; label: string }[]
+  onChange: (value: string) => void
+  className?: string
+}) {
+  return (
+    <Select
+      value={value}
+      onValueChange={(v) => onChange(v ?? options[0].value)}
+      items={items(label, options)}
+    >
+      <SelectTrigger className={`h-9 ${className}`} aria-label={`${label} 필터`}>
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {options.map((o) => (
+          <SelectItem key={o.value} value={o.value}>
+            {label} · {o.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}

--- a/src/features/manager/interviews/components/InterviewStatusBadge.tsx
+++ b/src/features/manager/interviews/components/InterviewStatusBadge.tsx
@@ -1,0 +1,20 @@
+import Badge from '@/components/ui/Badge'
+import { STATUS_LABEL, type InterviewCaseStatus } from '../mockData'
+
+/*
+  상태 3종(정의서 §3) — 예정/종결/제외. 목업 `.st.plan2`(파랑 계열)는 공용 Badge에
+  없는 primary 색이라, 가장 뜻이 가까운 `info`로 옮긴다(파랑 계열 유지 — "아직 처리할
+  일이 남았다"는 뜻). 종결·제외는 둘 다 `.st.cl`/`.st.ex`처럼 회색이라 `neutral` —
+  둘의 시각적 구분은 배지가 아니라 행 자체의 옅어짐으로 준다(`InterviewListScreen`의
+  `EXCLUDED` 행 `opacity-45`, 목업 `tr.off{opacity:.45}`와 같다). 라벨은
+  `mockData.ts`의 `STATUS_LABEL`이 원천이다 — `InterviewFilters`와 같은 값을 쓴다.
+*/
+const VARIANT: Record<InterviewCaseStatus, 'info' | 'neutral'> = {
+  PLANNED: 'info',
+  DONE: 'neutral',
+  EXCLUDED: 'neutral',
+}
+
+export default function InterviewStatusBadge({ status }: { status: InterviewCaseStatus }) {
+  return <Badge variant={VARIANT[status]}>{STATUS_LABEL[status]}</Badge>
+}

--- a/src/features/manager/interviews/components/RiskBadge.tsx
+++ b/src/features/manager/interviews/components/RiskBadge.tsx
@@ -1,0 +1,47 @@
+import Badge from '@/components/ui/Badge'
+import { RISK_LABEL, type CaseRisk } from '../mockData'
+
+/*
+  목업 `.rbadge.void`·`.rbadge.low`(둘 다 danger) · `.rbadge.down`(warning) ·
+  `.rbadge.obs`(neutral, 1차 전용 "관찰")를 그대로 옮긴다. `무효 응시`·`지속 저점`이
+  같은 색인 이유는 목업 자체가 그렇다 — 둘 다 "결과를 못 믿는다"는 뜻의 급함이다.
+  라벨은 `mockData.ts`의 `RISK_LABEL`이 원천이다 — `InterviewFilters`(필터 옵션)와
+  같은 값을 쓴다.
+*/
+const VARIANT: Record<CaseRisk['type'], 'danger' | 'warning' | 'neutral'> = {
+  INVALID: 'danger',
+  LOW_PERSISTENT: 'danger',
+  DECLINE: 'warning',
+  OBSERVE: 'neutral',
+}
+
+export default function RiskBadge({ risk }: { risk: CaseRisk }) {
+  return <Badge variant={VARIANT[risk.type]}>{RISK_LABEL[risk.type]}</Badge>
+}
+
+/** 판정 근거 열 — 위험 유형마다 문구가 다르다(정의서 §3 뷰, 숫자만 굵게) */
+export function RiskReason({ risk, voidResolved }: { risk: CaseRisk; voidResolved: boolean }) {
+  if (risk.type === 'INVALID') {
+    return <span className="text-fg-subtle">{voidResolved ? '— 확인 완료' : '— 채점 전'}</span>
+  }
+  if (risk.type === 'LOW_PERSISTENT') {
+    return (
+      <span className="text-fg-muted tabular-nums">
+        2단 이하 <b className="text-fg font-bold">{risk.lowCount}</b> · {risk.streak}회 연속
+      </span>
+    )
+  }
+  if (risk.type === 'DECLINE') {
+    return (
+      <span className="text-fg-muted tabular-nums">
+        2단 이하 <b className="text-fg font-bold">{risk.from}</b> →{' '}
+        <b className="text-fg font-bold">{risk.to}</b>
+      </span>
+    )
+  }
+  return (
+    <span className="text-fg-muted tabular-nums">
+      2단 이하 <b className="text-fg font-bold">{risk.lowCount}</b>
+    </span>
+  )
+}

--- a/src/features/manager/interviews/components/VoidConfirmDialog.tsx
+++ b/src/features/manager/interviews/components/VoidConfirmDialog.tsx
@@ -1,0 +1,106 @@
+import { useState } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/Dialog'
+import { Button } from '@/components/ui/Button'
+import { resolveVoid, type InterviewCase, type RoundId } from '../mockData'
+
+/*
+  무효 응시 확인 모달(#void) — 정의서 §5 "자동 확정하지 않는다"(9-4). 시스템은
+  **본 것**(무응답 문항 수·복사 여부·응답 시간)만 보여주고 판정은 사람이 한다 —
+  결과를 지우는 일이라 오탐 비용이 크다.
+*/
+
+type Props = {
+  roundId: RoundId
+  caseItem: InterviewCase
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onResolved: () => void
+}
+
+export default function VoidConfirmDialog({
+  roundId,
+  caseItem,
+  open,
+  onOpenChange,
+  onResolved,
+}: Props) {
+  const [pending, setPending] = useState<'INVALIDATE' | 'KEEP' | null>(null)
+  const ev = caseItem.voidEvidence
+
+  async function resolve(action: 'INVALIDATE' | 'KEEP') {
+    setPending(action)
+    try {
+      await resolveVoid(roundId, caseItem.id, action)
+      onOpenChange(false)
+      onResolved()
+    } finally {
+      setPending(null)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{caseItem.name} · 무효 응시로 처리할까요?</DialogTitle>
+        </DialogHeader>
+
+        <div className="text-fg-muted space-y-3 text-sm leading-relaxed">
+          <p>
+            <b className="text-fg">이 회차 결과가 지워집니다.</b>
+            <br />
+            도달 단계도 위험 판정도 남지 않고, 반 평균에서도 빠집니다.
+          </p>
+
+          {ev && (
+            <div className="bg-surface-2 border-border rounded-md border p-3">
+              <div className="text-fg-subtle mb-1 text-2xs font-bold">시스템이 본 것</div>
+              <div className="text-xs">
+                {ev.totalQuestions}문항 중{' '}
+                <b className="text-fg font-bold">{ev.unanswered}문항 무응답</b>
+                {ev.copied && (
+                  <>
+                    {' '}
+                    · 나머지 1문항은 <b className="text-fg font-bold">질문 문장을 그대로 복사</b>
+                  </>
+                )}{' '}
+                · 총 응답 시간 <b className="text-fg font-bold">{ev.durationMin}분</b>
+              </div>
+            </div>
+          )}
+
+          <div className="text-warning flex gap-1.5 text-xs leading-relaxed">
+            <span>⚠</span>
+            {/* 아이콘을 걸이표처럼 왼쪽에 붙이고, 줄바꿈된 두 줄은 아이콘 없이
+                본문끼리 세로줄을 맞춘다(사용자 지적 — "그대로 두면"이 "무효로"와
+                맞아야 한다) */}
+            <span>
+              무효로 처리하면 <b>1차로 재응시</b>하게 되고,
+              <br />
+              그대로 두면 이 결과가 남습니다.
+            </span>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" disabled={pending !== null} onClick={() => resolve('KEEP')}>
+            그대로 두기
+          </Button>
+          <Button
+            variant="primary"
+            disabled={pending !== null}
+            onClick={() => resolve('INVALIDATE')}
+          >
+            무효로 처리하고 재응시 안내
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/features/manager/interviews/filterState.ts
+++ b/src/features/manager/interviews/filterState.ts
@@ -1,0 +1,37 @@
+import type { RoundId } from './mockData'
+
+/*
+  목록 필터의 값. UI(`components/InterviewFilters.tsx`)와 파일을 가른 이유는
+  MG-07 filterState.ts(D20)와 같다 — 한 파일이 컴포넌트와 값을 같이 export하면
+  React Fast Refresh가 그 파일에 상태 보존 핫리로드를 못 해준다
+  (react/only-export-components).
+
+  정렬 값이 없다 — 정의서 §3 "이미 급한 순으로 온다, 사용자가 고를 일이 아니다"라
+  고정값이라 필터로 두지 않는다(`mockData.ts`의 `sortCases`가 갖는다).
+*/
+
+export const ALL = 'ALL'
+
+export type FilterValues = {
+  round: RoundId
+  search: string
+  /** 'ALL' | InterviewCaseStatus */
+  status: string
+  /** 'ALL' | CaseRisk['type'] */
+  riskType: string
+  /** 'ALL' | ClassName */
+  classFilter: string
+}
+
+export const INITIAL_FILTERS: FilterValues = {
+  round: '3',
+  search: '',
+  status: ALL,
+  riskType: ALL,
+  classFilter: ALL,
+}
+
+/** 빈 결과가 "아직 없음"인지 "필터에 안 걸림"인지 — 문구가 갈린다(MG-07 isNarrowed와 같은 이유) */
+export function isNarrowed(f: FilterValues): boolean {
+  return f.search !== '' || f.status !== ALL || f.riskType !== ALL || f.classFilter !== ALL
+}

--- a/src/features/manager/interviews/mockData.ts
+++ b/src/features/manager/interviews/mockData.ts
@@ -1,0 +1,467 @@
+/*
+  MG-03 면담 목록 목업. API 연동 전까지 화면을 검증하기 위한 고정 데이터 + mock API다.
+  실 데이터가 붙으면 이 파일은 지운다.
+
+  값은 목업 docs/plan/v2/wireframe/manager/interviews.html의 9개 케이스 장면(#list·
+  #done·#void·#exclude·#past·#empty·#pending·#first)을 그대로 옮긴다. 위험 배지 3종
+  (무효 응시·지속 저점·단계 하락)은 `features/manager/trainees/mockData.ts`의 기존
+  `RoundBadgeKind`(DECLINE·LOW_PERSISTENT·ACE 등)와 뜻이 대응하지만, 이 레포에 역할
+  간 mock cross-import 전례가 없어(projects/mockData.ts 머리말과 같은 이유) 값 자체는
+  이 파일에 독립적으로 둔다.
+
+  ⚠ 판단 기록 — 이 파일이 정한 것(정의서·와이어에 없음)
+
+  · **회차를 5개로 뒀다**(`features/manager/projects/mockData.ts`가 미프 1~5차를 쓰는
+    것과 같은 폭) — 와이어 9개 장면을 전부 재현하려면 최소 5개 상태가 필요하다:
+    1차(관찰 배지, #first) · 2차(전부 종결·제외, #past) · 3차(진행 중, #list 기본) ·
+    4차(결과 전, #pending) · 5차(대상 0명, #empty).
+  · **`MOCK_TODAY = '2026-07-27'`.** 와이어 상단 경고줄 "미프 3차 면담이 6일째 안
+    끝났습니다 · 7/21 리포트 발행"과 `#exclude` 장면의 "7/27 제외 · 박지현"이 같은
+    오늘을 가리킨다 — 역산하면 7/21 + 6일 = 7/27. `features/manager/projects/
+    mockData.ts`의 `MOCK_TODAY`(7/18)와 값이 다른데, 그 파일과 이 파일은 서로 다른
+    장면을 그리는 독립된 목이라 같은 "오늘"일 이유가 없다(사용자가 실제로 두 화면을
+    같은 순간에 렌더 비교하기 전까지는 맞출 필요가 없다).
+  · **등재일을 케이스마다 두지 않고 회차 하나로 둔다**(`InterviewRound.publishedAt`) —
+    정의서 §3 "대기는 개인별이 아니라 회차 경과다": 리포트가 회차 단위로 일괄
+    발행되므로 위험 판정도 그 순간 한꺼번에 켜져 회차 안에서 전부 같은 값이다. 케이스
+    마다 등재일을 반복해 두지 않는다(같은 값을 두 번 두지 않는다).
+  · **정렬은 사용자가 못 고른다**(정의서 §3 "이미 급한 순으로 온다"). 그래서
+    `InterviewFilters`에 실제 `Select`가 아니라 고정 문구만 둔다(E7 — 누를 수 없는
+    컨트롤은 장식이니 안 그린다) — **정렬 규칙 자체는 렌더 확인 후 사용자 지시로
+    한 번 바뀌었다**(아래).
+  · **⚠ 정렬 규칙 2차 반영(사용자 지시, 렌더 확인 후)** — 처음엔 정의서 §3 "위험
+    유형 → 2단 이하 개수"만 썼는데, 사용자가 위험 유형 필터·반 필터를 새로 추가하며
+    "기본값은 상태(예정, 종결) 그다음 반 오름차순"으로 바꿔달라고 지시했다. 이제
+    `sortCases`는 ① **무효 응시(9-4 "못하는 것보다 안 하는 것이 더 급하다")는
+    상태·반과 무관하게 항상 최상단** — 이 원칙은 이번 지시가 부정한 적이 없고,
+    위험 유형 필터로 걸러 보는 것과 별개로 "필터 없이 봐도 눈에 띄어야 한다"는
+    근거가 여전히 유효해 프론트 판단으로 남겼다. ② 그다음 상태(예정·제외를 먼저,
+    종결을 나중) → ③ 반 오름차순(A·B·C) → ④ 이름 가나다순(동점 결정성). 위험
+    유형별 순위(`riskRank`)·2단 이하 개수 내림차순(`riskCount`)은 더는 정렬에
+    안 쓰지만, **위험 유형 필터 옵션 개수 표시**에 여전히 쓰여서 남겨뒀다.
+  · **무효 응시 "그대로 두기"** — 정의서 "그대로 두면 이 결과가 남습니다"를 그대로
+    반영했다. 실제 채점 결과가 없어(무효라 채점 전이었으니) 위험 유형을 다시 계산할
+    수 없다 — `voidEvidence`를 지워 재확인 대상에서 빼고, 판정 근거·마지막 활동을
+    "확인 완료"로 바꾼다. 배지 자체("무효 응시")는 그대로 둔다 — 나중에 실제 채점이
+    끝나면 그 결과가 이 케이스를 대체할 것이다(그 흐름은 이 화면 밖).
+*/
+
+export type RoundId = '1' | '2' | '3' | '4' | '5'
+
+export const ROUND_OPTIONS: { value: RoundId; label: string }[] = [
+  { value: '1', label: '미프 1차' },
+  { value: '2', label: '미프 2차' },
+  { value: '3', label: '미프 3차' },
+  { value: '4', label: '미프 4차' },
+  { value: '5', label: '미프 5차' },
+]
+
+export const ROUND_LABEL: Record<RoundId, string> = Object.fromEntries(
+  ROUND_OPTIONS.map((o) => [o.value, o.label]),
+) as Record<RoundId, string>
+
+export const MOCK_TODAY = '2026-07-27'
+const CURRENT_MANAGER = '박지현'
+
+/** 담당 반 — `features/manager/projects/mockData.ts`의 담당 A·B·C반과 같은 스코프 */
+export type ClassName = 'A반' | 'B반' | 'C반'
+export const CLASS_OPTIONS: ClassName[] = ['A반', 'B반', 'C반']
+
+export type InterviewCaseStatus = 'PLANNED' | 'DONE' | 'EXCLUDED'
+export const STATUS_LABEL: Record<InterviewCaseStatus, string> = {
+  PLANNED: '예정',
+  DONE: '종결',
+  EXCLUDED: '제외',
+}
+
+/** 위험 유형 3종(9-2) + 1차 전용 `관찰`(9-5 — 비교할 직전 회차가 없어 유형이 안 붙는다) */
+export type CaseRisk =
+  | { type: 'INVALID' }
+  | { type: 'LOW_PERSISTENT'; lowCount: number; streak: number }
+  | { type: 'DECLINE'; from: number; to: number }
+  | { type: 'OBSERVE'; lowCount: number }
+
+export const RISK_LABEL: Record<CaseRisk['type'], string> = {
+  INVALID: '무효 응시',
+  LOW_PERSISTENT: '지속 저점',
+  DECLINE: '단계 하락',
+  OBSERVE: '관찰',
+}
+
+export type InterviewCase = {
+  id: string
+  traineeId: string
+  name: string
+  className: string
+  status: InterviewCaseStatus
+  risk: CaseRisk
+  /**
+   * 무효 응시일 때만. 매니저가 아직 판정하지 않았으면 값이 있다 — 확인(그대로 두기·
+   * 무효로 처리) 후에는 지워진다(무효로 처리는 케이스 자체가 목록에서 사라지고,
+   * 그대로 두기는 이 필드만 지운다. 위 파일 머리말 판단 기록 참고).
+   */
+  voidEvidence?: {
+    unanswered: number
+    totalQuestions: number
+    copied: boolean
+    durationMin: number
+  }
+  /** 종결(DONE)일 때만 — 면담일 + 다음에 할 것(없으면 null) */
+  interview?: { date: string; nextAction: string | null }
+  /** 제외(EXCLUDED)일 때만 */
+  excludedAt?: string
+  excludedBy?: string
+}
+
+export type InterviewRound = {
+  id: RoundId
+  /** 이해도 확인 결과가 아직 안 나왔다 — 위험 판정 자체가 없다(#pending) */
+  resultStatus: 'PENDING' | 'READY'
+  /** 1차 — 비교할 직전 회차가 없어 위험 유형이 안 붙는다(9-5, #first) */
+  isFirstRound: boolean
+  /** 리포트 발행일 — 회차 안 전 케이스의 등재일과 같다(위 판단 기록) */
+  publishedAt?: string
+  cases: InterviewCase[]
+}
+
+const byId = (id: string) => (c: InterviewCase) => c.id === id
+
+const ROUNDS: Record<RoundId, InterviewRound> = {
+  // 1차 — 관찰 배지만, 위험 유형 없음(#first)
+  '1': {
+    id: '1',
+    resultStatus: 'READY',
+    isFirstRound: true,
+    publishedAt: '2026-05-22',
+    cases: [
+      {
+        id: 'iv-1-1',
+        traineeId: 't-lee-seojun',
+        name: '이서준',
+        className: 'A반',
+        status: 'PLANNED',
+        risk: { type: 'OBSERVE', lowCount: 3 },
+      },
+      {
+        id: 'iv-1-2',
+        traineeId: 't-choi-yuna',
+        name: '최유나',
+        className: 'C반',
+        status: 'PLANNED',
+        risk: { type: 'OBSERVE', lowCount: 2 },
+      },
+    ],
+  },
+  // 2차 — 전부 종결·제외, 회고용(#past)
+  '2': {
+    id: '2',
+    resultStatus: 'READY',
+    isFirstRound: false,
+    publishedAt: '2026-06-15',
+    cases: [
+      {
+        id: 'iv-2-1',
+        traineeId: 't-lee-seojun',
+        name: '이서준',
+        className: 'A반',
+        status: 'DONE',
+        risk: { type: 'LOW_PERSISTENT', lowCount: 3, streak: 2 },
+        interview: { date: '2026-06-22', nextAction: '교안 1장 다시 읽기' },
+      },
+      {
+        id: 'iv-2-2',
+        traineeId: 't-kim-minjun',
+        name: '김민준',
+        className: 'A반',
+        status: 'DONE',
+        risk: { type: 'DECLINE', from: 0, to: 2 },
+        interview: { date: '2026-06-22', nextAction: null },
+      },
+      {
+        id: 'iv-2-3',
+        traineeId: 't-choi-yuna',
+        name: '최유나',
+        className: 'C반',
+        status: 'EXCLUDED',
+        risk: { type: 'LOW_PERSISTENT', lowCount: 2, streak: 2 },
+        excludedAt: '2026-06-21',
+        excludedBy: CURRENT_MANAGER,
+      },
+    ],
+  },
+  // 3차 — 진행 중, 기본 장면(#list·#done·#void·#exclude가 전부 이 데이터 하나를 공유)
+  '3': {
+    id: '3',
+    resultStatus: 'READY',
+    isFirstRound: false,
+    publishedAt: '2026-07-21',
+    cases: [
+      {
+        id: 'iv-3-1',
+        traineeId: 't-oh-serim',
+        name: '오세림',
+        className: 'C반',
+        status: 'PLANNED',
+        risk: { type: 'INVALID' },
+        voidEvidence: { unanswered: 2, totalQuestions: 3, copied: true, durationMin: 4 },
+      },
+      {
+        id: 'iv-3-2',
+        traineeId: 't-choi-yuna',
+        name: '최유나',
+        className: 'C반',
+        status: 'PLANNED',
+        risk: { type: 'LOW_PERSISTENT', lowCount: 3, streak: 2 },
+      },
+      {
+        id: 'iv-3-3',
+        traineeId: 't-lee-seojun',
+        name: '이서준',
+        className: 'A반',
+        status: 'PLANNED',
+        risk: { type: 'LOW_PERSISTENT', lowCount: 2, streak: 2 },
+      },
+      {
+        id: 'iv-3-4',
+        traineeId: 't-kim-minjun',
+        name: '김민준',
+        className: 'A반',
+        status: 'PLANNED',
+        risk: { type: 'DECLINE', from: 1, to: 2 },
+      },
+      {
+        id: 'iv-3-5',
+        traineeId: 't-han-jiwoo',
+        name: '한지우',
+        className: 'B반',
+        status: 'PLANNED',
+        risk: { type: 'DECLINE', from: 0, to: 2 },
+      },
+      {
+        id: 'iv-3-6',
+        traineeId: 't-park-dohyun',
+        name: '박도현',
+        className: 'B반',
+        status: 'DONE',
+        risk: { type: 'DECLINE', from: 1, to: 2 },
+        interview: { date: '2026-07-24', nextAction: '흐름 그려오기' },
+      },
+      {
+        id: 'iv-3-7',
+        traineeId: 't-kang-yunseo',
+        name: '강윤서',
+        className: 'B반',
+        status: 'DONE',
+        risk: { type: 'LOW_PERSISTENT', lowCount: 2, streak: 2 },
+        interview: { date: '2026-07-23', nextAction: '교안 2장 다시 읽기' },
+      },
+      {
+        id: 'iv-3-8',
+        traineeId: 't-jung-haneul',
+        name: '정하늘',
+        className: 'A반',
+        status: 'DONE',
+        risk: { type: 'LOW_PERSISTENT', lowCount: 2, streak: 2 },
+        interview: { date: '2026-07-22', nextAction: '팀에 먼저 물어보기' },
+      },
+      {
+        id: 'iv-3-9',
+        traineeId: 't-seo-jihun',
+        name: '서지훈',
+        className: 'C반',
+        status: 'DONE',
+        risk: { type: 'DECLINE', from: 1, to: 2 },
+        interview: { date: '2026-07-22', nextAction: null },
+      },
+    ],
+  },
+  // 4차 — 회차 결과 자체가 아직 없다(#pending)
+  '4': { id: '4', resultStatus: 'PENDING', isFirstRound: false, cases: [] },
+  // 5차 — 결과는 나왔지만 위험 대상이 없다(#empty)
+  '5': {
+    id: '5',
+    resultStatus: 'READY',
+    isFirstRound: false,
+    publishedAt: '2026-07-27',
+    cases: [],
+  },
+}
+
+// ── 파생값 ──────────────────────────────────────────────────
+// M/D 짧은 표기 — 와이어의 "7/21" 그대로. 자정 UTC 이슈를 피하려 로컬 파싱 고정.
+export function shortDateLabel(iso: string): string {
+  const [, m, d] = iso.split('-').map(Number)
+  return `${m}/${d}`
+}
+
+function diffDays(from: string, to: string): number {
+  const a = new Date(`${from}T00:00:00`)
+  const b = new Date(`${to}T00:00:00`)
+  return Math.round((b.getTime() - a.getTime()) / 86_400_000)
+}
+
+/** 위험 유형 순위 — 무효 응시 > 지속 저점/관찰 > 단계 하락. 정렬엔 안 쓰고 필터 옵션 순서에만 쓴다(위 판단 기록) */
+function riskRank(risk: CaseRisk['type']): number {
+  if (risk === 'INVALID') return 0
+  if (risk === 'DECLINE') return 2
+  return 1 // LOW_PERSISTENT · OBSERVE
+}
+
+/** 위험 유형 필터 옵션 — riskRank 순서 그대로(무효 응시 > 지속 저점/관찰 > 단계 하락) */
+export const RISK_TYPE_OPTIONS: CaseRisk['type'][] = (
+  Object.keys(RISK_LABEL) as CaseRisk['type'][]
+).sort((a, b) => riskRank(a) - riskRank(b))
+
+const classRank = (className: string) => {
+  const i = CLASS_OPTIONS.indexOf(className as ClassName)
+  return i === -1 ? CLASS_OPTIONS.length : i
+}
+
+const statusRank = (status: InterviewCaseStatus) => (status === 'DONE' ? 1 : 0)
+
+/**
+ * 정렬 — "이미 급한 순으로 온다"(정의서 §3, 사용자가 못 고른다). 규칙은 파일
+ * 머리말 "정렬 규칙 2차 반영" 참고 — ① 무효 응시 항상 최상단 → ② 상태(예정·제외
+ * 먼저, 종결 나중) → ③ 반 오름차순 → ④ 이름 가나다순.
+ */
+export function sortCases(cases: InterviewCase[]): InterviewCase[] {
+  const invalid = cases.filter((c) => c.risk.type === 'INVALID')
+  const rest = cases.filter((c) => c.risk.type !== 'INVALID')
+
+  const byRest = (a: InterviewCase, b: InterviewCase) =>
+    statusRank(a.status) - statusRank(b.status) ||
+    classRank(a.className) - classRank(b.className) ||
+    a.name.localeCompare(b.name, 'ko')
+
+  invalid.sort(byRest)
+  rest.sort(byRest)
+
+  return [...invalid, ...rest]
+}
+
+// ── 조회(mock API) ──────────────────────────────────────────
+// 백엔드 연동 시 이 블록만 fetch로 바꾼다.
+
+const LATENCY_MS = 250
+const delay = <T>(value: T): Promise<T> =>
+  new Promise((resolve) => setTimeout(() => resolve(value), LATENCY_MS))
+
+export type InterviewQuery = {
+  round: RoundId
+  search?: string
+  /** 'ALL' | InterviewCaseStatus */
+  status?: string
+  riskType?: CaseRisk['type']
+  classFilter?: ClassName
+}
+
+export type InterviewCounts = Record<InterviewCaseStatus, number>
+
+export type InterviewListResult = {
+  items: InterviewCase[]
+  total: number
+  /** 상태별 개수 — 검색·필터와 무관한 그 회차 전체 기준(OP-03·MG-07과 같은 이유) */
+  counts: InterviewCounts
+  /** 위험 유형별 개수 — 위와 같은 이유. 필터 옵션에 개수를 싣는다(`InterviewFilters`) */
+  riskCounts: Record<CaseRisk['type'], number>
+  round: {
+    id: RoundId
+    label: string
+    resultStatus: InterviewRound['resultStatus']
+    isFirstRound: boolean
+    publishedAtLabel?: string
+    /** 회차 경과일 — 상단 경고줄("N일째 안 끝났습니다")에 쓴다 */
+    daysSincePublish?: number
+  }
+}
+
+/**
+ * `GET /interviews?round=` — 위험 판정이 켜져 자동 등재된 케이스 목록(정의서 §6
+ * "대상은 자동 등재된다"). 검색·상태 필터는 서버가 처리한다는 전제(OP-03·MG-07과
+ * 같은 경계 원칙) — 정렬은 필터와 무관하게 항상 `sortCases` 하나다(사용자가
+ * 못 고른다).
+ */
+export function listInterviews(q: InterviewQuery): Promise<InterviewListResult> {
+  const round = ROUNDS[q.round]
+  const search = q.search?.trim().toLowerCase() ?? ''
+
+  const counts: InterviewCounts = { PLANNED: 0, DONE: 0, EXCLUDED: 0 }
+  const riskCounts: Record<CaseRisk['type'], number> = {
+    INVALID: 0,
+    LOW_PERSISTENT: 0,
+    DECLINE: 0,
+    OBSERVE: 0,
+  }
+  for (const c of round.cases) {
+    counts[c.status]++
+    riskCounts[c.risk.type]++
+  }
+
+  const filtered = round.cases.filter((c) => {
+    if (search && !c.name.toLowerCase().includes(search)) return false
+    if (q.status && q.status !== 'ALL' && c.status !== q.status) return false
+    if (q.riskType && c.risk.type !== q.riskType) return false
+    if (q.classFilter && c.className !== q.classFilter) return false
+    return true
+  })
+  const items = sortCases(filtered)
+
+  return delay({
+    items,
+    total: items.length,
+    counts,
+    riskCounts,
+    round: {
+      id: round.id,
+      label: ROUND_LABEL[round.id],
+      resultStatus: round.resultStatus,
+      isFirstRound: round.isFirstRound,
+      publishedAtLabel: round.publishedAt ? shortDateLabel(round.publishedAt) : undefined,
+      daysSincePublish: round.publishedAt ? diffDays(round.publishedAt, MOCK_TODAY) : undefined,
+    },
+  })
+}
+
+/** `PATCH /interviews/{id}` — 제외. 체크가 아니라 버튼(정의서 §3), 되돌릴 수 있다 */
+export function excludeCase(roundId: RoundId, caseId: string): Promise<void> {
+  const c = ROUNDS[roundId].cases.find(byId(caseId))
+  if (c && c.status === 'PLANNED') {
+    c.status = 'EXCLUDED'
+    c.excludedAt = MOCK_TODAY
+    c.excludedBy = CURRENT_MANAGER
+  }
+  return delay(undefined)
+}
+
+/** `PATCH /interviews/{id}` — 제외 되돌리기 */
+export function undoExclude(roundId: RoundId, caseId: string): Promise<void> {
+  const c = ROUNDS[roundId].cases.find(byId(caseId))
+  if (c && c.status === 'EXCLUDED') {
+    c.status = 'PLANNED'
+    c.excludedAt = undefined
+    c.excludedBy = undefined
+  }
+  return delay(undefined)
+}
+
+/**
+ * `PATCH /interviews/{id}` — 무효 응시 확인. 자동 확정하지 않는다(9-4) — 사람이
+ * 고른다. `INVALIDATE`는 결과 자체를 지우므로 케이스가 목록에서 사라진다(정의서
+ * "이 회차 결과가 지워집니다 · 위험 판정도 남지 않습니다"). `KEEP`은 파일 머리말
+ * 판단 기록 참고.
+ */
+export function resolveVoid(
+  roundId: RoundId,
+  caseId: string,
+  action: 'INVALIDATE' | 'KEEP',
+): Promise<void> {
+  const round = ROUNDS[roundId]
+  const c = round.cases.find(byId(caseId))
+  if (!c) return delay(undefined)
+  if (action === 'INVALIDATE') {
+    round.cases = round.cases.filter((x) => x.id !== caseId)
+  } else {
+    c.voidEvidence = undefined
+  }
+  return delay(undefined)
+}


### PR DESCRIPTION
## 작업 내용

위험 판정(9-2)이 자동으로 켜진 학생을 모아 매니저가 처리하는 작업 큐(MG-03)를
신규 구현했다. `PlaceholderScreen code="MG-03"` 자리를 실제 화면으로 교체.

- `InterviewListScreen.tsx` — 헤더 카운트(예정/종결/제외) · 경고줄 2종(회차 경과·
  1차 관찰 안내) · 되돌리기 배너 · 표 · 페이지 없는 푸터
- 상태 3종(예정/종결/제외) · 위험 유형 4종(무효 응시/지속 저점/단계 하락/1차 전용
  관찰) 배지
- 회차·검색·상태·반·위험 유형 필터. 정렬은 사용자가 못 고른다(정의서 §3) — 무효
  응시 최상단 → 상태 → 반 오름차순 → 이름 순 고정
- 무효 응시 확인 모달 — 시스템이 본 것(무응답 문항 수·복사 여부·응답 시간)만
  보여주고 자동 확정하지 않음(9-4)
- 제외는 확인 다이얼로그 없이 즉시 실행 + 인라인 되돌리기 배너
- `mockData.ts` — 회차 5개(1~5차)로 와이어프레임 9개 케이스 장면 전부 재현

## 리뷰 포인트

- **정렬 규칙이 정의서 원문("위험 유형 → 2단 이하 개수")과 다르다.** 렌더 확인
  중 위험 유형·반 필터를 추가하면서 기본 정렬을 "무효 응시 최상단 → 상태 → 반 →
  이름"으로 바꿨다(사용자 지시) — 근거는 `mockData.ts` 파일 머리말 판단 기록.
- 무효 응시 "그대로 두기" 처리 — 실제 채점 결과가 없어 위험 유형을 다시 계산할
  수 없으므로 `voidEvidence`만 지우고 배지는 유지했다(같은 파일 판단 기록).
- MG-04(면담 브리프)는 이 PR 범위 밖 — `/manager/interviews/:id/brief` 라우트와
  placeholder만 이미 있고 이동 링크만 연결했다.

## 완료 조건

- [x] `tsc --noEmit -p tsconfig.app.json`·`-p tsconfig.node.json` 통과
- [x] `prettier --check` 통과
- [x] `/manager/interviews` 렌더 확인(회차별 9개 케이스 장면, 무효 확인 모달,
      제외→되돌리기, 필터 4종, 이름 클릭→MG-06 이동)

closes #109