### PR TITLE
[Feat] Implement MG-04 Interview Brief Screen

### DIFF
--- a/src/features/manager/interviews/InterviewBriefScreen.tsx
+++ b/src/features/manager/interviews/InterviewBriefScreen.tsx
@@ -1,11 +1,528 @@
+import { useCallback, useState } from 'react'
+import { Link, useNavigate, useParams } from 'react-router'
+import { ArrowLeft, Check } from 'lucide-react'
 import ConsoleShell from '@/shells/ConsoleShell'
-import PlaceholderScreen from '@/app/PlaceholderScreen'
+import { Button } from '@/components/ui/Button'
+import { Textarea } from '@/components/ui/Textarea'
+import { Alert, AlertDescription } from '@/components/ui/Alert'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/Dialog'
+import { Empty, EmptyHeader, EmptyTitle, EmptyDescription } from '@/components/ui/Empty'
+import { Spinner } from '@/components/ui/Spinner'
+import { useAsync } from '@/lib/useAsync'
+import { cn } from '@/lib/utils/cn'
+import RiskBadge from './components/RiskBadge'
+import {
+  BRIEF_QUESTIONS,
+  CAUSE_OPTIONS,
+  destinationsFor,
+  getInterviewBrief,
+  groupIssueConcepts,
+  openingLine,
+  saveInterviewBrief,
+  talkingConcepts,
+  VOID_BRIEF_QUESTIONS,
+  type BriefData,
+  type CauseKey,
+  type OpeningLine,
+} from './mockData'
 
-/** MG-04 면담 브리프 — 모드 — 사이드바 항목 없음 — 화면 이식 전 자리표시. 실제 화면이 들어오면 이 파일 내용만 바뀐다. */
+/*
+  MG-04 면담 브리프 — "낭독 · 경청 · 라우팅"(정의서 §1).
+
+  ⚠ **정의서 §2는 원래 전체화면·사이드바 가림을 규정했다**(TR-03 검증 세션과 같은
+  논리 — "화면이 다르게 생긴 것 자체가 지금 작업 중이라는 신호"). 렌더 확인 중
+  사용자가 "다른 매니저 화면은 다 셸이 있는데 브리프만 앱 자체가 사라지는 느낌이라
+  어색하다"고 지적, 정의서를 번복하고 `ConsoleShell`로 감싸기로 결정했다(D50) —
+  근거·대안 3가지는 `docs/dev/decision-log.md` D50 참고.
+
+  나가는 길(좌상단 뒤로가기·하단 `[취소]`)은 그대로 있다 — 매니저 도구라 잘못 열
+  수 있다는 정의서 §2의 취지 자체는 유효해서다.
+
+  ⚠ **상단 정보 줄도 사용자 지시로 줄였다** — breadcrumb·"미프 N차 · 2단 이하
+  X→Y" 회차 요약을 뺐다("상단 좌측이 지저분하다"). 남긴 건 뒤로가기 아이콘 버튼 ·
+  이름 · 반 · 위험 배지뿐이다. 회차·판정 숫자는 ①의 여는 말이 이미 자연스러운
+  문장으로 말해주므로 중복이었다고 판단.
+
+  케이스별 데이터 판단 기록은 전부 `mockData.ts` 머리말에 있다("MG-04 면담 브리프
+  목업" 절) — 이 파일은 그 값을 그리기만 한다.
+*/
+
+const listPath = '/manager/interviews'
+
 export default function InterviewBriefScreen() {
+  const { id = '' } = useParams()
+  const navigate = useNavigate()
+  const load = useCallback(() => getInterviewBrief(id), [id])
+  const page = useAsync(load)
+
+  if (page.loading) {
+    return (
+      <ConsoleShell role="manager">
+        <div className="flex justify-center py-16">
+          <Spinner className="size-6" aria-label="브리프를 불러오는 중" />
+        </div>
+      </ConsoleShell>
+    )
+  }
+
+  if (page.failed || !page.data) {
+    return (
+      <ConsoleShell role="manager">
+        <Empty>
+          <EmptyHeader>
+            <EmptyTitle>브리프를 찾을 수 없습니다</EmptyTitle>
+            <EmptyDescription>잠시 후 다시 시도하거나 목록으로 돌아가세요.</EmptyDescription>
+          </EmptyHeader>
+          <div className="mt-2 flex justify-center gap-2">
+            <Button variant="ghost" onClick={page.reload}>
+              다시 시도
+            </Button>
+            <Button variant="ghost" onClick={() => navigate(listPath)}>
+              목록으로
+            </Button>
+          </div>
+        </Empty>
+      </ConsoleShell>
+    )
+  }
+
+  return <BriefSheet brief={page.data} />
+}
+
+function BriefSheet({ brief }: { brief: BriefData }) {
+  const navigate = useNavigate()
+  // 종결 후 다시 연 브리프면 이전에 저장한 값으로 시작한다(사용자 지시 — 재오픈 시
+  // 입력이 날아가면 안 된다). 처음 여는 브리프는 `savedRecord`가 없어 빈 값 그대로.
+  const [causes, setCauses] = useState<Set<CauseKey>>(new Set(brief.savedRecord?.causes ?? []))
+  const [why, setWhy] = useState(brief.savedRecord?.why ?? '')
+  const [nextAction, setNextAction] = useState(brief.savedRecord?.nextAction ?? '')
+  const [saving, setSaving] = useState(false)
+  const [saveFailed, setSaveFailed] = useState(false)
+  const [showEmptyConfirm, setShowEmptyConfirm] = useState(false)
+
+  const questions = brief.isVoid ? VOID_BRIEF_QUESTIONS : BRIEF_QUESTIONS
+  const talking = talkingConcepts(brief)
+  const groupIssues = groupIssueConcepts(brief)
+  const opening = openingLine(brief)
+  const selectedCauses = CAUSE_OPTIONS.filter((o) => causes.has(o.key))
+  const sentToText = selectedCauses
+    .flatMap((o) => destinationsFor(o.key, brief))
+    .map((l) => l.text)
+    .join(' · ')
+
+  function toggleCause(key: CauseKey) {
+    setCauses((prevSet) => {
+      const next = new Set(prevSet)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      return next
+    })
+  }
+
+  async function doSave() {
+    setSaving(true)
+    setSaveFailed(false)
+    try {
+      await saveInterviewBrief(brief.caseId, { causes: [...causes], why, nextAction })
+      navigate(listPath)
+    } catch {
+      setSaveFailed(true)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  function handleSaveClick() {
+    if (!nextAction.trim()) {
+      setShowEmptyConfirm(true)
+      return
+    }
+    void doSave()
+  }
+
   return (
     <ConsoleShell role="manager">
-      <PlaceholderScreen code="MG-04" title="면담 브리프" />
+      <div className="mb-5 flex items-center gap-3">
+        <Button
+          variant="ghost"
+          size="sm"
+          aria-label="저장하지 않고 면담 목록으로 돌아가기"
+          nativeButton={false}
+          render={<Link to={listPath} />}
+          className="p-1.5"
+        >
+          <ArrowLeft className="size-5" />
+        </Button>
+        <span className="flex items-baseline gap-2">
+          <span className="text-fg text-xl font-bold tracking-[-0.01em]">{brief.name}</span>
+          <span className="text-fg-subtle text-sm">7기 · {brief.className}</span>
+        </span>
+        <RiskBadge risk={brief.risk} />
+      </div>
+
+      <div className="max-w-[820px] pb-8">
+        <Block no={1} title="여는 말">
+          <div className="bg-primary-soft text-fg rounded-md p-4 text-sm leading-[1.85]">
+            {renderOpeningLine(opening)}
+          </div>
+
+          {brief.isVoid ? (
+            <>
+              <div className="text-fg mt-3 text-sm">
+                이 회차 결과 — <b className="font-bold">채점하지 않음</b>
+                <span className="text-fg-subtle mt-0.5 block text-2xs">
+                  도달 단계도 위험 판정도 없습니다. 다시 응시하면 그게 1차가 됩니다.
+                </span>
+              </div>
+              {brief.voidEvidence && (
+                <div className="border-border bg-surface-2 text-fg-muted mt-3 rounded-md border px-4 py-2.5 text-xs leading-relaxed">
+                  <div className="text-fg-subtle mb-1 text-2xs font-bold">
+                    시스템이 본 것 · 판단은 하지 않습니다
+                  </div>
+                  {brief.voidEvidence.totalQuestions}문항 중{' '}
+                  <b className="text-fg font-bold">{brief.voidEvidence.unanswered}문항 무응답</b>
+                  {brief.voidEvidence.copied && (
+                    <>
+                      {' '}
+                      · 나머지 1문항은 <b className="text-fg font-bold">질문 문장을 그대로 복사</b>
+                    </>
+                  )}{' '}
+                  · 총 응답 시간{' '}
+                  <b className="text-fg font-bold">{brief.voidEvidence.durationMin}분</b>
+                </div>
+              )}
+            </>
+          ) : (
+            <>
+              {talking.length > 0 && (
+                <div className="text-fg-muted mt-3 text-sm">
+                  이야기할 개념 —{' '}
+                  <b className="text-fg font-bold">{talking.map((c) => c.name).join(' · ')}</b>
+                </div>
+              )}
+              {groupIssues.length > 0 && (
+                <div className="text-fg-subtle mt-1.5 text-xs leading-relaxed">
+                  {groupIssues.map((c) => c.name).join('·')}은{' '}
+                  <b className="text-fg-muted font-normal">반 절반 이상이 같은 지점</b>이라 개인
+                  사유에서 빠졌습니다(9-6).
+                </div>
+              )}
+              {brief.hasPriorInterview && brief.priorInterview && (
+                <div className="border-border text-fg-muted mt-3 flex items-baseline gap-1.5 border-t pt-3 text-sm">
+                  <span className="text-warning">⚠</span>
+                  <span>
+                    지난 면담({brief.priorInterview.dateLabel})에서 정한 것 —{' '}
+                    <b className="text-fg font-bold">“{brief.priorInterview.nextAction}”</b>
+                  </span>
+                </div>
+              )}
+            </>
+          )}
+        </Block>
+
+        <Block no={2} title="질문">
+          <ul className="space-y-2 text-sm leading-relaxed">
+            {questions.map((q) => (
+              <li key={q} className="relative pl-4">
+                <span className="text-fg-subtle absolute left-0">·</span>
+                {q}
+              </li>
+            ))}
+          </ul>
+        </Block>
+
+        <Block no={3} title="원인">
+          <div className="flex flex-wrap gap-1.5">
+            {CAUSE_OPTIONS.map((o) => {
+              const active = causes.has(o.key)
+              return (
+                <button
+                  key={o.key}
+                  type="button"
+                  aria-pressed={active}
+                  onClick={() => toggleCause(o.key)}
+                  className={cn(
+                    'inline-flex items-center gap-1.5 rounded-full border px-3.5 py-2 text-sm',
+                    active
+                      ? 'bg-primary-soft border-primary-border text-primary font-semibold'
+                      : 'bg-surface border-border-strong text-fg-muted hover:bg-surface-2',
+                  )}
+                >
+                  <span
+                    className={cn(
+                      'flex size-3.5 shrink-0 items-center justify-center rounded-[4px] border',
+                      active ? 'bg-primary border-primary text-white' : 'border-border-strong',
+                    )}
+                  >
+                    {active && <Check className="size-2.5" strokeWidth={3} />}
+                  </span>
+                  {o.label}
+                </button>
+              )
+            })}
+          </div>
+        </Block>
+
+        <Block no={4} title="조치">
+          {selectedCauses.length === 0 ? (
+            <div className="text-fg-subtle py-4 text-center text-sm">
+              원인을 고르면 조치가 나타납니다.
+            </div>
+          ) : (
+            selectedCauses.map((cause, causeIdx) => {
+              const lines = destinationsFor(cause.key, brief)
+              return (
+                <div
+                  key={cause.key}
+                  className={causeIdx > 0 ? 'border-border mt-2 border-t pt-2' : ''}
+                >
+                  {lines.map((line, i) => (
+                    <div key={i} className="flex items-start gap-3 py-1.5 text-sm">
+                      <span className="text-fg w-[132px] shrink-0 font-bold">
+                        {line.showLabel ? cause.label : ''}
+                      </span>
+                      <span className="text-fg-muted flex-1 leading-relaxed">
+                        {line.href ? (
+                          <Link to={line.href} className="text-primary hover:underline">
+                            {line.text}
+                          </Link>
+                        ) : (
+                          renderBold(line.text, line.bold)
+                        )}
+                      </span>
+                      <span
+                        className={cn(
+                          'w-[62px] shrink-0 text-right text-2xs font-bold whitespace-nowrap',
+                          line.owner === 'MANAGER' && 'text-primary',
+                          line.owner === 'PASS' && 'text-fg-subtle',
+                        )}
+                      >
+                        {line.owner === 'MANAGER'
+                          ? '매니저'
+                          : line.owner === 'PASS'
+                            ? '전달만'
+                            : ''}
+                      </span>
+                    </div>
+                  ))}
+                  {cause.key === 'DIFFICULTY_UP' && groupIssues.length > 0 && (
+                    <div className="mt-2 space-y-1.5">
+                      {groupIssues.map((c) => (
+                        <Alert key={c.name} variant="warning">
+                          <AlertDescription className="text-xs leading-relaxed">
+                            <b className="text-warning">{c.name}은 이미 반 문제로 판정됐습니다</b> —{' '}
+                            {c.groupIssue!.classLabel}(9-6).{' '}
+                            <b className="text-warning">개인 위험 사유에서 빠지고</b> 반 전체 안내
+                            대상입니다.
+                          </AlertDescription>
+                        </Alert>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )
+            })
+          )}
+        </Block>
+
+        <div className="border-border bg-surface rounded-md border p-4">
+          <div className="mb-3 flex items-baseline gap-2">
+            <span className="text-fg text-sm font-bold">기록</span>
+            <Link
+              to={`/manager/trainees/${brief.traineeId}`}
+              className="text-primary ml-auto text-xs hover:underline"
+            >
+              전체 이력 ↗
+            </Link>
+          </div>
+          <div className="grid grid-cols-3 gap-3">
+            <RecordField label="상세 사유">
+              <Textarea
+                value={why}
+                onChange={(e) => setWhy(e.target.value)}
+                placeholder="상세 사유를 적어주세요."
+                className="min-h-16 text-xs"
+              />
+            </RecordField>
+            <RecordField label="조치" hint="4에서 자동 반영">
+              <div
+                aria-readonly="true"
+                className="border-border-strong bg-input/60 text-fg-subtle min-h-16 cursor-not-allowed rounded-sm border px-2.5 py-2 text-xs leading-relaxed"
+              >
+                {sentToText || (
+                  <>
+                    원인을 체크하시면
+                    <br />
+                    조치가 자동반영됩니다.
+                  </>
+                )}
+              </div>
+            </RecordField>
+            <RecordField label="추후 계획">
+              <Textarea
+                value={nextAction}
+                onChange={(e) => setNextAction(e.target.value)}
+                placeholder="추후 계획을 적어주세요."
+                className="min-h-16 text-xs"
+              />
+            </RecordField>
+          </div>
+        </div>
+
+        <div className="mt-4 flex items-center justify-end gap-2">
+          <Button variant="ghost" disabled={saving} onClick={() => navigate(listPath)}>
+            취소
+          </Button>
+          <Button variant="primary" disabled={saving} onClick={handleSaveClick}>
+            {brief.savedRecord ? '저장' : '저장하고 종결'}
+          </Button>
+        </div>
+      </div>
+
+      <Dialog open={showEmptyConfirm} onOpenChange={setShowEmptyConfirm}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>추후 계획을 비워 두고 저장할까요?</DialogTitle>
+          </DialogHeader>
+          <p className="text-fg-muted text-sm leading-relaxed">
+            비워 두면 <b className="text-fg">다음 회차 브리프에 이어받을 것이 없습니다.</b>
+          </p>
+          <DialogFooter>
+            <Button
+              variant="ghost"
+              onClick={() => {
+                setShowEmptyConfirm(false)
+                void doSave()
+              }}
+            >
+              비워 두고 저장
+            </Button>
+            <Button variant="primary" onClick={() => setShowEmptyConfirm(false)}>
+              돌아가서 적기
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={saveFailed} onOpenChange={(open) => !open && setSaveFailed(false)}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>저장하지 못했습니다</DialogTitle>
+          </DialogHeader>
+          <div className="text-fg-muted space-y-2 text-sm leading-relaxed">
+            <p>
+              적으신 내용은 <b className="text-fg">그대로 남아 있습니다.</b> 잠시 후 다시 시도해
+              주세요.
+            </p>
+            <p className="text-fg-subtle text-xs">창을 닫으면 지금까지 적은 것이 사라집니다.</p>
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setSaveFailed(false)}>
+              닫기
+            </Button>
+            <Button variant="primary" disabled={saving} onClick={() => void doSave()}>
+              다시 저장
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </ConsoleShell>
+  )
+}
+
+function Block({ no, title, children }: { no: number; title: string; children: React.ReactNode }) {
+  return (
+    <div className="bg-surface border-border mb-4 overflow-hidden rounded-md border">
+      <div className="border-border bg-surface-2 flex items-center gap-2 border-b px-5 py-3">
+        <span className="bg-primary flex size-5 shrink-0 items-center justify-center rounded-full text-xs leading-none font-bold text-white tabular-nums">
+          {no}
+        </span>
+        <span className="text-sm font-bold">{title}</span>
+      </div>
+      <div className="px-5 py-4">{children}</div>
+    </div>
+  )
+}
+
+function RecordField({
+  label,
+  hint,
+  children,
+}: {
+  label: string
+  hint?: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="flex flex-col">
+      <div className="text-fg-subtle mb-1 text-2xs font-bold">
+        {label} {hint && <span className="text-primary font-semibold">· {hint}</span>}
+      </div>
+      {children}
+    </div>
+  )
+}
+
+/**
+ * ① 여는 말 — 위험 유형 4종 × 고정 템플릿(사용자 지시로 새로 작성, D51). "점수
+ * 얘기를 하려는 게 아니라" 같은 정형화된 변명 문구를 빼고 2줄로 짧게 줄였다.
+ * 숫자만 `openingLine`(mockData.ts)이 계산해 넘기고 문장 자체는 여기서 고정한다.
+ */
+function renderOpeningLine(line: OpeningLine) {
+  switch (line.kind) {
+    case 'VOID':
+      return (
+        <>
+          “이번엔 답변이 거의 없어서 따로 채점하지 않았어요.
+          <br />
+          그날 무슨 일이 있었는지 편하게 들어보고 싶어서 불렀어요.”
+        </>
+      )
+    case 'DECLINE':
+      return (
+        <>
+          “지난 회차엔 3개 중 <b>{line.prev}</b>개만 막혔었는데, 이번엔 <b>{line.now}</b>개나
+          막혔더라고요.
+          <br />
+          편하게 무슨 일이 있었는지 들어보고 싶어서 불렀어요.”
+        </>
+      )
+    case 'LOW_PERSISTENT':
+      return (
+        <>
+          “최근 <b>{line.streak}</b>번 연속으로 3개 중 <b>{line.lowCount}</b>개에서 막히고
+          있더라고요.
+          <br />
+          계속 같은 자리에서 걸리는 이유가 궁금해서 한번 얘기해보고 싶었어요.”
+        </>
+      )
+    case 'OBSERVE':
+      return (
+        <>
+          “이번에 3개 중 <b>{line.lowCount}</b>개에서 멈췄더라고요.
+          <br />
+          어떤 부분이 어려웠는지 편하게 들어보고 싶어서 불렀어요.”
+        </>
+      )
+  }
+}
+
+/** text 안에서 bold 부분 문자열 하나만 굵게 감싼다(정확히 일치하는 첫 구간) */
+function renderBold(text: string, bold?: string) {
+  if (!bold) return text
+  const idx = text.indexOf(bold)
+  if (idx === -1) return text
+  return (
+    <>
+      {text.slice(0, idx)}
+      <b className="text-fg font-bold">{bold}</b>
+      {text.slice(idx + bold.length)}
+    </>
   )
 }

--- a/src/features/manager/interviews/InterviewListScreen.tsx
+++ b/src/features/manager/interviews/InterviewListScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { Link, useNavigate } from 'react-router'
 import ConsoleShell from '@/shells/ConsoleShell'
 import PageHeader from '@/components/common/PageHeader'
@@ -24,7 +24,14 @@ import {
   type ClassName,
   type InterviewCase,
 } from './mockData'
-import { ALL, INITIAL_FILTERS, isNarrowed, type FilterValues } from './filterState'
+import {
+  ALL,
+  getSessionFilters,
+  INITIAL_FILTERS,
+  isNarrowed,
+  setSessionFilters,
+  type FilterValues,
+} from './filterState'
 import InterviewStatusBadge from './components/InterviewStatusBadge'
 import RiskBadge, { RiskReason } from './components/RiskBadge'
 import InterviewFilters from './components/InterviewFilters'
@@ -53,7 +60,10 @@ const traineePath = (traineeId: string) => `/manager/trainees/${traineeId}`
 
 export default function InterviewListScreen() {
   const navigate = useNavigate()
-  const [filters, setFilters] = useState<FilterValues>(INITIAL_FILTERS)
+  // 브리프로 갔다가 "← 목록으로"로 돌아와도 회차·검색·상태가 그대로 있어야 한다
+  // (사용자 지시) — 세션 동안만 기억하는 모듈 전역값에서 초기화한다. 새로고침하면
+  // 사라진다(filterState.ts 판단 기록).
+  const [filters, setFilters] = useState<FilterValues>(getSessionFilters)
   const [voidTarget, setVoidTarget] = useState<InterviewCase | null>(null)
   const [undoBanner, setUndoBanner] = useState<{ caseId: string; name: string } | null>(null)
   const [rowPending, setRowPending] = useState<string | null>(null)
@@ -74,8 +84,24 @@ export default function InterviewListScreen() {
   const page = useAsync(loadInterviews)
   const narrowed = isNarrowed(filters)
 
+  useEffect(() => {
+    setSessionFilters(filters)
+  }, [filters])
+
+  /**
+   * 회차를 바꾸면 검색·상태·위험 유형·반 필터를 전부 초기화한다(사용자 질문에 대한
+   * 판단, decision-log D52) — 회차마다 케이스 구성 자체가 다르다(위험 유형·상태
+   * 분포가 회차마다 갈린다). 이전 회차에서 걸어둔 필터를 그대로 들고 가면 새
+   * 회차에서 "왜 아무것도 안 보이지"로 이어지기 쉽다. 브리프를 열었다 돌아오는
+   * 것(같은 회차 안에서의 이동)은 필터를 유지해야 하는 다른 경우라 여기 영향
+   * 없다 — `getSessionFilters`가 이미 그건 처리한다.
+   */
   function changeFilters(patch: Partial<FilterValues>) {
-    if (patch.round) setUndoBanner(null)
+    if (patch.round) {
+      setUndoBanner(null)
+      setFilters({ ...INITIAL_FILTERS, round: patch.round })
+      return
+    }
     setFilters((f) => ({ ...f, ...patch }))
   }
 
@@ -273,7 +299,7 @@ export default function InterviewListScreen() {
                     <TableCell>
                       <RiskReason
                         risk={c.risk}
-                        voidResolved={c.risk.type === 'INVALID' && !c.voidEvidence}
+                        voidResolved={c.risk.type === 'INVALID' && !!c.voidConfirmed}
                       />
                     </TableCell>
                     <TableCell>
@@ -362,7 +388,7 @@ function LastActivityCell({
     )
   }
   // PLANNED
-  if (c.risk.type === 'INVALID' && c.voidEvidence) {
+  if (c.risk.type === 'INVALID' && !c.voidConfirmed) {
     return <span className="text-warning font-medium">응답 없음 · 매니저 확인 필요</span>
   }
   if (c.risk.type === 'INVALID') {
@@ -386,7 +412,17 @@ function RowActions({
   onExclude: () => void
   onUndo: () => void
 }) {
-  if (c.status === 'DONE') return null
+  // 종결 — 브리프를 다시 열어 수정할 수 있다(사용자 지시). 제외는 안 보인다 —
+  // 이미 끝난 면담을 "제외"한다는 게 의미가 없다(제외는 PLANNED 케이스를 큐에서
+  // 빼는 동작이지, 완료된 기록을 지우는 동작이 아니다). `saveInterviewBrief` 판단
+  // 기록 참고.
+  if (c.status === 'DONE') {
+    return (
+      <Button variant="ghost" size="sm" disabled={pending} onClick={onOpenBrief}>
+        브리프 수정
+      </Button>
+    )
+  }
 
   if (c.status === 'EXCLUDED') {
     return (
@@ -397,7 +433,7 @@ function RowActions({
   }
 
   // PLANNED
-  const needsVoidCheck = c.risk.type === 'INVALID' && c.voidEvidence
+  const needsVoidCheck = c.risk.type === 'INVALID' && !c.voidConfirmed
   return (
     <div className="flex justify-end gap-1.5">
       {needsVoidCheck ? (

--- a/src/features/manager/interviews/filterState.ts
+++ b/src/features/manager/interviews/filterState.ts
@@ -1,4 +1,4 @@
-import type { RoundId } from './mockData'
+import { ROUND_OPTIONS, type RoundId } from './mockData'
 
 /*
   목록 필터의 값. UI(`components/InterviewFilters.tsx`)와 파일을 가른 이유는
@@ -23,8 +23,14 @@ export type FilterValues = {
   classFilter: string
 }
 
+/**
+ * 기본 회차 — **가장 마지막에 생성된 회차**(사용자 지시, `ROUND_OPTIONS` 끝값).
+ * `'3'` 하드코딩이었던 걸 회차가 늘어도 안 깨지게 동적으로 바꿨다.
+ */
+export const DEFAULT_ROUND: RoundId = ROUND_OPTIONS[ROUND_OPTIONS.length - 1].value
+
 export const INITIAL_FILTERS: FilterValues = {
-  round: '3',
+  round: DEFAULT_ROUND,
   search: '',
   status: ALL,
   riskType: ALL,
@@ -34,4 +40,22 @@ export const INITIAL_FILTERS: FilterValues = {
 /** 빈 결과가 "아직 없음"인지 "필터에 안 걸림"인지 — 문구가 갈린다(MG-07 isNarrowed와 같은 이유) */
 export function isNarrowed(f: FilterValues): boolean {
   return f.search !== '' || f.status !== ALL || f.riskType !== ALL || f.classFilter !== ALL
+}
+
+/**
+ * 목록 필터를 세션 동안만 기억한다 — 브리프로 갔다가 `← 목록으로`로 돌아오면
+ * 회차·검색·상태가 그대로 있어야 한다는 사용자 지시. 모듈 전역 변수라 **SPA 안
+ * 화면 전환에서는 살아있고, 새로고침(F5)하면 모듈이 다시 로드되며 사라진다** —
+ * 정확히 그 동작을 원한 것이라 `localStorage` 대신 이 방식을 썼다(그리고
+ * `InterviewListScreen`은 필터 없는 URL 하나만 쓰므로 URL 쿼리에 실으면 새로고침
+ * 에도 남아 요구와 어긋난다).
+ */
+let sessionFilters: FilterValues | null = null
+
+export function getSessionFilters(): FilterValues {
+  return sessionFilters ?? INITIAL_FILTERS
+}
+
+export function setSessionFilters(next: FilterValues): void {
+  sessionFilters = next
 }

--- a/src/features/manager/interviews/mockData.ts
+++ b/src/features/manager/interviews/mockData.ts
@@ -41,9 +41,11 @@
     안 쓰지만, **위험 유형 필터 옵션 개수 표시**에 여전히 쓰여서 남겨뒀다.
   · **무효 응시 "그대로 두기"** — 정의서 "그대로 두면 이 결과가 남습니다"를 그대로
     반영했다. 실제 채점 결과가 없어(무효라 채점 전이었으니) 위험 유형을 다시 계산할
-    수 없다 — `voidEvidence`를 지워 재확인 대상에서 빼고, 판정 근거·마지막 활동을
-    "확인 완료"로 바꾼다. 배지 자체("무효 응시")는 그대로 둔다 — 나중에 실제 채점이
-    끝나면 그 결과가 이 케이스를 대체할 것이다(그 흐름은 이 화면 밖).
+    수 없다 — 재확인 대상에서 빼고 판정 근거·마지막 활동을 "확인 완료"로 바꾸는 건
+    `voidConfirmed`(D49)가 갖는다. `voidEvidence` 자체는 지우지 않는다 — MG-04
+    브리프가 무효 응시 케이스를 열 때마다 "시스템이 본 것"을 계속 보여줘야 해서다.
+    배지 자체("무효 응시")는 그대로 둔다 — 나중에 실제 채점이 끝나면 그 결과가 이
+    케이스를 대체할 것이다(그 흐름은 이 화면 밖).
 */
 
 export type RoundId = '1' | '2' | '3' | '4' | '5'
@@ -96,9 +98,11 @@ export type InterviewCase = {
   status: InterviewCaseStatus
   risk: CaseRisk
   /**
-   * 무효 응시일 때만. 매니저가 아직 판정하지 않았으면 값이 있다 — 확인(그대로 두기·
-   * 무효로 처리) 후에는 지워진다(무효로 처리는 케이스 자체가 목록에서 사라지고,
-   * 그대로 두기는 이 필드만 지운다. 위 파일 머리말 판단 기록 참고).
+   * 무효 응시일 때만. 이 값 자체는 "그대로 두기"를 골라도 안 지워진다 — MG-04
+   * 브리프가 "시스템이 본 것"을 보여줄 때 언제든 다시 읽어야 해서다(재확인 대상
+   * 여부는 아래 `voidConfirmed`가 별도로 갖는다. 이전엔 이 필드를 지워 "확인
+   * 완료"를 표현했는데, 그러면 브리프를 다시 열었을 때 보여줄 값이 없어져 D49로
+   * 갈라냈다).
    */
   voidEvidence?: {
     unanswered: number
@@ -106,8 +110,18 @@ export type InterviewCase = {
     copied: boolean
     durationMin: number
   }
-  /** 종결(DONE)일 때만 — 면담일 + 다음에 할 것(없으면 null) */
-  interview?: { date: string; nextAction: string | null }
+  /**
+   * 무효 응시 확인(§6 "그대로 두기")을 마쳤는가 — MG-03 목록의 "무효 확인" 게이트·
+   * "확인 완료" 표시가 이 값을 본다. `voidEvidence`와 분리한 이유는 위 주석 참고.
+   */
+  voidConfirmed?: boolean
+  /**
+   * 종결(DONE)일 때만 — 면담일 + 다음에 할 것(없으면 null). `causes`·`why`는
+   * 브리프를 다시 열었을 때 이전에 고른 원인·적은 상세 사유를 복원하기 위한
+   * 값이다(종결 후에도 브리프를 다시 열 수 있다 — 아래 `saveInterviewBrief`
+   * 판단 기록 참고).
+   */
+  interview?: { date: string; nextAction: string | null; causes?: CauseKey[]; why?: string }
   /** 제외(EXCLUDED)일 때만 */
   excludedAt?: string
   excludedBy?: string
@@ -175,7 +189,9 @@ const ROUNDS: Record<RoundId, InterviewRound> = {
         className: 'A반',
         status: 'DONE',
         risk: { type: 'DECLINE', from: 0, to: 2 },
-        interview: { date: '2026-06-22', nextAction: null },
+        // MG-04 브리프 ①의 "지난 면담에서 정한 것" 예시(정의서·와이어 그대로)가
+        // 이 케이스를 인용한다 — nextAction을 null로 두면 인용할 값이 없다.
+        interview: { date: '2026-06-22', nextAction: '담당 기능 흐름 그려오기' },
       },
       {
         id: 'iv-2-3',
@@ -447,8 +463,10 @@ export function undoExclude(roundId: RoundId, caseId: string): Promise<void> {
 /**
  * `PATCH /interviews/{id}` — 무효 응시 확인. 자동 확정하지 않는다(9-4) — 사람이
  * 고른다. `INVALIDATE`는 결과 자체를 지우므로 케이스가 목록에서 사라진다(정의서
- * "이 회차 결과가 지워집니다 · 위험 판정도 남지 않습니다"). `KEEP`은 파일 머리말
- * 판단 기록 참고.
+ * "이 회차 결과가 지워집니다 · 위험 판정도 남지 않습니다"). `KEEP`은 `voidEvidence`를
+ * 지우지 않는다(D49) — MG-04 브리프가 "그대로 둔" 뒤에도 "시스템이 본 것"을 계속
+ * 보여줘야 해서다. 대신 `voidConfirmed`만 세워 MG-03의 "무효 확인" 게이트·"확인
+ * 완료" 표시를 가른다.
  */
 export function resolveVoid(
   roundId: RoundId,
@@ -461,7 +479,368 @@ export function resolveVoid(
   if (action === 'INVALIDATE') {
     round.cases = round.cases.filter((x) => x.id !== caseId)
   } else {
-    c.voidEvidence = undefined
+    c.voidConfirmed = true
+  }
+  return delay(undefined)
+}
+
+// ── MG-04 면담 브리프 목업 ──────────────────────────────────
+/*
+  값은 목업 docs/plan/v2/wireframe/manager/interview-brief.html의 장면(#brief·
+  #one·#multi·#group·#first·#void·#confirm·#savefail)을 그대로 옮긴다.
+
+  ⚠ 판단 기록 — 정의서·와이어에 없어 이 파일이 정한 것
+
+  · **"첫 면담"은 회차가 아니라 학생 단위다.** 와이어 #first 장면은 라벨상
+    "미프 2차"이지만, 이 저장소엔 그 회차가 없다 — 대신 "이 학생에게 이전
+    **면담**(DONE) 기록이 있는가"로 재정의해 판정한다(`findPriorInterview`).
+    한지우(`iv-3-5`)는 3차에서 처음 등장하고 이전 DONE 기록이 없어 자연히
+    "첫 면담" 장면과 같은 조건이 된다 — 회차 번호를 억지로 맞추지 않았다.
+  · **① 여는 말은 위험 유형이 아니라 "이전 면담 여부"로 갈린다.** 한지우의
+    위험 유형은 DECLINE(0→2)이라 비교 숫자가 있는데도, 와이어 #first는 비교
+    없는 문장("3개 중 2개에서 멈췄어요")을 쓴다 — 헤더 배지의 "0 → 2"는 그대로
+    두고(원본 데이터 그대로), ①의 문장만 이전 면담 유무로 고른다.
+  · **지속 저점(LOW_PERSISTENT)의 "지난 회차" 숫자** — 이 위험 유형은 from이
+    없다(계속 같은 지점에서 멈춘다는 뜻이라). 비교 문장을 쓸 때는 지난·이번
+    모두 같은 `lowCount`를 넣는다(이서준 `iv-3-3`) — 그래도 "무엇이 달라졌는지"
+    질문 자체는 여전히 유효하다(숫자가 아니라 이유가 바뀌었는지 묻는 것).
+  · **막힌 개념 목록은 이번 파일에 새로 둔다**(`CASE_CONCEPTS`) — 정의서 §4
+    "막힌 개념 · 채점 근거"는 세션 데이터를 읽는다고 했지만 이 레포에 세션-면담
+    간 연동은 없다(session 목업은 검증 문제 데이터라 개념 단위가 아니다). 위험
+    유형의 개수(2단 이하 N개)와 목록 길이가 어긋나지 않게 손으로 맞췄다.
+  · **"Graph 구성"을 김민준 말고 최유나(`iv-3-2`)에게도 겹쳐 뒀다** — 반 문제로
+    판정되려면(9-6) 원래 여러 학생이 같은 지점에서 막혀야 말이 된다. 한 명만
+    막힌 개념을 "반 절반 이상"이라고 부르면 그 자체로 앞뒤가 안 맞는다.
+  · **교안 위치("N장 P–Q쪽")는 `curriculum/mockData.ts`를 참조하지 않는다** —
+    이 파일 머리말이 이미 정한 "역할 간 mock cross-import 전례 없음" 원칙을
+    그대로 따른다. 값은 이 파일에서 독립적으로 붙인, 실제 페이지와 무관한
+    표시용 문자열이다.
+  · **"설명·표현 어려움"의 보낼 곳은 정의서·와이어 어디에도 없다** — 나머지
+    6개 원인은 정의서 표 또는 와이어 장면 어딘가에 예시가 있는데 이것만 없다.
+    "개념은 아는데 표현이 안 되는" 경우라 교안 재안내(개념 이해 부족)나 강사
+    Q&A(기술 문제)로 보내는 게 맞지 않다고 판단, **매니저가 다음 면담에서 직접
+    다시 설명해 보게 하는 것**으로 채웠다(전달만이 아니라 매니저 소관 — 면담
+    진행 자체가 매니저 일이라서). 팀장님 확인 필요하면 알려달라고 다음 세션에
+    남긴다.
+  · **③ 미체크 상태의 안내 문구는 와이어 원문("③에서 고르면 보낼 곳이
+    나타납니다")을 그대로 쓴다.** 정의서 6절의 paraphrase("고르지 않아도 저장할
+    수 있어요…")는 별도 저장 시점 토스트가 아니라 이 placeholder가 이미 하는
+    말과 같은 뜻이라 판단해, 저장을 막지 않는 것 자체로 충분하다고 보고 별도
+    확인 문구를 더 만들지 않았다.
+  · **"코드 매칭 0" 개념 제외·각주(정의서 6절)는 구현하지 않았다** — 이번
+    7개 케이스 어디에도 해당하는 예시가 없어 검증할 방법이 없다. `ConceptRef`
+    타입에 자리는 남겨 뒀다(`zeroMatch?`), 실제로 쓰는 케이스가 생기면 그때
+    필터링 로직을 채운다.
+  · **"저장 실패"(#savefail)는 mock이 실제로 실패시키지 않는다** — 이 파일의
+    다른 mock API(`excludeCase`·`undoExclude`·`resolveVoid`)도 전부 항상
+    성공한다. 화면 쪽 오류 처리 UI는 정의서·와이어대로 만들되, 강제로 실패를
+    재현하는 장치는 이 레포 관례에 없어 새로 만들지 않았다.
+*/
+
+export type CauseKey =
+  | 'CONCEPT_GAP'
+  | 'OUT_OF_SCOPE'
+  | 'TIME_SHORTAGE'
+  | 'EXPRESSION'
+  | 'DIFFICULTY_UP'
+  | 'TEAM_DEPENDENCE'
+  | 'CONDITION'
+
+/** ③ 들은 것 — 정의서 §3, 순서 고정 */
+export const CAUSE_OPTIONS: { key: CauseKey; label: string }[] = [
+  { key: 'CONCEPT_GAP', label: '개념 이해 부족' },
+  { key: 'OUT_OF_SCOPE', label: '담당 범위 밖' },
+  { key: 'TIME_SHORTAGE', label: '구현 시간 부족' },
+  { key: 'EXPRESSION', label: '설명·표현 어려움' },
+  { key: 'DIFFICULTY_UP', label: '난이도 상승' },
+  { key: 'TEAM_DEPENDENCE', label: '팀 의존' },
+  { key: 'CONDITION', label: '컨디션·심리' },
+]
+export const CAUSE_LABEL: Record<CauseKey, string> = Object.fromEntries(
+  CAUSE_OPTIONS.map((o) => [o.key, o.label]),
+) as Record<CauseKey, string>
+
+/** ② 질문 — 고정, 사용자가 못 고른다(정의서 §7 "② 질문 고르기 — 하지 않는다") */
+export const BRIEF_QUESTIONS = [
+  '이전 프로젝트와 비교해서 가장 달랐던 점이 뭐였어요?',
+  '이번에 어떤 역할을 맡았어요?',
+  '만들면서 제일 자신 없던 부분은요?',
+  '답하기 어려웠던 게 코드 때문이었어요, 설명하는 방식 때문이었어요?',
+]
+/** 무효 응시 전용 질문 3개(정의서 6-2) */
+export const VOID_BRIEF_QUESTIONS = [
+  '그날 컨디션이나 일정에 무슨 일이 있었어요?',
+  '화면을 열었을 때 어디서부터 막혔어요?',
+  '다시 볼 시간을 언제로 잡으면 좋을까요?',
+]
+
+export type DestOwner = 'MANAGER' | 'PASS'
+
+/** ④ 보낼 곳 한 줄. `owner`가 없으면 라우팅 액션이 아니라 안내 정보 줄(난이도 상승 공지문) */
+export type DestLine = {
+  /** 원인 라벨을 이 줄에 보여줄지 — 한 원인이 줄을 여럿 쓰면 첫 줄에만 true */
+  showLabel: boolean
+  text: string
+  /** text 안에서 굵게 표시할 부분 문자열(정확히 일치하는 첫 구간만) */
+  bold?: string
+  owner?: DestOwner
+  href?: string
+}
+
+export type ConceptRef = {
+  name: string
+  /** 교안 인용 문구 — "N장 P–Q쪽"(이 파일 안에서만 쓰는 표시용 값, 위 판단 기록 참고) */
+  curriculumRef?: string
+  /** 반 문제로 이미 판정됐으면(9-6) — 개인 사유·개념 이해 부족 목적지에서 빠지고 배너로 대체 */
+  groupIssue?: { classLabel: string }
+  /** 코드 매칭 0(정의서 6절) — 이번 케이스엔 없어 미사용, 자리만 남긴다 */
+  zeroMatch?: boolean
+}
+
+/**
+ * 케이스별 막힌 개념 — 위 판단 기록 참고. 처음엔 브리프가 열리는 PLANNED 7개
+ * 케이스만 채웠는데, 종결 후 브리프 재오픈(D47)으로 2차 DONE 케이스(`iv-2-1`·
+ * `iv-2-2`)도 브리프를 열 수 있게 되며 "이야기할 개념"이 비어 보이는 문제가
+ * 생겨(사용자 지적) 그 둘도 채웠다. `iv-2-3`(최유나, 제외 상태)은 브리프 버튼
+ * 자체가 없어 빠졌다.
+ */
+const CASE_CONCEPTS: Record<string, ConceptRef[]> = {
+  'iv-2-1': [
+    { name: 'HITL 개념 정의', curriculumRef: 'AI_LLMOps · 1장 12–18쪽' },
+    { name: 'HITL이 필요한 이유', curriculumRef: 'AI_LLMOps · 1장 19–24쪽' },
+    { name: '승인 UI 패턴', curriculumRef: 'AI_LLMOps · 4장 66–70쪽' },
+  ],
+  'iv-2-2': [
+    { name: '역할 기반 설계', curriculumRef: 'AI_LLMOps · 3장 30–36쪽' },
+    { name: '중단과 재개', curriculumRef: 'AI_LLMOps · 2장 55–59쪽' },
+  ],
+  'iv-1-1': [
+    { name: 'HITL 개념 정의', curriculumRef: 'AI_LLMOps · 1장 12–18쪽' },
+    { name: 'HITL이 필요한 이유', curriculumRef: 'AI_LLMOps · 1장 19–24쪽' },
+    { name: '중단과 재개', curriculumRef: 'AI_LLMOps · 2장 55–59쪽' },
+  ],
+  'iv-1-2': [
+    { name: '역할 기반 설계', curriculumRef: 'AI_LLMOps · 3장 30–36쪽' },
+    { name: '승인 UI 패턴', curriculumRef: 'AI_LLMOps · 4장 66–70쪽' },
+  ],
+  'iv-3-2': [
+    { name: 'Graph 구성', groupIssue: { classLabel: 'A반 23명 중 12명이 2단 이하' } },
+    { name: '체크포인트 저장', curriculumRef: 'AI_LLMOps · 6장 95–101쪽' },
+    { name: '승인 UI 패턴', curriculumRef: 'AI_LLMOps · 4장 66–70쪽' },
+  ],
+  'iv-3-3': [
+    { name: 'AgentState 필드 설계', curriculumRef: 'AI_LLMOps · 2장 50–54쪽' },
+    { name: '중단과 재개', curriculumRef: 'AI_LLMOps · 2장 55–59쪽' },
+  ],
+  'iv-3-4': [
+    { name: 'Graph 구성', groupIssue: { classLabel: 'A반 23명 중 12명이 2단 이하' } },
+    { name: 'HITL Trigger', curriculumRef: 'AI_LLMOps · 3장 36–46쪽' },
+  ],
+  'iv-3-5': [
+    { name: '인증 흐름', curriculumRef: 'AI_LLMOps · 5장 78–84쪽' },
+    { name: '트랜잭션', curriculumRef: 'AI_LLMOps · 5장 85–91쪽' },
+  ],
+}
+
+export type BriefData = {
+  caseId: string
+  traineeId: string
+  roundId: RoundId
+  roundLabel: string
+  name: string
+  className: string
+  risk: CaseRisk
+  isVoid: boolean
+  voidEvidence?: InterviewCase['voidEvidence']
+  hasPriorInterview: boolean
+  priorInterview?: { dateLabel: string; nextAction: string }
+  concepts: ConceptRef[]
+  /**
+   * 이 케이스 자신의 저장된 기록 — 종결(DONE) 후 브리프를 다시 열었을 때 이전에
+   * 고른 원인·적은 상세 사유·추후 계획을 복원한다(아래 `saveInterviewBrief`
+   * 판단 기록 참고). PLANNED로 처음 여는 브리프는 항상 없다.
+   */
+  savedRecord?: { causes: CauseKey[]; why: string; nextAction: string }
+}
+
+export const talkingConcepts = (b: BriefData): ConceptRef[] =>
+  b.concepts.filter((c) => !c.groupIssue && !c.zeroMatch)
+export const groupIssueConcepts = (b: BriefData): ConceptRef[] =>
+  b.concepts.filter((c) => !!c.groupIssue)
+
+/**
+ * ① 여는 말에 쓸 값 — **위험 유형 4종 × 고정 문장**(D51, 사용자 지시로 다시 씀).
+ * 전엔 "이전 면담 유무"로 비교/비비교 문장을 갈랐는데, 사용자가 "다들 어색하고
+ * 똑같다"고 지적해 위험 유형별로 자연스러운 문장을 따로 만들었다 — 문장 자체는
+ * `InterviewBriefScreen.tsx`의 `renderOpeningLine`이 갖고, 여기는 거기 꽂을
+ * 숫자만 계산한다(LLM 0회 원칙 유지 — 새로 쓴 문장은 화면 쪽 고정 템플릿뿐).
+ */
+export type OpeningLine =
+  | { kind: 'VOID' }
+  | { kind: 'DECLINE'; prev: number; now: number }
+  | { kind: 'LOW_PERSISTENT'; lowCount: number; streak: number }
+  | { kind: 'OBSERVE'; lowCount: number }
+
+export function openingLine(b: BriefData): OpeningLine {
+  const risk = b.risk
+  // `risk.type`으로 직접 좁힌다 — `b.isVoid`로 갈라도 값은 같지만, 그러면
+  // TS가 나머지 분기에서 `risk`가 `INVALID`를 배제한 걸 못 좁혀 컴파일 에러가 난다.
+  if (risk.type === 'INVALID') return { kind: 'VOID' }
+  if (risk.type === 'DECLINE') return { kind: 'DECLINE', prev: risk.from, now: risk.to }
+  if (risk.type === 'LOW_PERSISTENT') {
+    return { kind: 'LOW_PERSISTENT', lowCount: risk.lowCount, streak: risk.streak }
+  }
+  return { kind: 'OBSERVE', lowCount: risk.lowCount }
+}
+
+function findCaseLocation(caseId: string): { roundId: RoundId; item: InterviewCase } | null {
+  for (const roundId of Object.keys(ROUNDS) as RoundId[]) {
+    const item = ROUNDS[roundId].cases.find(byId(caseId))
+    if (item) return { roundId, item }
+  }
+  return null
+}
+
+/** 이 학생의 가장 최근 DONE 면담(현재 회차보다 이전) — "첫 면담" 여부와 지난 약속 인용에 쓴다 */
+function findPriorInterview(
+  traineeId: string,
+  beforeRoundId: RoundId,
+): { dateLabel: string; nextAction: string } | null {
+  const before = Number(beforeRoundId)
+  let found: InterviewCase | null = null
+  let foundRoundNum = -1
+  for (const roundId of Object.keys(ROUNDS) as RoundId[]) {
+    const roundNum = Number(roundId)
+    if (roundNum >= before) continue
+    const match = ROUNDS[roundId].cases.find(
+      (c) => c.traineeId === traineeId && c.status === 'DONE',
+    )
+    if (match && roundNum > foundRoundNum) {
+      found = match
+      foundRoundNum = roundNum
+    }
+  }
+  if (!found?.interview?.nextAction) return null
+  return { dateLabel: shortDateLabel(found.interview.date), nextAction: found.interview.nextAction }
+}
+
+/** `GET /interviews/{id}/brief` */
+export function getInterviewBrief(caseId: string): Promise<BriefData | null> {
+  const loc = findCaseLocation(caseId)
+  if (!loc) return delay(null)
+  const { roundId, item } = loc
+  const isVoid = item.risk.type === 'INVALID'
+  const prior = isVoid ? null : findPriorInterview(item.traineeId, roundId)
+  return delay({
+    caseId,
+    traineeId: item.traineeId,
+    roundId,
+    roundLabel: ROUND_LABEL[roundId],
+    name: item.name,
+    className: item.className,
+    risk: item.risk,
+    isVoid,
+    voidEvidence: item.voidEvidence,
+    hasPriorInterview: prior !== null,
+    priorInterview: prior ?? undefined,
+    concepts: isVoid ? [] : (CASE_CONCEPTS[caseId] ?? []),
+    savedRecord: item.interview
+      ? {
+          causes: item.interview.causes ?? [],
+          why: item.interview.why ?? '',
+          nextAction: item.interview.nextAction ?? '',
+        }
+      : undefined,
+  })
+}
+
+/**
+ * ④ 보낼 곳 — 원인 하나를 목적지 줄로 바꾼다. 원인 체크박스는 분류 라벨이 아니라
+ * 라우팅 스위치다(정의서 §3). `CONCEPT_GAP`·`DIFFICULTY_UP`만 케이스 데이터를
+ * 본다 — 나머지 5개는 고정 문구.
+ */
+export function destinationsFor(cause: CauseKey, brief: BriefData): DestLine[] {
+  switch (cause) {
+    case 'CONCEPT_GAP': {
+      const concepts = talkingConcepts(brief)
+      const lines: DestLine[] = concepts.map((c, i) => ({
+        showLabel: i === 0,
+        text: `교안 ${c.curriculumRef ?? 'AI_LLMOps'} 안내`,
+        owner: 'MANAGER',
+        href: '/manager/curriculum/cur-1',
+      }))
+      lines.push({ showLabel: lines.length === 0, text: '강사 Q&A 안내', owner: 'PASS' })
+      return lines
+    }
+    case 'OUT_OF_SCOPE':
+      return [
+        {
+          showLabel: true,
+          text: '다음 프로젝트 역할 분담에서 조정',
+          bold: '역할 분담',
+          owner: 'MANAGER',
+        },
+      ]
+    case 'TIME_SHORTAGE':
+      return [
+        {
+          showLabel: true,
+          text: '다시 보기 창 안내 · 다음 회차 일정 확인',
+          bold: '다시 보기 창',
+          owner: 'MANAGER',
+        },
+      ]
+    case 'EXPRESSION':
+      // 정의서·와이어에 예시가 없다 — 위 판단 기록 참고
+      return [{ showLabel: true, text: '다음 면담에서 다시 설명해보게 하기', owner: 'MANAGER' }]
+    case 'TEAM_DEPENDENCE':
+      return [{ showLabel: true, text: '다음 팀 편성에서 고려', bold: '팀 편성', owner: 'MANAGER' }]
+    case 'CONDITION':
+      return [
+        {
+          showLabel: true,
+          text: '기관 상담 채널로 연결',
+          bold: '상담 채널',
+          owner: 'PASS',
+        },
+      ]
+    case 'DIFFICULTY_UP':
+      // owner 없음 — 분류가 아니라 안내 정보 줄(9-6, 매니저가 세지 않게 한다)
+      return [
+        {
+          showLabel: true,
+          text: '반 절반 이상이면 개인 문제가 아님 — 기관에 보고',
+          bold: '기관에 보고',
+        },
+      ]
+  }
+}
+
+/**
+ * `PATCH /interviews/{id}/brief` — 저장은 항상 종결(정의서 §5). mock은 항상
+ * 성공한다(위 판단 기록).
+ *
+ * ⚠ **종결(DONE) 후에도 다시 저장할 수 있다** — 정의서·와이어엔 없는 흐름이다
+ * (7절 "약속 이행 추적은 하지 않는다"가 재오픈까지 막는다는 뜻은 아니라고 판단).
+ * 사용자 지시로 `InterviewListScreen`이 종결된 케이스에도 `[브리프 수정]`을 계속
+ * 보여주므로, 여기서도 상태를 `PLANNED`로 좁히지 않고 `EXCLUDED`만 막는다 —
+ * 제외는 별개의 종결 상태라 브리프로 되돌아오지 않는다(아래 `excludeCase` 판단
+ * 기록과 같은 이유, 이 함수는 상태 전이를 만들지 않는다). 원인·상세 사유도 같이
+ * 저장해 다음에 다시 열면 그대로 복원된다(`getInterviewBrief`의 `savedRecord`).
+ */
+export function saveInterviewBrief(
+  caseId: string,
+  payload: { causes: CauseKey[]; why: string; nextAction: string },
+): Promise<void> {
+  const loc = findCaseLocation(caseId)
+  if (loc && loc.item.status !== 'EXCLUDED') {
+    loc.item.status = 'DONE'
+    loc.item.interview = {
+      date: MOCK_TODAY,
+      nextAction: payload.nextAction.trim() || null,
+      causes: payload.causes,
+      why: payload.why,
+    }
   }
   return delay(undefined)
 }

--- a/src/features/manager/trainees/mockData.ts
+++ b/src/features/manager/trainees/mockData.ts
@@ -175,6 +175,80 @@ export const TRAINEES: TraineeRow[] = [
       '3': { status: 'ATTENDED', levels: [3, null, 4] },
     },
   },
+
+  /*
+   * MG-04(면담 브리프) 세션에서 추가 — `features/manager/interviews/mockData.ts`가
+   * 쓰는 `traineeId`(t-kim-minjun 등, 이 파일과 독립적으로 만들어진 값)가 위 t-1~
+   * t-12 어디에도 없어 "전체 이력"·이름 클릭이 전부 D-1(조회 권한 없음) 화면으로
+   * 막히던 문제를 사용자 확인 후 고쳤다. 기존 12명은 손대지 않고, 면담 화면이
+   * 실제로 참조하는 9명만 **같은 id·이름**으로 새로 추가한다 — 두 화면이 이제
+   * 같은 사람을 가리킨다. `rounds`·타임라인 오버레이는 채우지 않았다(면담 목업이
+   * 요구하는 범위 밖 — `getTraineeDetailOverlay`가 오버레이 없는 id는 빈 타임라인
+   * "아직 응시한 회차가 없습니다"로 이미 정상 처리한다, §6).
+   */
+  {
+    id: 't-lee-seojun',
+    name: '이서준',
+    email: 'seojun.lee@ex.com',
+    className: 'A반',
+    accountStatus: 'ACTIVE',
+  },
+  {
+    id: 't-choi-yuna',
+    name: '최유나',
+    email: 'yuna@ex.com',
+    className: 'C반',
+    accountStatus: 'ACTIVE',
+  },
+  {
+    id: 't-kim-minjun',
+    name: '김민준',
+    email: 'minjun.kim@ex.com',
+    className: 'A반',
+    accountStatus: 'ACTIVE',
+  },
+  {
+    id: 't-oh-serim',
+    name: '오세림',
+    email: 'serim@ex.com',
+    className: 'C반',
+    accountStatus: 'ACTIVE',
+  },
+  {
+    id: 't-han-jiwoo',
+    name: '한지우',
+    email: 'jiwoo.han@ex.com',
+    className: 'B반',
+    accountStatus: 'ACTIVE',
+  },
+  {
+    id: 't-park-dohyun',
+    name: '박도현',
+    email: 'dohyun.park@ex.com',
+    className: 'B반',
+    accountStatus: 'ACTIVE',
+  },
+  {
+    id: 't-kang-yunseo',
+    name: '강윤서',
+    email: 'yunseo@ex.com',
+    className: 'B반',
+    accountStatus: 'ACTIVE',
+  },
+  {
+    id: 't-jung-haneul',
+    name: '정하늘',
+    email: 'haneul@ex.com',
+    className: 'A반',
+    accountStatus: 'ACTIVE',
+  },
+  {
+    id: 't-seo-jihun',
+    name: '서지훈',
+    email: 'jihun@ex.com',
+    className: 'C반',
+    accountStatus: 'ACTIVE',
+  },
 ]
 
 /** 2단 이하 개수. 3(그 회차 검증 개념 수)은 고정 분모라 셀 수와 별개로 저장하지 않는다 */


### PR DESCRIPTION
## 작업 내용

MG-04 면담 브리프 화면 구현. 위험 판정 근거·과거 이력·이야기할 개념을 한 화면에서
보고 원인·조치를 기록. ConsoleShell로 통일, 무효 응시 evidence 유지, 종결된 면담
재오픈 지원, 위험 유형별 여는 말, 목록 필터 세션 유지(회차 전환 시 초기화).
`trainees/mockData.ts`에 9명 추가해 면담 mock traineeId를 실제 ID와 매칭.

## 리뷰 포인트

* `voidEvidence`/`voidConfirmed` 분리 — 무효 응시 확인 후에도 evidence가 안 사라지는지
* 종결(DONE) 케이스 브리프 재오픈 시 `savedRecord` prefill 동작
* `openingLine()` 타입 좁히기(`risk.type`) — 컴파일은 통과하나 로직 리뷰 필요

## 확인

- [x] 로컬에서 동작 확인 (tsc·prettier·check-design)
- [x] 로컬 브라우저 렌더 확인
- [x] 하나의 PR = 하나의 기능

closes #115 