### PR TITLE
[Chore] Set Up OpenAPI Spec Pipeline and Codegen

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,3 +13,12 @@
 *.woff binary
 *.woff2 binary
 *.pdf binary
+
+# 자동 생성물 — PR diff에서 접어 리뷰 소음을 줄인다(내용은 그대로 커밋된다)
+# 손으로 쓰는 _contract는 제외한다. 나머지 src/api/**는 api:gen 산출물이다.
+src/api/*.ts linguist-generated=true
+src/api/*.d.ts linguist-generated=true
+src/api/PENDING.md linguist-generated=true
+src/api/*/*.ts linguist-generated=true
+src/api/_contract/** !linguist-generated
+api/openapi.json linguist-generated=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,13 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      # 커밋된 스펙이 코드 생성을 감당할 품질인가. 네트워크를 타지 않는다(api/openapi.json을 읽는다).
+      # error만 실패시킨다 — warn(백엔드에 개선 요청 중인 것들)은 통과한다.
+      - name: API spec
+        run: |
+          npm run api:test
+          npm run api:check
+
       # 아래 셋은 typecheck·lint·build가 **전부 통과하는 버그**를 잡는다.
       # 문법도 타입도 맞는데 규칙이 틀린 것들이라, 여기 없으면 사람이 눈으로 찾게 된다.
       # (실제로 IME 가드는 사용자가 칩 두 개 생기는 걸 보고 알려줘서 발견했다)

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,7 +1,9 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
   "plugins": ["react", "typescript", "oxc"],
-  "ignorePatterns": ["scripts/**", "dist/**"],
+  // openapi-typescript가 뱉는 스펙 전량 타입. 사람이 안 읽고 안 고치는 파일이라 제외한다.
+  // 나머지 생성물(호출 함수·훅)은 우리 생성기가 만들고 우리 규칙을 지켜야 하므로 린트한다.
+  "ignorePatterns": ["scripts/**", "dist/**", "src/api/schema.d.ts"],
   "rules": {
     "react/rules-of-hooks": "error",
     "react/only-export-components": ["warn", { "allowConstantExport": true }],

--- a/.prettierignore
+++ b/.prettierignore
@@ -16,3 +16,9 @@ docs/plan/v2/wireframe
 # 생성물 — 포맷하면 생성기 출력과 달라져 드리프트 검사가 깨진다
 docs/dev/design-system.html
 docs/dev/components.html
+
+# 생성물(src/api/generated)은 여기서 빼지 않는다 — api:gen이 마지막에 prettier를 돌리므로
+# 이미 같은 포맷이고, format:check가 "생성 후 손댔는지"까지 잡아 준다.
+
+# 백엔드에서 받아 온 스펙 원본. 포매터가 손대면 api:pull이 매번 되돌려 diff가 튄다
+api/openapi.json

--- a/api/codegen.config.json
+++ b/api/codegen.config.json
@@ -1,0 +1,55 @@
+{
+  "$comment": [
+    "코드 생성 설정 — 경로·이름 규칙을 여기 한 곳에서만 정한다.",
+    "생성기(scripts/api-gen.mjs)는 이 파일 밖의 경로를 하드코딩하지 않는다.",
+    "배치를 바꾸고 싶으면 이 파일만 고치고 `npm run api:gen`을 다시 돌린다 — 파일을 손으로 옮기지 않는다.",
+    "치환자: {tagName}(짧은 도메인 이름) · {TagName}(PascalCase) · {featurePath}(tagPaths 값)"
+  ],
+  "spec": {
+    "url": "https://xvdanr6m362b2ge232vdmfbrny0kwakz.lambda-url.ap-northeast-1.on.aws/v3/api-docs",
+    "file": "api/openapi.json"
+  },
+  "paths": {
+    "$comment": "shared = 전 도메인이 함께 쓰는 생성물 · domain = 도메인별 생성물 · contract = 손으로 쓰는 것",
+    "shared": "src/api",
+    "domain": "src/api/{tagName}",
+    "contract": "src/api/_contract"
+  },
+  "files": {
+    "schema": "schema.d.ts",
+    "errorCodes": "errorCodes.ts",
+    "pending": "PENDING.md",
+    "domainTypes": "{tagName}Types.ts",
+    "domainApi": "{tagName}Api.ts",
+    "queryKeys": "{tagName}Keys.ts",
+    "queries": "use{TagName}Queries.ts",
+    "mutations": "use{TagName}Mutations.ts"
+  },
+  "imports": {
+    "contract": "@/api/_contract",
+    "schema": "@/api/schema",
+    "errorCodes": "@/api/errorCodes",
+    "domainTypes": "./{tagName}Types",
+    "domainApi": "./{tagName}Api",
+    "queryKeys": "./{tagName}Keys",
+    "reactQuery": "@tanstack/react-query"
+  },
+  "$comment_tags": [
+    "OpenAPI 태그 → 폴더·파일 이름. 'Academic Operations'를 그대로 쓰면 길어져 읽기 나쁘다.",
+    "여기 없는 태그는 camelCase 변환을 그대로 쓴다.",
+    "",
+    "화면 폴더로 나누지 않는 이유: 태그가 화면과 1:1이 아니다.",
+    "  Usage Metering → SA-02 + OP-06 · Disclosure → TR-04 + MG-08 · Reporting → TR-04 + OP-05",
+    "화면 폴더에 넣으면 ① 어느 화면 것인지 임의로 골라야 하고 ② 다른 역할이 쓸 때",
+    "레이어 린트(features/A → features/B 금지)에 막힌다. 상세는 docs/dev/api-codegen.md D7."
+  ],
+  "tags": {
+    "Auth": "auth",
+    "Consent": "consent",
+    "Organization": "organization",
+    "Usage Metering": "usage",
+    "Platform Governance": "platform",
+    "Academic Operations": "academic",
+    "Member": "member"
+  }
+}

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -1,0 +1,8973 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "IZ-Get",
+    "description": "IZ-Get API Specification",
+    "version": "v0.1"
+  },
+  "servers": [
+    {
+      "url": "https://mmbvymzj5k.ap-northeast-1.awsapprunner.com",
+      "description": "Generated server url"
+    }
+  ],
+  "security": [
+    {
+      "bearerAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Academic Operations",
+      "description": "기수, 반, 교육생 소속 이력, 매니저 반 배정 API"
+    },
+    {
+      "name": "Consent",
+      "description": "가입 화면 동의 항목 조회 API"
+    },
+    {
+      "name": "Organization",
+      "description": "기관 프로비저닝, 기관 상태, 계약, 기관별 운영 정책, 기관 삭제·복구 API (v2 IA: SA-01 기관 목록 / SA-02 기관 상세)"
+    },
+    {
+      "name": "Member",
+      "description": "사용자 계정, 역할, 초대, 활성화, 계정 상태, 약관 동의 API (매니저·교육생)"
+    },
+    {
+      "name": "Platform Governance",
+      "description": "플랫폼 전역 AI 모델 정책, 모델 티어, 단가, 보정 버전, 전역 설정 API (v2 IA: SA-03 플랫폼 설정 — 모델·단가 / 슈퍼어드민 계정)"
+    },
+    {
+      "name": "Disclosure",
+      "description": "리포트 공개 범위 조회·설정 API (v2 IA: TR-04 / MG-08)"
+    },
+    {
+      "name": "Reporting",
+      "description": "리포트 발행 이력·본문·문답 조회 API (v2 IA: TR-04 / OP-05)"
+    },
+    {
+      "name": "Auth",
+      "description": "로그인, Access/Refresh Token 재발급·세션 폐기, 비밀번호 재설정, 초대 계정 활성화 API"
+    },
+    {
+      "name": "Usage Metering",
+      "description": "AI 호출량·토큰·비용, 저장소 사용량, 기관 한도, 비용 집계 API (v2 IA: SA-02 ③④ / OP-06 ⑤)"
+    }
+  ],
+  "paths": {
+    "/api/v0/reports/{reportId}/disclosure": {
+      "get": {
+        "tags": [
+          "Disclosure"
+        ],
+        "summary": "내 리포트 공개 상태 조회 | ⚠️ 사용 불가",
+        "description": "TR-04에서 **본문이 안 열리는 이유**를 판별한다. `GET /reports`가 회차 상태까지\n같이 주므로 화면이 매번 부를 필요는 없고, `PENDING_VISIBILITY`처럼\n**공개 쪽 사정으로 잠긴 회차**를 눌렀을 때 확인용으로 쓴다.\n\n**교육생 본인 것만 나간다.** `traineeId`를 받지 않고 인증 주체로 결정한다.\n\n## 요청\n\n| 변수 | 필수 | 타입 | 설명 |\n|---|---|---|---|\n| `reportId` | **필수** | UUID | 리포트 식별자. `assessmentRoundId`가 아니다 |\n\n## 응답\n\n| 필드 | 타입 | 설명 |\n|---|---|---|\n| `releaseStatus` | enum | **판별자.** `NOT_CONFIGURED` · `WITHHELD` · `RELEASED` |\n| `scope` | enum? | `PRIVATE` · `SUMMARY` · `FULL`. 미지정이면 **키가 빠진다** |\n| `publishedAt` | instant? | 발행 시각. 발행 전이면 키가 빠진다 |\n| `releasedAt` | instant? | 공개 처리 시각. `RELEASED`에서만 |\n| `bodyVisible` | boolean | 본문을 읽을 수 있는가 |\n| `visibleFields` | object | `{said, curriculumRef, qa}` — 범위가 여는 필드 |\n\n## 상태 3종이 화면에서 뜻하는 것\n\n| `releaseStatus` | 화면 |\n|---|---|\n| `NOT_CONFIGURED` | `공개 범위 미지정` — **결과는 나와 있고 매니저가 여는 시점만 남았다** |\n| `WITHHELD` | 회차는 목록에 보이되 본문이 잠긴다 |\n| `RELEASED` | `PUBLISHED` |\n\n⚠️ **셋 다 정상 상태라 오류를 던지지 않는다.** 본문 조회가 막히는 것과 다르다 —\n이 API는 \"왜 막혔나\"를 알려 주는 쪽이므로 200으로 상태를 싣는다.\n\n## visibleFields — 범위→필드 규칙을 서버가 계산한다\n\n| 범위 | `said` | `curriculumRef` | `qa` |\n|---|---|---|---|\n| `PRIVATE`·미지정 | ❌ | ❌ | ❌ |\n| `SUMMARY` | ⭕ | ⭕ | ❌ |\n| `FULL` | ⭕ | ⭕ | ⭕ |\n\n프론트가 이 표를 다시 구현하면 서버와 어긋날 때 **학생에게 안 보여야 할 문답이\n보이는 쪽**으로 틀릴 수 있다.\n\n## 오류\n\n| 코드 | 상황 |\n|---|---|\n| 404 `REPORT_NOT_FOUND` | 없는 리포트 **또는 남의 리포트** |\n\n남의 리포트를 403이 아니라 404로 돌려준다 — 403이면 그 id가 존재한다는 사실이 샌다.\n",
+        "operationId": "findMyDisclosure",
+        "parameters": [
+          {
+            "name": "reportId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReportDisclosureResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "unavailable"
+      },
+      "put": {
+        "tags": [
+          "Disclosure"
+        ],
+        "summary": "리포트 공개 범위 설정 | ⚠️ 사용 불가",
+        "description": "담당 매니저가 회차 결과를 교육생에게 연다. TR-04의 `공개 범위 미지정`을\n푸는 유일한 경로다 — 이 호출이 없으면 리포트는 발행돼도 영원히 잠겨 있다.\n\n## 요청\n\n| 필드 | 필수 | 타입 | 설명 |\n|---|---|---|---|\n| `scope` | **필수** | enum | `PRIVATE` · `SUMMARY` · `FULL` |\n\n`NOT_CONFIGURED`는 보낼 수 없다. 미지정은 아직 아무도 정하지 않은 초기 상태이지\n선택지가 아니며, 열었다 닫는 것은 `PRIVATE`이다.\n\n## scope가 상태 4컬럼을 결정한다\n\n| 보낸 값 | 결과 상태 | 시각·주체 |\n|---|---|---|\n| `PRIVATE` | `WITHHELD` | 비운다 |\n| `SUMMARY` · `FULL` | `RELEASED` | 지금 · 요청한 매니저 |\n\n클라이언트가 상태·시각·주체를 직접 보내지 않는 이유는 DB CHECK\n`ck_report_trainee_release_status_2`가 넷의 조합을 강제하기 때문이다 —\n따로 받으면 제약을 어기는 조합을 만들 수 있다.\n\n## 발행 전에도 정할 수 있다\n\n**발행(`publishedAt`)과 공개(`releaseStatus`)는 다른 사건**이라 순서를 강제하지 않는다.\n발행 전에 범위를 정해 두면 발행되는 순간 바로 열린다. 다만 `bodyVisible`은\n둘이 모두 갖춰져야 참이다.\n\n## 권한\n\n요청 매니저가 **지금 담당하는 반**의 교육생 리포트만 바꿀 수 있다.\n배정 이력이 해제된 반(`manager_assignment.unassigned_at`)과 이탈한 교육생\n(`cohort_member.left_at`)은 제외된다 — 지난 기수에 잠깐 담당했던 매니저가\n계속 공개 범위를 바꾸면 안 된다.\n\n## 오류\n\n| 코드 | 상황 |\n|---|---|\n| 400 `REPORT_DISCLOSURE_SCOPE_INVALID` | 도메인이 막는 조합(공개인데 범위가 비공개) |\n| 404 `REPORT_NOT_FOUND` | 없는 리포트 · **담당하지 않는 교육생** · 기수 단위 리포트 |\n\n담당하지 않는 경우도 403이 아니라 404다 — 존재 여부를 흘리지 않기 위해\n조회 실패와 권한 실패를 같은 응답으로 합쳤다.\n",
+        "operationId": "updateDisclosure",
+        "parameters": [
+          {
+            "name": "reportId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateReportDisclosureRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReportDisclosureResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "unavailable"
+      }
+    },
+    "/api/v0/platform/operations/tier-models": {
+      "put": {
+        "tags": [
+          "Platform Governance"
+        ],
+        "summary": "티어 ↔ 모델 매핑 변경 | ✅ 사용 가능",
+        "description": "SA-03 ① `코드 세션 · 정확도 우선 / 균형 / 비용 우선` 3티어 매핑을 바꾼다.\n**한 번에 한 티어씩** 바꾼다.\n\n## 요청 (JSON 본문)\n\n| 필드 | 필수 | 타입 | 설명 |\n|---|---|---|---|\n| `featureCode` | **필수** | enum | **`CODE_SESSION` 하나뿐이다**(v07 기준) |\n| `tierCode` | **필수** | enum | `ACCURACY_FIRST` · `BALANCED` · `COST_FIRST` |\n| `modelId` | **필수** | UUID | 그 (기능, 티어)가 실제로 호출할 모델 |\n| `changeReason` | 선택 | string | 변경 사유 |\n\n## 응답\n\n변경 후의 **모델·단가 설정 전체**(`GET /model-settings` 와 같은 구조).\n화면을 그대로 다시 그리면 된다.\n\n## 채점 모델 변경과 다르다\n\n| | 채점 모델 | 티어 매핑 |\n|---|---|---|\n| 재캘리브레이션 | **발생** | **없음** |\n| 확인 플래그 | 필수 | 불필요 |\n| 되돌리기 | 사실상 불가 | 다시 바꾸면 됨 |\n\n코드 세션은 점수가 아니라 **산출물**이라 버전 간 비교 문제가 없다.\n화면의 확인 모달은 \"정말 바꿀지\"만 묻는 가벼운 확인이면 된다.\n\n(기능, 티어) 조합별로 버전이 올라가고 이전 활성 버전은 `SUPERSEDED` 로 닫힌다.\n\n## 오류\n\n| 코드 | 상황 |\n|---|---|\n| 400 | 필수 누락 · `featureCode` 가 `CODE_SESSION` 이 아님 |\n| 400 `AI_MODEL_NOT_AVAILABLE` | 없는 모델이거나 `INACTIVE` 상태 |\n",
+        "operationId": "updateTierModel",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTierModelRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "변경 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlatformModelSettingResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "AI_MODEL_NOT_AVAILABLE",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "AI_MODEL_NOT_AVAILABLE": {
+                    "summary": "AI_MODEL_NOT_AVAILABLE",
+                    "value": {
+                      "code": "AI_MODEL_NOT_AVAILABLE",
+                      "message": "사용할 수 없는 AI 모델입니다."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "available"
+      }
+    },
+    "/api/v0/platform/operations/models/{modelId}/pricing": {
+      "put": {
+        "tags": [
+          "Platform Governance"
+        ],
+        "summary": "모델 단가 수정 | ✅ 사용 가능",
+        "description": "SA-03 ① `단가 · 모델별 입력·출력 토큰 단가` 행의 `입력`/`수정` 액션.\n\n## 요청\n\n**경로 변수** — `modelId` (**필수**, UUID). 조회 응답의 `modelPricings[].modelId`\n\n**JSON 본문** — 단가는 모두 **100만 토큰당** 값이다.\n\n| 필드 | 필수 | 타입 | 설명 |\n|---|---|---|---|\n| `inputPricePerMillionTokens` | 조건부 | decimal | 입력 단가. 0 이상 |\n| `outputPricePerMillionTokens` | 조건부 | decimal | 출력 단가. 0 이상 |\n| `cachedInputPricePerMillionTokens` | 선택 | decimal | 캐시 입력 단가 |\n| `priceUnitTokenCount` | 선택 | int | 단가 기준 토큰 수. 기본 `1000000` |\n\n**입력·출력 단가는 함께 움직인다.**\n\n| 보내는 값 | 결과 |\n|---|---|\n| 입력·출력 **둘 다 값** | 단가 설정 |\n| 입력·출력 **둘 다 `null`** | **단가 미설정으로 되돌림** |\n| 한쪽만 값 | **400** — 쌍이 맞지 않음 |\n\n캐시 단가는 입력 단가가 있을 때만 설정할 수 있다(입력이 `null` 인데 캐시만 보내면 400).\n\n## ⚠️ 미설정과 0은 다르다\n\n단가를 지우려면 **`null`** 을 보내세요. **`0` 은 '무료'라는 뜻**이라 전혀 다릅니다.\n\n| | 사용량 집계에서 |\n|---|---|\n| `null`(미설정) | 비용 합계에서 **제외**하고 `unpricedCallCount` 로 따로 센다 |\n| `0` | 0원으로 **합산**된다 |\n\n목업 SA-03: *\"0으로 합산하면 청구액이 실제보다 작아 보인다.\"*\n\n## 응답\n\n변경 후의 **모델·단가 설정 전체**(`GET /model-settings` 와 같은 구조).\n\n## 오류\n\n| 코드 | 상황 |\n|---|---|\n| 400 | 입력·출력 단가 쌍 불일치 · 캐시 단가만 지정 · 음수 |\n| 400 `AI_MODEL_NOT_AVAILABLE` | 없는 모델 |\n",
+        "operationId": "updateModelPricing",
+        "parameters": [
+          {
+            "name": "modelId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateModelPricingRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "수정 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlatformModelSettingResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "AI_MODEL_NOT_AVAILABLE · 단가 쌍 불일치",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "AI_MODEL_NOT_AVAILABLE": {
+                    "summary": "AI_MODEL_NOT_AVAILABLE",
+                    "value": {
+                      "code": "AI_MODEL_NOT_AVAILABLE",
+                      "message": "사용할 수 없는 AI 모델입니다."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "available"
+      }
+    },
+    "/api/v0/platform/operations/grading-model": {
+      "put": {
+        "tags": [
+          "Platform Governance"
+        ],
+        "summary": "채점 모델 변경 (전 기관 재캘리브레이션 유발) | ✅ 사용 가능",
+        "description": "SA-03 ① `채점 · 고정 · claude-x` 행의 변경 액션.\n\n## ⚠️ 되돌릴 수 없다\n\n목업: *\"채점 모델을 바꾸면 **전 기관 재캘리브레이션**이 필요하고, 버전이 다른 결과끼리는\n화면에서 비교를 막는다.\"*\n\n**반드시 확인 모달을 거쳐 호출하세요.** 서버도 `acknowledgeRecalibration=true` 를\n요구해 한 번 더 막는다.\n\n## 요청 (JSON 본문)\n\n| 필드 | 필수 | 타입 | 설명 |\n|---|---|---|---|\n| `modelId` | **필수** | UUID | 새 채점 모델. `GET /model-settings` 의 `modelPricings[].modelId` 에서 고른다 |\n| `calibrationVersionCode` | **필수** | string | 새로 만들 캘리브레이션 버전 코드 |\n| `acknowledgeRecalibration` | **필수** | boolean | **반드시 `true`.** false·누락이면 400 |\n| `changeReason` | 선택 | string | 변경 사유(감사·이력용) |\n\n**`calibrationVersionCode` 는 조회해서 고르는 값이 아니라 직접 짓는 이름이다.**\n\n- 형식: `^[A-Z][A-Z0-9_]*$` — 대문자로 시작, 대문자·숫자·밑줄만. 100자 이하\n- **전체 UNIQUE** — 이미 쓴 값이면 409\n- 예: `CAL_2026_08_V1`\n\n## 응답\n\n변경 후의 **모델·단가 설정 전체**(`GET /model-settings` 와 같은 구조).\n화면을 그대로 다시 그리면 된다. `gradingPolicy.runningCalibration` 에 방금 만든\n재캘리브레이션 버전이 담긴다.\n\n## 한 번 호출하면 벌어지는 일\n\n한 트랜잭션에서:\n\n1. 현재 활성 채점 정책을 `SUPERSEDED` 로 닫고 **새 버전 발급**\n2. 새 캘리브레이션 버전 생성(`PENDING`)\n3. **삭제되지 않은 전 기관**에 재캘리브레이션 대기 행 생성\n\n⚠️ **실제 재캘리브레이션 실행은 별도 배치 담당이고, 그 배치가 아직 없다.**\n따라서 상태가 `PENDING` 에서 넘어가지 않으며, **다시 바꾸려 하면 계속 409 가 난다.**\n테스트 중이라면 개발 DB 에서 해당 버전 상태를 직접 정리해야 한다.\n\n## 오류\n\n| 코드 | 상황 |\n|---|---|\n| 400 | `acknowledgeRecalibration` 이 true 가 아님 · 버전 코드 형식 오류 |\n| 400 `AI_MODEL_NOT_AVAILABLE` | 없는 모델이거나 `INACTIVE` 상태 |\n| 409 `CALIBRATION_VERSION_CODE_TAKEN` | 이미 쓴 버전 코드 |\n| 409 `CALIBRATION_IN_PROGRESS` | **재캘리브레이션이 이미 진행 중** — 두 버전이 동시에 돌면 어느 쪽이 비교 기준인지 알 수 없다 |\n",
+        "operationId": "updateGradingModel",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateGradingModelRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "변경 성공(재캘리브레이션 대기 생성 완료)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlatformModelSettingResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "AI_MODEL_NOT_AVAILABLE · 확인 플래그 누락",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "AI_MODEL_NOT_AVAILABLE": {
+                    "summary": "AI_MODEL_NOT_AVAILABLE",
+                    "value": {
+                      "code": "AI_MODEL_NOT_AVAILABLE",
+                      "message": "사용할 수 없는 AI 모델입니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "CALIBRATION_IN_PROGRESS · CALIBRATION_VERSION_CODE_TAKEN",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "CALIBRATION_IN_PROGRESS": {
+                    "summary": "CALIBRATION_IN_PROGRESS",
+                    "value": {
+                      "code": "CALIBRATION_IN_PROGRESS",
+                      "message": "재캘리브레이션이 이미 진행 중입니다."
+                    }
+                  },
+                  "CALIBRATION_VERSION_CODE_TAKEN": {
+                    "summary": "CALIBRATION_VERSION_CODE_TAKEN",
+                    "value": {
+                      "code": "CALIBRATION_VERSION_CODE_TAKEN",
+                      "message": "이미 사용 중인 캘리브레이션 버전 코드입니다."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "available"
+      }
+    },
+    "/api/v0/organizations/{organizationId}/operations/settings": {
+      "get": {
+        "tags": [
+          "Usage Metering"
+        ],
+        "summary": "기관 운영 설정 조회 | ✅ 사용 가능",
+        "description": "SA-02 ④ 설정 탭을 채운다. 현재 **활성(ACTIVE) 정책 버전**의 값이다.\n\n## 요청\n\n| 변수 | 필수 | 타입 | 설명 |\n|---|---|---|---|\n| `organizationId` | **필수** | UUID | 기관 식별자 |\n\n본문 없음.\n\n## 응답\n\n| 필드 | 타입 | 설명 |\n|---|---|---|\n| `organizationId` | UUID | 기관 식별자 |\n| `organizationStatus` | enum | `ACTIVE` · `SUSPENDED` · `DELETION_PENDING` · `DELETED` |\n| `monthlyAiBudget` | decimal | 월 AI 예산 상한. `0` 은 무제한이 아니라 **예산 0** |\n| `currencyCode` | string | 통화. 플랫폼 공통 `USD` 고정, 변경 불가 |\n| `monthlyTokenLimit` | long? | 월 토큰 상한. **`null` 이면 무제한** |\n| `storageLimitBytes` | long? | 저장량 상한(바이트). **`null` 이면 무제한** |\n| `dataRetentionDays` | int | 보존기간. `90` · `180` · `365` 중 하나 |\n| `defaultDisclosureScope` | enum | 신규 기수 공개범위 기본값. `SUMMARY` · `PRIVATE` · `FULL` |\n| `codeSessionTierCode` | enum | 코드 세션 모델 티어. `ACCURACY_FIRST` · `BALANCED` · `COST_FIRST` |\n| `allowManagerInvite` | boolean | 신규 매니저 초대·재발송 허용 |\n| `allowDataExport` | boolean | 신규 데이터 export 생성 허용 |\n| `allowZipSubmission` | boolean | ZIP 코드 제출 허용. 끄면 GitHub 연동만 남는다 |\n| `allowGithubIntegration` | boolean | GitHub 조직 연동 허용(**정책**이며 실제 연결은 별도 흐름) |\n| `enableBigProjectContributionAnalysis` | boolean | 빅프로젝트 기여도 분석 허용 |\n| `policyVersion` | int | 현재 정책 버전. 변경할 때마다 올라간다 |\n\n⚠️ **변경 API 가 전체 치환이므로 이 응답을 그대로 폼 초기값으로 쓰세요.**\n사용자가 바꾼 필드만 덮어쓰고 나머지는 여기서 받은 값을 그대로 다시 보내야 합니다.\n\n## 오류\n\n| 코드 | 상황 |\n|---|---|\n| 404 `ORG_NOT_FOUND` | 없는 기관 |\n| 409 `ORG_POLICY_NOT_FOUND` | 활성 정책이 없음(API 를 거치지 않고 만들어진 데이터) |\n",
+        "operationId": "findOrganizationOperationSettings",
+        "parameters": [
+          {
+            "name": "organizationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OperationSettingResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "available"
+      },
+      "put": {
+        "tags": [
+          "Usage Metering"
+        ],
+        "summary": "기관 운영 설정 변경 | ✅ 사용 가능",
+        "description": "SA-02 ④ 설정 탭의 저장 액션. **슈퍼어드민 전용**이다(오퍼레이터는 사용량 조회만 가능).\n\n## ⚠️ 부분 수정(PATCH)이 아니라 전체 치환(PUT)이다\n\n**보내지 않은 필드는 유지되는 게 아니라 검증 오류(400)가 난다.**\n`GET .../settings` 응답을 폼 초기값으로 받아 두고, 사용자가 바꾼 것만 덮어써서\n**전체를 다시 보내세요.**\n\n`organization_policy` 는 append-only 이력 테이블이라 기존 행을 고치지 않는다.\n활성 버전을 `SUPERSEDED` 로 닫고 **새 버전을 발급**하므로 `policyVersion` 이 1 올라간다.\n\n## 요청\n\n**경로 변수** — `organizationId` (**필수**, UUID)\n\n**JSON 본문**\n\n| 필드 | 필수 | 타입 | 설명 |\n|---|---|---|---|\n| `organizationStatus` | **필수** | enum | `ACTIVE` 또는 `SUSPENDED` 만. 그 외 값은 400 |\n| `monthlyAiBudget` | **필수** | decimal | 0 이상. `0` 은 무제한이 아니라 **예산 0** |\n| `dataRetentionDays` | **필수** | int | **`90` · `180` · `365` 중 하나만** |\n| `defaultDisclosureScope` | **필수** | enum | `SUMMARY` · `PRIVATE` · `FULL` |\n| `codeSessionTierCode` | **필수** | enum | `ACCURACY_FIRST` · `BALANCED` · `COST_FIRST` |\n| `allowManagerInvite` | **필수** | boolean | 신규 매니저 초대·재발송 허용 |\n| `allowDataExport` | **필수** | boolean | 신규 데이터 export 생성 허용 |\n| `allowZipSubmission` | **필수** | boolean | ZIP 코드 제출 허용 |\n| `allowGithubIntegration` | **필수** | boolean | GitHub 조직 연동 허용(정책이며 실제 연결은 별도 흐름) |\n| `enableBigProjectContributionAnalysis` | **필수** | boolean | 빅프로젝트 기여도 분석 허용 |\n| `monthlyTokenLimit` | 선택 | long | 월 토큰 상한. **`null` 이면 무제한**. 보낼 경우 0 초과 |\n| `storageLimitBytes` | 선택 | long | 저장량 상한(바이트). **`null` 이면 무제한**. 0 이상 |\n\n통화(`currencyCode`)는 **요청 항목이 아니다.** 플랫폼 공통 USD 고정이며 DB CHECK 로도 강제된다.\n\n## 응답\n\n새 버전 기준의 운영 설정. **`GET .../settings` 와 완전히 같은 구조**다.\n`policyVersion` 이 올라간 것을 확인하면 저장이 반영된 것이다.\n\n## 이 API 로 기관 상태도 바뀐다\n\n`organizationStatus` 가 함께 저장되므로 설정 탭의 `기관 상태` 행이 여기서 처리된다.\n다만 **삭제(`DELETED`)된 기관은 이 API 로 되살릴 수 없다** —\n`POST /organizations/{organizationId}/restore` 를 쓰세요.\n\n## 오류\n\n| 코드 | 상황 |\n|---|---|\n| 400 | 필수 누락 · `dataRetentionDays` 가 90/180/365 밖 · `organizationStatus` 가 ACTIVE/SUSPENDED 밖 |\n| 404 `ORG_NOT_FOUND` | 없는 기관 |\n| 409 `ORG_ALREADY_DELETED` | 삭제된 기관 |\n| 409 `ORG_POLICY_NOT_FOUND` | 활성 정책이 없음 |\n",
+        "operationId": "updateOrganizationOperationSettings",
+        "parameters": [
+          {
+            "name": "organizationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateOperationSettingRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OperationSettingResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "available"
+      }
+    },
+    "/api/v0/platform/operations/super-admins/invitations": {
+      "post": {
+        "tags": [
+          "Platform Governance"
+        ],
+        "summary": "슈퍼어드민 초대 | ✅ 사용 가능",
+        "description": "SA-03 ② `+ 계정 초대`. 계정 자리를 만들고 초대 메일을 보낸다.\n\n## 요청 (JSON 본문)\n\n| 필드 | 필수 | 타입 | 설명 |\n|---|---|---|---|\n| `email` | **필수** | string | 초대할 이메일. **이 API 의 유일한 입력이다** |\n\n**헤더 (선택)** — `X-Request-Id: {문자열}` 추적용. 생략하면 서버가 만든다.\n\n역할을 고르는 칸이 없다 — 이 화면에서 보내는 초대는 슈퍼어드민 하나뿐이라\n**초대하는 화면이 곧 역할**이다. 기관·기수·반도 없다 — 슈퍼어드민은 어느 기관에도\n속하지 않는다(`app_user.org_id IS NULL`).\n\n**이메일 도메인 제한이 없다.** 플랫폼 도메인을 저장하는 곳이 없고, 오퍼레이터 초대와\n같은 이유(초대 시점에는 그 도메인 메일함을 아직 가질 수 없다)가 적용된다.\n\n## 응답 — `201 Created`\n\n| 필드 | 타입 | 설명 |\n|---|---|---|\n| `memberId` | UUID | 생성된 계정 자리 |\n| `email` | string | 초대 메일 수신 주소 |\n| `status` | enum | 항상 `PENDING`(목업 `초대됨`) |\n| `invitedAt` | datetime | 초대 원장·최초 토큰 생성 시각 |\n| `accounts` | object | **초대 반영 후의 슈퍼어드민 목록 전체** |\n\n`accounts` 는 `GET /super-admins` 와 같은 구조(`content[]` · `activeCount`)다.\n**목록을 따로 재조회할 필요 없이 표를 그대로 다시 그리면 된다.**\n\n## 오류\n\n| 코드 | 상황 |\n|---|---|\n| 400 | 이메일 형식 오류 |\n| 403 | 슈퍼어드민이 아닌 호출자 |\n| 409 `ALREADY_INVITED` | 이미 등록되었거나 초대가 진행 중인 이메일 |\n| 502 `INVITE_MAIL_FAILED` | 메일 발송 실패 |\n\n502 여도 **계정 자리와 초대 기록은 남는다.** 목록에 `PENDING` 으로 계속 보이므로\n같은 주소로 다시 초대하면 그 자리를 되살려 재발송된다.\n\n> 오퍼레이터 초대와 달리 **취소·재발송 전용 API 가 없다.** 목업 SA-03 ② 표에\n> 그 액션이 없기 때문이다. 필요해지면 오퍼레이터 쪽과 같은 방식으로 추가할 수 있다\n> (member 도메인의 재발송 엔진이 이미 슈퍼어드민 목적을 처리한다).\n",
+        "operationId": "inviteSuperAdmin",
+        "parameters": [
+          {
+            "name": "X-Request-Id",
+            "in": "header",
+            "description": "초대 요청 추적용 식별자이며 생략 시 서버가 생성합니다.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "invite-sa-001"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InviteSuperAdminRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "슈퍼어드민 계정 자리 생성 및 초대 발송 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InviteSuperAdminResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "이메일 형식이 올바르지 않음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "VALIDATION_FAILED": {
+                    "summary": "VALIDATION_FAILED",
+                    "value": {
+                      "code": "VALIDATION_FAILED",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  },
+                  "BAD_REQUEST": {
+                    "summary": "BAD_REQUEST",
+                    "value": {
+                      "code": "BAD_REQUEST",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "슈퍼어드민만 슈퍼어드민을 초대할 수 있음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "ACCESS_DENIED": {
+                    "summary": "ACCESS_DENIED",
+                    "value": {
+                      "code": "ACCESS_DENIED",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "ALREADY_INVITED · 이미 등록되었거나 초대된 이메일",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "ALREADY_INVITED": {
+                    "summary": "ALREADY_INVITED",
+                    "value": {
+                      "code": "ALREADY_INVITED",
+                      "message": "이미 등록되었거나 초대된 이메일입니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "INVITE_MAIL_FAILED · 초대 메일 발송 실패",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "INVITE_MAIL_FAILED": {
+                    "summary": "INVITE_MAIL_FAILED",
+                    "value": {
+                      "code": "INVITE_MAIL_FAILED",
+                      "message": "초대 메일을 보내지 못했습니다."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "available"
+      }
+    },
+    "/api/v0/organizations": {
+      "get": {
+        "tags": [
+          "Organization"
+        ],
+        "summary": "기관 목록 조회 | ✅ 사용 가능",
+        "description": "SA-01 기관 목록 표를 채운다. 이름 검색·상태 필터·정렬을 **모두 서버가 처리**하므로\n화면은 파라미터만 넘기면 된다(클라이언트에서 다시 거르지 않는다).\n\n## 요청 (쿼리 파라미터)\n\n| 파라미터 | 필수 | 타입 | 설명 |\n|---|---|---|---|\n| `query` | 선택 | string | 기관명 부분검색. 대소문자 구분 없음. 비우면 전체 |\n| `status` | 선택 | enum | `ACTIVE` · `SUSPENDED` · `DELETION_PENDING` · `DELETED`. **비우면 전체**(화면의 `상태 · 전체`) |\n| `sort` | 선택 | enum | `CREATED_AT_DESC`(기본) · `CREATED_AT_ASC` · `NAME_ASC` · `NAME_DESC` |\n| `page` | 선택 | int | 0부터 시작. 기본 `0` |\n| `size` | 선택 | int | 페이지당 개수. 기본 `20`, 최대 `100` |\n\n⚠️ 기수 수·교육생 수·비용은 **정렬 대상이 아니다.** 별도 배치 집계라 페이지를 자른 뒤에\n채워지므로 전역 정렬이 성립하지 않는다.\n\n## 응답\n\n| 필드 | 타입 | 설명 |\n|---|---|---|\n| `content[]` | array | 기관 목록. 각 항목 구조는 아래 |\n| `page` | int | 현재 페이지(0부터) |\n| `size` | int | 페이지당 개수 |\n| `totalElements` | long | 조건에 맞는 전체 건수 |\n| `totalPages` | int | 전체 페이지 수 |\n\n**content[] 각 항목**\n\n| 필드 | 타입 | 설명 |\n|---|---|---|\n| `organizationId` | UUID | 기관 식별자. 상세 이동에 쓴다 |\n| `name` | string | 기관명 |\n| `slug` | string? | URL용 짧은 식별값. 미지정이면 `null` |\n| `displayCode` | string? | 화면 표시용 코드. 미지정이면 `null` |\n| `emailDomain` | string? | 초대 허용 도메인. `null`이면 제한 없음 |\n| `status` | enum | `ACTIVE` · `SUSPENDED` · `DELETION_PENDING` · `DELETED` |\n| `operatorUnassigned` | boolean | `true`면 `오퍼레이터 미배정` 배지. operators가 비었을 때 |\n| `budgetExceeded` | boolean | `true`면 `예산 초과` 배지. 예산이 0이면 항상 false |\n| `operators[]` | array | `{ memberId, name, email }`. 목록의 `박지현 외 1` 렌더링용 |\n| `cohorts` | object | `{ total, running, closed }` — 목업 `기수 3 (진행 2 · 종료 1)` |\n| `traineeCount` | int | 활성 교육생 수(기수를 나간 인원 제외) |\n| `activeSessionCount` | int | 진행 중 세션 수(`IN_PROGRESS`·`PAUSED`) |\n| `currentMonthAiCost` | decimal | 이번 달(UTC) AI 비용 |\n| `monthlyAiBudget` | decimal | 월 예산. 정책이 없으면 `0` |\n| `budgetUsageRate` | decimal? | 소진율(0~1). 예산이 0이면 `null` |\n| `currencyCode` | string? | 통화. 플랫폼 공통 `USD`. 정책이 없으면 `null` |\n| `dataRetentionDays` | int | 보존기간(일). 정책이 없으면 `0` |\n| `defaultDisclosureScope` | enum? | 기본 공개범위. 정책이 없으면 `null` |\n| `createdAt` | datetime | 생성 시각 (ISO-8601 UTC) |\n| `deletedAt` | datetime? | 삭제 시각. 살아 있으면 `null` |\n",
+        "operationId": "findOrganizations",
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/OrganizationStatus"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/OrganizationSort"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 20,
+              "maximum": 100,
+              "minimum": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationListResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "available"
+      },
+      "post": {
+        "tags": [
+          "Organization"
+        ],
+        "summary": "기관 생성 및 기본 운영 정책 초기화 | ✅ 사용 가능",
+        "description": "SA-01 `기관 생성 (테넌트 프로비저닝)` 모달. 기관과 **최초 운영 정책(버전 1)을 함께** 만든다.\n정책 기본값은 월 예산 0 · 통화 USD · 공개범위 SUMMARY 다.\n\n## 요청 (JSON 본문)\n\n| 필드 | 필수 | 타입 | 설명 |\n|---|---|---|---|\n| `name` | **필수** | string | 기관명. 전체에서 유일해야 한다 |\n| `dataRetentionDays` | **필수** | int | 보존기간. **`90` · `180` · `365` 중 하나만** |\n| `emailDomain` | 선택 | string | 기관 대표 도메인(예: `codebase.ac.kr`). 생략하거나 `null` |\n| `slug` | 선택 | string | URL용 짧은 식별값. 소문자·숫자·하이픈, 64자 이하, 전체 UNIQUE |\n| `displayCode` | 선택 | string | 화면 표시용 코드. 대문자로 시작, 대문자·숫자·밑줄, 32자 이하 |\n\n⚠️ **선택 필드에 빈 문자열(`\"\"`)을 보내면 400 이다.** 안 쓸 거면 필드를 아예 생략하거나\n`null` 로 보내세요.\n\n⚠️ `emailDomain` 은 저장만 되고 **초대를 제한하지 않는다.** 오퍼레이터는 기관의 첫 계정이라\n초대 시점에 그 기관 메일함이 없기 때문이다.\n\n**헤더 (선택)** — `Idempotency-Key: {UUID}`\n같은 키 + 같은 내용으로 재요청하면 최초 생성 결과를 그대로 돌려준다(기관이 두 개 생기지 않는다).\n같은 키로 **다른 내용**을 보내면 409 `ORG_IDEMPOTENCY_CONFLICT`. 생략하면 멱등 처리를 하지 않으므로\n네트워크 재시도 시 기관이 중복 생성될 수 있다.\n\n## 응답 — `201 Created`\n\n목록 조회의 `content[]` 항목과 **같은 구조**다. 주요 필드만 적는다.\n\n| 필드 | 타입 | 설명 |\n|---|---|---|\n| `organizationId` | UUID | **이후 모든 API 호출에 쓰는 식별자** |\n| `status` | enum | 항상 `ACTIVE` |\n| `operatorUnassigned` | boolean | 항상 `true` — 오퍼레이터가 아직 없다 |\n| `dataRetentionDays` | int | 요청값 그대로 |\n| `currencyCode` | string | `USD` |\n| `monthlyAiBudget` | decimal | `0` |\n| 나머지 | | 목록 조회 응답과 동일 |\n\n**생성 직후 화면 처리** — 목록으로 돌아가면 `GET /organizations` 와\n`GET /organizations/summary` 를 **둘 다** 다시 불러야 카드 숫자가 맞는다.\n\n## 오류\n\n| 코드 | 상황 |\n|---|---|\n| 400 | 필수 누락 · 형식 오류 · `dataRetentionDays` 가 90/180/365 밖 |\n| 409 `ORG_NAME_TAKEN` | 이미 사용 중인 기관명(삭제된 기관 이름 포함) |\n| 409 `ORG_IDEMPOTENCY_CONFLICT` | 같은 멱등키로 다른 내용을 보냄 |\n",
+        "operationId": "createOrganization",
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "재시도 안전을 위한 멱등성 키(UUID). 생략 가능.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateOrganizationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "생성 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "ORG_NAME_TAKEN · ORG_IDEMPOTENCY_CONFLICT",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "ORG_NAME_TAKEN": {
+                    "summary": "ORG_NAME_TAKEN",
+                    "value": {
+                      "code": "ORG_NAME_TAKEN",
+                      "message": "이미 있는 기관명입니다."
+                    }
+                  },
+                  "ORG_IDEMPOTENCY_CONFLICT": {
+                    "summary": "ORG_IDEMPOTENCY_CONFLICT",
+                    "value": {
+                      "code": "ORG_IDEMPOTENCY_CONFLICT",
+                      "message": "같은 요청 키로 다른 내용이 이미 처리되었습니다."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "available"
+      }
+    },
+    "/api/v0/organizations/{organizationId}/restore": {
+      "post": {
+        "tags": [
+          "Organization"
+        ],
+        "summary": "기관 복구 | ✅ 사용 가능",
+        "description": "soft-delete 된 기관을 되살린다. 목업 case 7: *\"보존기간이 지난 뒤 파기됩니다.\n**그전까지는 복구할 수 있습니다.**\"*\n\n**삭제 상태를 되돌리는 유일한 방법이다.** 운영 설정으로 `status` 를 `ACTIVE` 로 바꾸는 것은\n막혀 있다 — 삭제 흔적(`deleted_at` 등)이 남은 채 활성이 되면 DB 제약을 위반한다.\n\n## 요청\n\n| 변수 | 필수 | 타입 | 설명 |\n|---|---|---|---|\n| `organizationId` | **필수** | UUID | 삭제된 기관의 식별자 |\n\n본문 없음.\n\n## 응답\n\n복구된 기관 정보. **목록 조회 `content[]` 항목과 같은 구조**다.\n\n`status` 는 **항상 `ACTIVE`** 로 돌아온다. 삭제 전 상태를 보관하는 컬럼이 없고,\n복구의 의도는 \"다시 쓰겠다\" 이기 때문이다. 정지 상태로 두고 싶다면 복구 후\n설정에서 `SUSPENDED` 로 바꾸세요.\n\n함께 정리되는 값 — `deletedAt` · `retentionUntil` · `suspendedAt` 이 비워지고\n파기 예약(`purgeStatus`)도 취소된다.\n\n## 오류\n\n| 코드 | 상황 |\n|---|---|\n| 404 `ORG_NOT_FOUND` | 없는 기관 |\n| 409 `ORG_NOT_DELETED` | 삭제되지 않은 기관 |\n| 409 `ORG_ALREADY_DELETED` | **보존기간이 이미 지나 파기 대상** — 복구 불가 |\n| 409 `ORG_NAME_TAKEN` | 삭제된 사이 같은 이름의 기관이 새로 생김 |\n",
+        "operationId": "restoreOrganization",
+        "parameters": [
+          {
+            "name": "organizationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "복구 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "ORG_NOT_FOUND",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "ORG_NOT_FOUND": {
+                    "summary": "ORG_NOT_FOUND",
+                    "value": {
+                      "code": "ORG_NOT_FOUND",
+                      "message": "기관을 찾을 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "ORG_NOT_DELETED · ORG_ALREADY_DELETED · ORG_NAME_TAKEN",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "ORG_NOT_DELETED": {
+                    "summary": "ORG_NOT_DELETED",
+                    "value": {
+                      "code": "ORG_NOT_DELETED",
+                      "message": "삭제되지 않은 기관입니다."
+                    }
+                  },
+                  "ORG_ALREADY_DELETED": {
+                    "summary": "ORG_ALREADY_DELETED",
+                    "value": {
+                      "code": "ORG_ALREADY_DELETED",
+                      "message": "이미 삭제된 기관입니다."
+                    }
+                  },
+                  "ORG_NAME_TAKEN": {
+                    "summary": "ORG_NAME_TAKEN",
+                    "value": {
+                      "code": "ORG_NAME_TAKEN",
+                      "message": "이미 있는 기관명입니다."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "available"
+      }
+    },
+    "/api/v0/organizations/{organizationId}/purge": {
+      "post": {
+        "tags": [
+          "Organization"
+        ],
+        "summary": "기관 파기 요청 | ⚠️ 사용 불가",
+        "description": "**요청은 접수되지만 데이터가 실제로 지워지지 않는다.** 보존기간 검증과\n`purge_status = IN_PROGRESS` 전이까지만 구현돼 있고, 응답은 항상 `purged=false`다.\n\n`organization(org_id)`를 참조하는 FK가 52개이고 전부 `ON DELETE RESTRICT`라\n52개 테이블을 위상 정렬 역순으로 지워야 하는데, 한 트랜잭션에 담을 수 없어\n별도 배치가 필요하다. 그 배치가 아직 없다.\n\n⚠️ 한 번 호출하면 `purge_status`가 `IN_PROGRESS`로 바뀌고 **복구가 막힌다**\n(`POST /{organizationId}/restore`가 보존기간 경과를 이유로 거절한다).\n되돌리려면 DB를 직접 손봐야 하므로 **버려도 되는 기관에만 호출한다.**\n\n---\n\n보존기간이 지난 기관의 데이터 파기를 요청한다. 목업 case 8 — **화면이 없고**\n운영자가 API 로 직접 호출하는 경로다.\n\n## 요청\n\n| 변수 | 필수 | 타입 | 설명 |\n|---|---|---|---|\n| `organizationId` | **필수** | UUID | soft-delete 된 기관의 식별자 |\n\n본문 없음.\n\n## 응답\n\n| 필드 | 타입 | 설명 |\n|---|---|---|\n| `organizationId` | UUID | 대상 기관 |\n| `deletedAt` | datetime | soft-delete 시각 |\n| `retentionUntil` | datetime | 보존기간 종료 시각 |\n| `requestedAt` | datetime | 파기 요청 접수 시각 |\n| `purged` | boolean | **항상 `false`** — 실제 파기는 아직 수행되지 않는다 |\n| `message` | string | 운영자에게 보여줄 안내 문구 |\n\n⚠️ **화면에서 `purged` 를 반드시 확인하세요.** 200 이 왔다고 \"파기 완료\" 로 그리면 안 된다.\n`false` 이므로 **\"파기 접수됨\"** 으로 표시해야 한다.\n\n## 오류\n\n| 코드 | 상황 |\n|---|---|\n| 404 `ORG_NOT_FOUND` | 없는 기관 |\n| 409 `ORG_NOT_DELETED` | soft-delete 되지 않은 기관. 먼저 `DELETE /{organizationId}` |\n| 409 `RETENTION_NOT_MET` | 보존기간이 남음. 응답 메시지에 파기 가능 시각이 담긴다 |\n\n즉시 물리 삭제 경로는 두지 않는다 — 실수로 지우면 되돌릴 방법이 없다.\n",
+        "operationId": "purgeOrganization",
+        "parameters": [
+          {
+            "name": "organizationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "파기 요청 접수(보존기간 충족)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PurgeOrganizationResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "ORG_NOT_FOUND",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "ORG_NOT_FOUND": {
+                    "summary": "ORG_NOT_FOUND",
+                    "value": {
+                      "code": "ORG_NOT_FOUND",
+                      "message": "기관을 찾을 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "RETENTION_NOT_MET · ORG_NOT_DELETED",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "RETENTION_NOT_MET": {
+                    "summary": "RETENTION_NOT_MET",
+                    "value": {
+                      "code": "RETENTION_NOT_MET",
+                      "message": "보존기간이 남아 파기할 수 없습니다."
+                    }
+                  },
+                  "ORG_NOT_DELETED": {
+                    "summary": "ORG_NOT_DELETED",
+                    "value": {
+                      "code": "ORG_NOT_DELETED",
+                      "message": "삭제되지 않은 기관입니다."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "unavailable"
+      }
+    },
+    "/api/v0/organizations/{organizationId}/operators/invitations": {
+      "post": {
+        "tags": [
+          "Organization"
+        ],
+        "summary": "오퍼레이터 초대 | ⚠️ 사용 보류",
+        "description": "SA-02 ② `오퍼레이터 초대` 모달. 계정 자리를 만들고 초대 메일을 보낸다.\n\n## 요청\n\n**경로 변수** — `organizationId` (**필수**, UUID)\n\n**JSON 본문**\n\n| 필드 | 필수 | 타입 | 설명 |\n|---|---|---|---|\n| `email` | **필수** | string | 초대할 이메일. **이 API 의 유일한 입력이다** |\n\n**헤더 (선택)** — `X-Request-Id: {문자열}` 초대·토큰 발급 추적용. 생략하면 서버가 만든다.\n\n권한·기수를 고르는 칸이 없는 건 의도한 설계다 — 목업: *\"이 화면에서 보내는 초대는\n오퍼레이터 하나뿐이라 초대하는 화면이 곧 역할이다. 기수 배정도 없다 —\n오퍼레이터는 기관 전체를 본다.\"*\n\n**이메일 도메인 제한이 없다.** 기관에 `emailDomain` 이 설정돼 있어도 **아무 주소로나**\n(개인 메일 포함) 초대할 수 있다. 오퍼레이터는 기관의 첫 계정이라 초대받는 시점에\n그 기관 메일함을 가질 수 없기 때문이다.\n\n## 응답 — `201 Created`\n\n| 필드 | 타입 | 설명 |\n|---|---|---|\n| `organizationId` | UUID | 기관 식별자 |\n| `memberId` | UUID | 생성된 계정 자리 |\n| `email` | string | 초대 메일 수신 주소 |\n| `status` | enum | 항상 `PENDING`(목업 `초대됨`) |\n| `invitedAt` | datetime | 초대 원장·최초 토큰 생성 시각 |\n\n받는 사람은 메일 링크로 AU-02 에서 **이름·비밀번호만 정하면** 활성화된다.\n\n**초대 직후 목록을 다시 불러야** 새 행이 표에 나타난다. 응답에 목록이 함께 오지 않는다.\n\n## 오류\n\n| 코드 | 상황 |\n|---|---|\n| 404 | 활성 기관이 아님(삭제·미존재) |\n| 409 `ALREADY_INVITED` | 이미 등록되었거나 초대가 진행 중인 이메일 |\n| 502 `INVITE_MAIL_FAILED` | 메일 발송 실패 — **아래 참고** |\n\n### 502 여도 계정 자리는 남는다\n\n목업 case 4·5 *\"자리는 남기고 링크만 실패\"* 대로 동작한다.\n목록을 다시 부르면 그 계정이 `invitationDeliveryFailed=true` 로 나오므로,\n화면은 **그 행에** `초대 메일이 나가지 않았습니다` 안내와 [재발송] 버튼을 붙이면 된다.\n\n자리를 지우지 않는 이유 — 지우면 같은 주소로 다시 초대했을 때\n**중복 초대인지 재시도인지 구분할 수 없다.**\n",
+        "operationId": "inviteOperator",
+        "parameters": [
+          {
+            "name": "organizationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Request-Id",
+            "in": "header",
+            "description": "초대 요청 추적용 식별자이며 생략 시 서버가 생성합니다.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "invite-op-001"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InviteOperatorRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "오퍼레이터 계정 생성 및 초대 발송 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InviteOperatorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "활성 기관을 찾을 수 없음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "NOT_FOUND": {
+                    "summary": "NOT_FOUND",
+                    "value": {
+                      "code": "NOT_FOUND",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "ALREADY_INVITED · 이미 등록되었거나 초대된 이메일",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "ALREADY_INVITED": {
+                    "summary": "ALREADY_INVITED",
+                    "value": {
+                      "code": "ALREADY_INVITED",
+                      "message": "이미 등록되었거나 초대된 이메일입니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "INVITE_MAIL_FAILED · 초대 메일 발송 실패",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "INVITE_MAIL_FAILED": {
+                    "summary": "INVITE_MAIL_FAILED",
+                    "value": {
+                      "code": "INVITE_MAIL_FAILED",
+                      "message": "초대 메일을 보내지 못했습니다."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "hold"
+      }
+    },
+    "/api/v0/organizations/{organizationId}/operators/invitations/{tokenId}/resend": {
+      "post": {
+        "tags": [
+          "Organization"
+        ],
+        "summary": "오퍼레이터 초대 재발송 | ⚠️ 사용 보류",
+        "description": "SA-02 ② case 4·5 의 [재발송] 액션. 초대 메일을 다시 보낸다.\n\n## 언제 쓰나\n\n| 상황 | 목록에서의 신호 |\n|---|---|\n| 메일이 나가지 않음 | `invitationDeliveryFailed === true` |\n| 링크가 만료됨 | 상태로는 구분되지 않는다. 사용자가 요청하면 호출 |\n\n**만료된 초대도 대상이다** — 만료야말로 재발송이 필요한 주된 상황이다.\n\n## 요청\n\n| 변수 | 필수 | 타입 | 설명 |\n|---|---|---|---|\n| `organizationId` | **필수** | UUID | 기관 식별자 |\n| `tokenId` | **필수** | UUID | 목록 응답의 **`pendingInvitationTokenId`** |\n\n**헤더 (선택)** — `X-Request-Id: {문자열}` 추적용. 생략하면 서버가 만든다.\n\n본문 없음.\n\n## 응답\n\n**재발송 후의 오퍼레이터 목록 전체**(`GET .../operators` 와 같은 구조).\n\n해당 계정은 이렇게 바뀐다.\n\n| 필드 | 재발송 후 |\n|---|---|\n| `invitationDeliveryFailed` | `false` 로 내려감 |\n| `pendingInvitationTokenId` | **새 토큰 값으로 교체** |\n| `status` | `PENDING` 유지 |\n\n## 동작\n\n- **이전 토큰을 무효화하고 새로 발급한다** — 재발송 뒤에도 옛 링크가 살아 있으면\n  유효한 가입 링크가 둘이 된다\n- **초대 원장은 새로 만들지 않는다** — 재발송인지 새 초대인지 구분되고\n  재발송 횟수(`resend_count`)가 정확히 쌓인다\n\n**쿨다운·횟수 제한은 없다.** 필요하면 화면에서 버튼을 잠시 비활성화하세요.\n\n## 취소된 초대에는 쓸 수 없다\n\n취소하면 토큰이 무효화되고 `pendingInvitationTokenId` 가 `null` 이 되어 넘길 값이 없다.\n그 경우는 **재초대**(`POST .../operators/invitations`)를 쓴다.\n\n## 오류\n\n| 코드 | 상황 |\n|---|---|\n| 404 `OPERATOR_INVITATION_NOT_FOUND` | 이미 수락·취소된 초대이거나 다른 기관의 토큰 |\n| 502 `INVITE_MAIL_FAILED` | 재발송도 실패. 자리와 기록은 남으므로 다시 시도할 수 있다 |\n",
+        "operationId": "resendOperatorInvitation",
+        "parameters": [
+          {
+            "name": "organizationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "tokenId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Request-Id",
+            "in": "header",
+            "description": "재발송 요청 추적용 식별자이며 생략 시 서버가 생성합니다.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "resend-op-001"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "재발송 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OperatorListResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "OPERATOR_INVITATION_NOT_FOUND · 이미 수락·취소된 초대",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "OPERATOR_INVITATION_NOT_FOUND": {
+                    "summary": "OPERATOR_INVITATION_NOT_FOUND",
+                    "value": {
+                      "code": "OPERATOR_INVITATION_NOT_FOUND",
+                      "message": "취소할 수 있는 오퍼레이터 초대를 찾을 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "INVITE_MAIL_FAILED · 재발송도 실패(자리와 기록은 남는다)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "INVITE_MAIL_FAILED": {
+                    "summary": "INVITE_MAIL_FAILED",
+                    "value": {
+                      "code": "INVITE_MAIL_FAILED",
+                      "message": "초대 메일을 보내지 못했습니다."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "hold"
+      }
+    },
+    "/api/v0/members/organizations/{organizationId}/manager-invitations": {
+      "post": {
+        "tags": [
+          "Member"
+        ],
+        "summary": "매니저 초대 | ✅ 사용 가능",
+        "description": "오퍼레이터가 자기 기관의 **매니저**를 초대합니다(OP-06). 이 경로가 만드는 계정은 항상 MANAGER이며, 다른 역할은 만들 수 없습니다.\n\n**초대 권한 체계**: 슈퍼어드민 → 오퍼레이터 초대는 `POST /organizations/{organizationId}/operators/invitations`(SA-02 ②)가 전담하고, 오퍼레이터 → 매니저 초대는 이 API가 전담합니다.\n\n**요청**\n- organizationId (경로): 초대 대상 기관. 호출자의 소속 기관과 다르면 403\n- email (필수, 최대 320자): 초대받을 이메일\n- cohortId (필수): 담당할 기수 ID. 그 기관의 기수가 아니면 400\n- X-Request-Id (헤더, 선택): 초대 추적용 식별자. 생략하면 서버가 만든다\n\n**반 배정은 초대 시점에 하지 않습니다** — 요청에 반 필드가 없으며, 담당 반은 가입 이후\n`PATCH /cohorts/{cohortId}/classrooms/{classroomId}/managers`로 따로 정합니다.\n\n**응답 (201)**\n- memberId: 생성된 계정 자리 ID\n- email / role(항상 MANAGER) / status(항상 INVITED) / invitedAt\n\n**메일이 나갔다고 계정이 활성화된 것은 아닙니다.** 초대받은 매니저가\n`POST /auth/manager-signup`에서 이름·비밀번호를 정해야 활성 계정이 됩니다.\n\n⚠️ 메일 발송에 실패하면(502) 계정 자리도 **함께 롤백**되어 아무것도 남지 않습니다.\n",
+        "operationId": "inviteManager",
+        "parameters": [
+          {
+            "name": "organizationId",
+            "in": "path",
+            "description": "초대 대상 기관 ID. 호출자인 오퍼레이터의 소속 기관만 허용됩니다.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          {
+            "name": "X-Request-Id",
+            "in": "header",
+            "description": "초대 생성·토큰 발급 추적용 요청 ID이며 생략 시 서버가 생성합니다.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "invite-request-001"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InviteManagerRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "초대 원장·현재 토큰 생성 및 메일 발송 성공; 계정 활성화 완료를 의미하지 않음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InviteManagerResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "EMAIL_FORMAT_INVALID 이메일 형식 오류 · MANAGER_COHORT_REQUIRED 담당 기수 미지정 · COHORT_NOT_IN_ORGANIZATION 기관에 속하지 않은 기수",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "EMAIL_FORMAT_INVALID": {
+                    "summary": "EMAIL_FORMAT_INVALID",
+                    "value": {
+                      "code": "EMAIL_FORMAT_INVALID",
+                      "message": "이메일 형식이 올바르지 않습니다."
+                    }
+                  },
+                  "MANAGER_COHORT_REQUIRED": {
+                    "summary": "MANAGER_COHORT_REQUIRED",
+                    "value": {
+                      "code": "MANAGER_COHORT_REQUIRED",
+                      "message": "일반 매니저는 하나의 기수를 반드시 지정해야 합니다."
+                    }
+                  },
+                  "COHORT_NOT_IN_ORGANIZATION": {
+                    "summary": "COHORT_NOT_IN_ORGANIZATION",
+                    "value": {
+                      "code": "COHORT_NOT_IN_ORGANIZATION",
+                      "message": "기관에 속하지 않은 기수입니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UNAUTHENTICATED 액세스 토큰 없음 · INVITER_NOT_FOUND 인증 사용자를 찾을 수 없음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "INVITER_NOT_FOUND": {
+                    "summary": "INVITER_NOT_FOUND",
+                    "value": {
+                      "code": "INVITER_NOT_FOUND",
+                      "message": "인증 사용자를 찾을 수 없습니다."
+                    }
+                  },
+                  "UNAUTHENTICATED": {
+                    "summary": "UNAUTHENTICATED",
+                    "value": {
+                      "code": "UNAUTHENTICATED",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "INVITE_ROLE_NOT_ALLOWED 이 역할을 초대할 권한이 없음 · INVITE_CROSS_ORGANIZATION 다른 기관 지정 · INVITER_NOT_ACTIVE 호출자가 활성 계정이 아님",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "INVITE_ROLE_NOT_ALLOWED": {
+                    "summary": "INVITE_ROLE_NOT_ALLOWED",
+                    "value": {
+                      "code": "INVITE_ROLE_NOT_ALLOWED",
+                      "message": "이 역할을 초대할 권한이 없습니다."
+                    }
+                  },
+                  "INVITE_CROSS_ORGANIZATION": {
+                    "summary": "INVITE_CROSS_ORGANIZATION",
+                    "value": {
+                      "code": "INVITE_CROSS_ORGANIZATION",
+                      "message": "다른 기관에는 초대할 수 없습니다."
+                    }
+                  },
+                  "INVITER_NOT_ACTIVE": {
+                    "summary": "INVITER_NOT_ACTIVE",
+                    "value": {
+                      "code": "INVITER_NOT_ACTIVE",
+                      "message": "활성 사용자만 초대할 수 있습니다."
+                    }
+                  },
+                  "ACCESS_DENIED": {
+                    "summary": "ACCESS_DENIED",
+                    "value": {
+                      "code": "ACCESS_DENIED",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "ORGANIZATION_NOT_FOUND 초대 대상 기관을 찾을 수 없음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "ORGANIZATION_NOT_FOUND": {
+                    "summary": "ORGANIZATION_NOT_FOUND",
+                    "value": {
+                      "code": "ORGANIZATION_NOT_FOUND",
+                      "message": "활성 기관을 찾을 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "ALREADY_INVITED 이미 등록된 계정 또는 동일 대상의 미완료 초대가 존재함",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "ALREADY_INVITED": {
+                    "summary": "ALREADY_INVITED",
+                    "value": {
+                      "code": "ALREADY_INVITED",
+                      "message": "이미 등록되었거나 초대된 이메일입니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "INVITATION_SAVE_FAILED 이메일 중복이 아닌 DB 제약 위반 등으로 초대 정보를 저장하지 못함",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "INVITATION_SAVE_FAILED": {
+                    "summary": "INVITATION_SAVE_FAILED",
+                    "value": {
+                      "code": "INVITATION_SAVE_FAILED",
+                      "message": "초대 정보를 저장할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "INVITE_MAIL_FAILED 초대 메일 발송 실패로 초대 트랜잭션을 완료하지 못함. 계정은 만들어지지 않았다",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "INVITE_MAIL_FAILED": {
+                    "summary": "INVITE_MAIL_FAILED",
+                    "value": {
+                      "code": "INVITE_MAIL_FAILED",
+                      "message": "초대 메일을 보내지 못했습니다."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "available"
+      }
+    },
+    "/api/v0/cohorts": {
+      "get": {
+        "tags": [
+          "Academic Operations"
+        ],
+        "summary": "기관 기수 목록 조회 | ✅ 사용 가능",
+        "description": "로그인한 사용자의 소속 기관에 개설된 기수를 상태 필터·이름 검색으로 페이지네이션 조회한다.\n조회 범위인 기관은 요청 파라미터가 아니라 액세스 토큰에서 가져온다 — 다른 기관의 기수는 조회할 수 없다.\n\n**요청**\n- status (쿼리, 선택): 기수 상태 필터. PLANNED/RUNNING/CLOSED. 생략하면 전체\n- query (쿼리, 선택): 기수명 부분검색\n- page (쿼리, 선택, 기본 0): 0부터 시작하는 페이지 번호\n- size (쿼리, 선택, 기본 20, 최대 100): 페이지당 개수\n\n**응답 (200)**\n- content[]: 기수 목록(필드는 아래 \"기수 상세 조회\" 응답과 동일)\n- page / size: 요청한 페이지 정보 그대로\n- totalElements: 조건에 맞는 전체 기수 수\n- totalPages: 전체 페이지 수\n\n**아직 채워지지 않는 값** — content[].traineeCount는 항상 0, content[].managers는 항상 빈 배열이다.\n교육생 수와 담당 매니저는 member·classroom 도메인 조인이 필요해 아직 연결되지 않았다.\n반 목록·담당 매니저가 필요하면 `GET /cohorts/{cohortId}/classrooms`를 함께 호출한다.\n",
+        "operationId": "findCohorts",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "기수 상태 필터. 생략하면 전체",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/CohortStatus"
+            }
+          },
+          {
+            "name": "query",
+            "in": "query",
+            "description": "기수명 부분검색",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "7기"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "0부터 시작하는 페이지 번호",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            },
+            "example": 0
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "페이지당 개수(최대 100)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 20,
+              "maximum": 100,
+              "minimum": 1
+            },
+            "example": 20
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "기수 목록 조회 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CohortListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "VALIDATION_FAILED page·size 범위가 올바르지 않음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "VALIDATION_FAILED": {
+                    "summary": "VALIDATION_FAILED",
+                    "value": {
+                      "code": "VALIDATION_FAILED",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "액세스 토큰이 없거나 유효하지 않음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "UNAUTHENTICATED": {
+                    "summary": "UNAUTHENTICATED",
+                    "value": {
+                      "code": "UNAUTHENTICATED",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "ORGANIZATION_CONTEXT_MISSING 인증 정보에서 organizationId를 확인할 수 없음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "ORGANIZATION_CONTEXT_MISSING": {
+                    "summary": "ORGANIZATION_CONTEXT_MISSING",
+                    "value": {
+                      "code": "ORGANIZATION_CONTEXT_MISSING",
+                      "message": "기관 컨텍스트를 확인할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "available"
+      },
+      "post": {
+        "tags": [
+          "Academic Operations"
+        ],
+        "summary": "기수 생성 | ✅ 사용 가능",
+        "description": "오퍼레이터가 자기 기관에 새 기수를 개설한다. 개설 시 기관의 활성 운영 정책에서\n기본 공개범위(defaultDisclosureScope)를 복사해 기수에 고정한다 — 이후 기관 정책이 바뀌어도\n이미 만들어진 기수의 공개범위는 따라 바뀌지 않는다.\n\n**요청**\n- organizationId (필수): 기수를 개설할 기관 ID. 액세스 토큰의 기관과 다르면 403\n- name (필수): 기수명. 같은 기관 안에서 중복되면 409\n- startDate (필수) / endDate (필수): 기수 기간. endDate가 startDate보다 빠르면 400\n\n**응답 (201)**\n- 생성된 기수 정보(응답 필드는 \"기수 상세 조회\"와 동일). status는 PLANNED로 시작한다\n\n⚠️ `initialTrainees`를 요청에 넣어도 저장되지 않는다. 스키마에는 남아 있지만 서버가 사용하지 않으며,\n교육생 등록은 `POST /cohorts/{cohortId}/trainees`(CSV) 또는 `.../trainees/invitations`(직접 입력)로 한다.\n",
+        "operationId": "createCohort",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateCohortRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "기수 생성 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CohortResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "VALIDATION_FAILED 필수값 누락 · COHORT_PERIOD_INVALID 종료일이 시작일보다 빠름",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "VALIDATION_FAILED": {
+                    "summary": "VALIDATION_FAILED",
+                    "value": {
+                      "code": "VALIDATION_FAILED",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  },
+                  "COHORT_PERIOD_INVALID": {
+                    "summary": "COHORT_PERIOD_INVALID",
+                    "value": {
+                      "code": "COHORT_PERIOD_INVALID",
+                      "message": "시작일은 종료일보다 늦을 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "액세스 토큰이 없거나 유효하지 않음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "UNAUTHENTICATED": {
+                    "summary": "UNAUTHENTICATED",
+                    "value": {
+                      "code": "UNAUTHENTICATED",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "오퍼레이터가 아니거나 다른 기관의 organizationId를 지정함",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "ACCESS_DENIED": {
+                    "summary": "ACCESS_DENIED",
+                    "value": {
+                      "code": "ACCESS_DENIED",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "COHORT_NAME_TAKEN 같은 기관에 이미 존재하는 기수명 · ORG_POLICY_NOT_FOUND 기관에 활성 운영 정책이 없음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "COHORT_NAME_TAKEN": {
+                    "summary": "COHORT_NAME_TAKEN",
+                    "value": {
+                      "code": "COHORT_NAME_TAKEN",
+                      "message": "이미 있는 기수명입니다."
+                    }
+                  },
+                  "ORG_POLICY_NOT_FOUND": {
+                    "summary": "ORG_POLICY_NOT_FOUND",
+                    "value": {
+                      "code": "ORG_POLICY_NOT_FOUND",
+                      "message": "기관에 활성 운영 정책이 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "ORGANIZATION_CONTEXT_MISSING 인증 정보에서 organizationId를 확인할 수 없음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "ORGANIZATION_CONTEXT_MISSING": {
+                    "summary": "ORGANIZATION_CONTEXT_MISSING",
+                    "value": {
+                      "code": "ORGANIZATION_CONTEXT_MISSING",
+                      "message": "기관 컨텍스트를 확인할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "available"
+      }
+    },
+    "/api/v0/cohorts/{cohortId}/trainees": {
+      "post": {
+        "tags": [
+          "Member"
+        ],
+        "summary": "CSV 교육생 명단 등록 및 초대 | ✅ 사용 가능",
+        "description": "오퍼레이터가 CSV 파일을 올려 기수 교육생을 한 번에 등록하고 초대 메일을 보낸다.\n\n**요청** (multipart/form-data)\n- cohortId (경로): 교육생을 등록할 기수 ID\n- file (필수): UTF-8 CSV. **첫 행은 `이름,이메일` 헤더**이며 최대 1MB·1,000행\n- X-Request-Id (헤더, 선택): 일괄 등록 추적용 식별자. 생략하면 서버가 만든다\n\n**응답 (201)**\n- requestedCount: 받은 전체 행 수\n- registeredCount: 계정·명단·초대 원장 생성에 성공한 수\n- invitationSentCount: 초대 메일 발송까지 끝난 수\n- failures[]: 실패한 행만 담긴 목록\n  - row: **헤더를 포함한 실제 CSV 행 번호**(첫 데이터 행이 2)\n  - email: 그 행에 적힌 이메일\n  - status: 1=이메일 형식 오류, 2=요청 안에서 중복, 3=기관에 이미 있는 교육생 이메일\n\n**행별 부분 성공을 허용한다.** 한 행이 실패해도 나머지는 등록되므로, 화면은 201을 성공으로 처리하되\n`failures`가 비어 있는지 반드시 확인해야 한다 — 실패가 있어도 상태코드는 201이다.\n\n**메일이 나갔다고 계정이 활성화된 것은 아니다.** 교육생은 PENDING 상태로 만들어지고,\n본인이 초대 링크에서 `POST /auth/trainee-activation`을 마쳐야 활성 계정이 된다.\n",
+        "operationId": "registerTraineesFromCsv",
+        "parameters": [
+          {
+            "name": "cohortId",
+            "in": "path",
+            "description": "교육생을 등록할 기수 ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          {
+            "name": "X-Request-Id",
+            "in": "header",
+            "description": "일괄 등록 요청 추적용 식별자이며 생략 시 서버가 생성합니다.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "trainee-batch-001"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary",
+                    "description": "첫 행이 '이름,이메일'인 UTF-8 CSV 파일"
+                  }
+                },
+                "required": [
+                  "file"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "CSV 행별 등록·초대 처리 완료; 성공·실패 건수와 실패 행을 응답",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegisterTraineesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "CSV_FORMAT_INVALID CSV 파일·헤더·인코딩·열 구성 오류. 어느 행이 왜 틀렸는지는 message에 있다",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "CSV_FORMAT_INVALID": {
+                    "summary": "CSV_FORMAT_INVALID",
+                    "value": {
+                      "code": "CSV_FORMAT_INVALID",
+                      "message": "CSV 파일을 읽을 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UNAUTHENTICATED 액세스 토큰 없음 · INVITER_NOT_FOUND 인증 사용자를 찾을 수 없음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "INVITER_NOT_FOUND": {
+                    "summary": "INVITER_NOT_FOUND",
+                    "value": {
+                      "code": "INVITER_NOT_FOUND",
+                      "message": "인증 사용자를 찾을 수 없습니다."
+                    }
+                  },
+                  "UNAUTHENTICATED": {
+                    "summary": "UNAUTHENTICATED",
+                    "value": {
+                      "code": "UNAUTHENTICATED",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "INVITE_ROLE_NOT_ALLOWED 오퍼레이터만 교육생을 초대할 수 있음 · INVITER_NOT_ACTIVE 활성 계정이 아님 · INVITE_CROSS_ORGANIZATION 다른 기관의 기수",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "INVITE_ROLE_NOT_ALLOWED": {
+                    "summary": "INVITE_ROLE_NOT_ALLOWED",
+                    "value": {
+                      "code": "INVITE_ROLE_NOT_ALLOWED",
+                      "message": "이 역할을 초대할 권한이 없습니다."
+                    }
+                  },
+                  "INVITER_NOT_ACTIVE": {
+                    "summary": "INVITER_NOT_ACTIVE",
+                    "value": {
+                      "code": "INVITER_NOT_ACTIVE",
+                      "message": "활성 사용자만 초대할 수 있습니다."
+                    }
+                  },
+                  "INVITE_CROSS_ORGANIZATION": {
+                    "summary": "INVITE_CROSS_ORGANIZATION",
+                    "value": {
+                      "code": "INVITE_CROSS_ORGANIZATION",
+                      "message": "다른 기관에는 초대할 수 없습니다."
+                    }
+                  },
+                  "ACCESS_DENIED": {
+                    "summary": "ACCESS_DENIED",
+                    "value": {
+                      "code": "ACCESS_DENIED",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "COHORT_NOT_INVITABLE 등록 가능한 기수를 찾을 수 없음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "COHORT_NOT_INVITABLE": {
+                    "summary": "COHORT_NOT_INVITABLE",
+                    "value": {
+                      "code": "COHORT_NOT_INVITABLE",
+                      "message": "초대 가능한 기수를 찾을 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "available"
+      }
+    },
+    "/api/v0/cohorts/{cohortId}/trainees/invitations": {
+      "post": {
+        "tags": [
+          "Member"
+        ],
+        "summary": "직접 입력 교육생 등록 및 초대 | ✅ 사용 가능",
+        "description": "CSV 업로드 대신 화면에서 이름·이메일을 직접 입력해 교육생을 등록한다.\n처리 규칙과 응답 형식은 CSV 등록(`POST /cohorts/{cohortId}/trainees`)과 완전히 같다.\n\n**요청** (application/json)\n- cohortId (경로): 교육생을 등록할 기수 ID\n- trainees (필수, 1건 이상): 등록할 교육생 목록\n  - name (필수, 최대 200자)\n  - email (필수): 형식·요청 내 중복·기존 계정을 행별로 검증한다\n- X-Request-Id (헤더, 선택): 일괄 등록 추적용 식별자\n\n**응답 (201)**\n- requestedCount / registeredCount / invitationSentCount\n- failures[]: row는 **1부터 시작하는 배열 순번**(CSV와 달리 헤더가 없다),\n  email, status(1=형식 오류, 2=요청 내 중복, 3=기관에 이미 있는 교육생 이메일)\n\n**행별 부분 성공을 허용한다.** 실패가 있어도 상태코드는 201이므로 `failures`를 확인해야 한다.\n\n**이름이 비어 있으면 행 단위 실패가 아니라 요청 전체가 400이다.** 이메일 오류는 failures로\n돌려주지만 이름 누락은 입력 화면에서 먼저 걸러야 할 값으로 보기 때문이다.\n\n등록된 교육생은 PENDING이며 `POST /auth/trainee-activation`을 거쳐야 활성화된다.\n",
+        "operationId": "registerTrainees",
+        "parameters": [
+          {
+            "name": "cohortId",
+            "in": "path",
+            "description": "교육생을 등록할 기수 ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          {
+            "name": "X-Request-Id",
+            "in": "header",
+            "description": "일괄 등록 요청 추적용 식별자이며 생략 시 서버가 생성합니다.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "trainee-direct-001"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegisterTraineesRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "직접 입력 행별 등록·초대 처리 완료; 성공·실패 건수와 실패 행을 응답",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegisterTraineesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "VALIDATION_FAILED 교육생 목록이 비었음 · TRAINEE_NAME_INVALID 이름이 비었거나 200자 초과 · EMAIL_FORMAT_INVALID 이메일 형식 오류",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "VALIDATION_FAILED": {
+                    "summary": "VALIDATION_FAILED",
+                    "value": {
+                      "code": "VALIDATION_FAILED",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  },
+                  "TRAINEE_NAME_INVALID": {
+                    "summary": "TRAINEE_NAME_INVALID",
+                    "value": {
+                      "code": "TRAINEE_NAME_INVALID",
+                      "message": "교육생 이름이 올바르지 않습니다."
+                    }
+                  },
+                  "EMAIL_FORMAT_INVALID": {
+                    "summary": "EMAIL_FORMAT_INVALID",
+                    "value": {
+                      "code": "EMAIL_FORMAT_INVALID",
+                      "message": "이메일 형식이 올바르지 않습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UNAUTHENTICATED 액세스 토큰 없음 · INVITER_NOT_FOUND 인증 사용자를 찾을 수 없음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "INVITER_NOT_FOUND": {
+                    "summary": "INVITER_NOT_FOUND",
+                    "value": {
+                      "code": "INVITER_NOT_FOUND",
+                      "message": "인증 사용자를 찾을 수 없습니다."
+                    }
+                  },
+                  "UNAUTHENTICATED": {
+                    "summary": "UNAUTHENTICATED",
+                    "value": {
+                      "code": "UNAUTHENTICATED",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "INVITE_ROLE_NOT_ALLOWED 오퍼레이터만 교육생을 초대할 수 있음 · INVITER_NOT_ACTIVE 활성 계정이 아님 · INVITE_CROSS_ORGANIZATION 다른 기관의 기수",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "INVITE_ROLE_NOT_ALLOWED": {
+                    "summary": "INVITE_ROLE_NOT_ALLOWED",
+                    "value": {
+                      "code": "INVITE_ROLE_NOT_ALLOWED",
+                      "message": "이 역할을 초대할 권한이 없습니다."
+                    }
+                  },
+                  "INVITER_NOT_ACTIVE": {
+                    "summary": "INVITER_NOT_ACTIVE",
+                    "value": {
+                      "code": "INVITER_NOT_ACTIVE",
+                      "message": "활성 사용자만 초대할 수 있습니다."
+                    }
+                  },
+                  "INVITE_CROSS_ORGANIZATION": {
+                    "summary": "INVITE_CROSS_ORGANIZATION",
+                    "value": {
+                      "code": "INVITE_CROSS_ORGANIZATION",
+                      "message": "다른 기관에는 초대할 수 없습니다."
+                    }
+                  },
+                  "ACCESS_DENIED": {
+                    "summary": "ACCESS_DENIED",
+                    "value": {
+                      "code": "ACCESS_DENIED",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "COHORT_NOT_INVITABLE 등록 가능한 기수를 찾을 수 없음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "COHORT_NOT_INVITABLE": {
+                    "summary": "COHORT_NOT_INVITABLE",
+                    "value": {
+                      "code": "COHORT_NOT_INVITABLE",
+                      "message": "초대 가능한 기수를 찾을 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "available"
+      }
+    },
+    "/api/v0/cohorts/{cohortId}/classrooms": {
+      "get": {
+        "tags": [
+          "Academic Operations"
+        ],
+        "summary": "기수 반 목록 조회 | ✅ 사용 가능",
+        "description": "기수에 편성된 반 전체를 조회한다. 조회 범위인 기관은 액세스 토큰에서 가져온다.\n\n**요청**\n- cohortId (경로): 반을 조회할 기수 ID\n\n**응답 (200)**\n- classrooms[].classroomId: 반 ID\n- classrooms[].cohortId: 소속 기수 ID\n- classrooms[].name: 반 이름\n- classrooms[].managers[]: 담당 매니저 목록(memberId, name)\n- classrooms[].traineeCount: 현재 그 반에 소속된 교육생 수\n- classrooms[].managerAssignmentRequired: 담당 매니저가 없으면 true — 화면의 `매니저 미배정` 표시 근거\n\n**아직 채워지지 않는 값** — managers[].name은 항상 빈 문자열이다.\n매니저 이름은 app_user 조인이 필요해 member 도메인 의존이 생기므로 memberId만 내려준다.\n",
+        "operationId": "findClassrooms",
+        "parameters": [
+          {
+            "name": "cohortId",
+            "in": "path",
+            "description": "반을 조회할 기수 ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "반 목록 조회 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClassroomListResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "액세스 토큰이 없거나 유효하지 않음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "UNAUTHENTICATED": {
+                    "summary": "UNAUTHENTICATED",
+                    "value": {
+                      "code": "UNAUTHENTICATED",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "COHORT_NOT_FOUND 기수를 찾을 수 없음(다른 기관의 기수 포함)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "COHORT_NOT_FOUND": {
+                    "summary": "COHORT_NOT_FOUND",
+                    "value": {
+                      "code": "COHORT_NOT_FOUND",
+                      "message": "기수를 찾을 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "ORGANIZATION_CONTEXT_MISSING 인증 정보에서 organizationId를 확인할 수 없음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "ORGANIZATION_CONTEXT_MISSING": {
+                    "summary": "ORGANIZATION_CONTEXT_MISSING",
+                    "value": {
+                      "code": "ORGANIZATION_CONTEXT_MISSING",
+                      "message": "기관 컨텍스트를 확인할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "available"
+      },
+      "post": {
+        "tags": [
+          "Academic Operations"
+        ],
+        "summary": "반 생성 | ✅ 사용 가능",
+        "description": "오퍼레이터가 기수 안에 반을 만든다.\n\n**요청**\n- cohortId (경로): 반을 만들 기수 ID\n- name (필수): 반 이름. 같은 기수 안에서 중복되면 409\n- capacity (필수, 1 이상): 정원\n- managerIds (선택): ⚠ 요청에 넣어도 적용되지 않는다(아래 참고)\n\n**응답 (201)**\n- 생성된 반 정보(응답 필드는 \"기수 반 목록 조회\"의 classrooms[] 항목과 동일).\n  갓 만든 반이므로 traineeCount=0, managers=[], managerAssignmentRequired=true로 내려온다\n\n⚠️ `managerIds`를 요청에 넣어도 적용되지 않는다. 스키마에는 남아 있지만 서버가 사용하지 않으며,\n담당 매니저 지정은 `PATCH /cohorts/{cohortId}/classrooms/{classroomId}/managers`로 따로 호출해야 한다.\n",
+        "operationId": "createClassroom",
+        "parameters": [
+          {
+            "name": "cohortId",
+            "in": "path",
+            "description": "반을 만들 기수 ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateClassroomRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "반 생성 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClassroomResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "VALIDATION_FAILED 반 이름이 비었거나 정원이 1 미만임",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "VALIDATION_FAILED": {
+                    "summary": "VALIDATION_FAILED",
+                    "value": {
+                      "code": "VALIDATION_FAILED",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "액세스 토큰이 없거나 유효하지 않음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "UNAUTHENTICATED": {
+                    "summary": "UNAUTHENTICATED",
+                    "value": {
+                      "code": "UNAUTHENTICATED",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "오퍼레이터 권한이 없음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "ACCESS_DENIED": {
+                    "summary": "ACCESS_DENIED",
+                    "value": {
+                      "code": "ACCESS_DENIED",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "COHORT_NOT_FOUND 기수를 찾을 수 없음(다른 기관의 기수 포함)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "COHORT_NOT_FOUND": {
+                    "summary": "COHORT_NOT_FOUND",
+                    "value": {
+                      "code": "COHORT_NOT_FOUND",
+                      "message": "기수를 찾을 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "available"
+      }
+    },
+    "/api/v0/auth/trainee-activation": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "초대받은 교육생 계정 활성화 | ✅ 사용 가능",
+        "description": "초대받은 교육생이 비밀번호를 정해 계정을 활성화한다. 인증 없이 호출하며,\n신원은 초대 토큰이 증명한다.\n\n**요청**\n- user_id (필수): 초대 토큰 해석 응답의 사용자 ID\n- invitationToken (필수, 최대 512자): 초대 링크의 원문 토큰\n- password (필수, 8~64자): 영문·숫자·특수문자를 각각 하나 이상 포함해야 한다\n- passwordConfirmation (필수): password와 같아야 한다\n- serviceTermsAgreed (필수, true): 서비스 이용약관\n- privacyCollectionAgreed (필수, true): 개인정보 수집\n- aiAnalysisAgreed (필수, true): AI 분석\n- organizationSharingAgreed (필수, true): 기관 공유\n- anonymousImprovementAgreed (선택): 익명 데이터 서비스 개선. **유일하게 false를 허용**한다\n\n**이름을 받지 않는다.** 교육생 이름은 오퍼레이터가 명단(CSV·직접 입력)으로 등록할 때 이미 정해져 있다.\n매니저 가입(`/auth/manager-signup`)과 다른 점이니 화면에 이름 입력칸을 두지 않는다.\n\n필수 동의 4개는 false로 보내면 400이다. AI 분석·기관 공유가 필수인 것은 서비스가 그 데이터를\n전제로 동작하기 때문이고, 익명 개선 동의만 거부해도 서비스를 쓸 수 있다.\n\n**응답**\n- user_id / email / name / role (TRAINEE) / activated\n\n계정 활성화와 **기수 소속(cohort_member) 활성화**가 함께 확정된다 — 초대 상태로 남아 있던\n명단 항목이 이 시점에 실제 수강생이 된다. 409는 동시 제출로 상태가 먼저 바뀐 경우다.\n",
+        "operationId": "activateTrainee",
+        "parameters": [
+          {
+            "name": "X-Request-Id",
+            "in": "header",
+            "description": "활성화 요청 추적용 식별자이며 생략 시 서버가 생성합니다.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "activation-request-001"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TraineeActivationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "TRAINEE 계정·기수 소속 활성화와 초대 ACCEPTED 전환 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivateAccountResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "INVITATION_INVALID 교육생 초대 토큰·명단 범위가 유효하지 않음 · PASSWORD_CONFIRMATION_MISMATCH 비밀번호 확인 불일치 · REQUIRED_CONSENT_MISSING 필수 동의 누락",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "INVITATION_INVALID": {
+                    "summary": "INVITATION_INVALID",
+                    "value": {
+                      "code": "INVITATION_INVALID",
+                      "message": "유효하지 않은 초대 링크입니다."
+                    }
+                  },
+                  "PASSWORD_CONFIRMATION_MISMATCH": {
+                    "summary": "PASSWORD_CONFIRMATION_MISMATCH",
+                    "value": {
+                      "code": "PASSWORD_CONFIRMATION_MISMATCH",
+                      "message": "비밀번호 확인이 일치하지 않습니다."
+                    }
+                  },
+                  "REQUIRED_CONSENT_MISSING": {
+                    "summary": "REQUIRED_CONSENT_MISSING",
+                    "value": {
+                      "code": "REQUIRED_CONSENT_MISSING",
+                      "message": "필수 동의 항목에 모두 동의해야 합니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "ACTIVATION_STATE_CHANGED 동시 요청으로 계정·기수 소속·초대·토큰 상태가 먼저 변경됨",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "ACTIVATION_STATE_CHANGED": {
+                    "summary": "ACTIVATION_STATE_CHANGED",
+                    "value": {
+                      "code": "ACTIVATION_STATE_CHANGED",
+                      "message": "계정 활성화 상태가 변경되었습니다. 다시 시도해 주세요."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "WEAK_PASSWORD 비밀번호 정책 미충족",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "WEAK_PASSWORD": {
+                    "summary": "WEAK_PASSWORD",
+                    "value": {
+                      "code": "WEAK_PASSWORD",
+                      "message": "비밀번호는 8~64자이며 영문, 숫자, 특수문자를 포함해야 합니다."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [],
+        "x-readiness": "available"
+      }
+    },
+    "/api/v0/auth/refresh": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "액세스 토큰 재발급 | ✅ 사용 가능",
+        "description": "액세스 토큰이 만료됐을 때 새로 발급받는다. 만료된 액세스 토큰을 보낼 필요는 없다 —\n인증은 **리프레시 토큰 쿠키로만** 한다.\n\n**요청**\n- refresh_token (쿠키, 필수): 로그인 시 발급된 HttpOnly 쿠키. 브라우저가 자동으로 실어 보내므로\n  클라이언트가 직접 다룰 필요가 없다(`credentials: 'include'`만 켜면 된다).\n  쿠키는 `SameSite=None; Secure`이므로 프론트가 백엔드와 다른 사이트여도 실린다\n- X-Swagger-Client-Origin (헤더, 선택): Swagger UI 테스트 전용\n\n**응답**\n- accessToken\n- accessTokenExpiresIn: 만료까지 남은 시간 — **단위는 밀리초다**(1시간이면 `3600000`)\n\n**역할·이름은 주지 않는다.** 새로고침 후 세션을 복원할 때는 이 호출 뒤에\n`GET /members/me`를 부른다 — 역할을 브라우저 저장소에 남기지 않아도 되고,\n정지·역할 변경이 즉시 반영된다.\n\n**401을 받으면 재시도하지 말고 로그인 화면으로 보내야 한다.** 쿠키가 없거나 만료·위조됐거나,\n비밀번호 변경 등으로 세션이 폐기된 상태이므로 다시 호출해도 결과가 같다.\n",
+        "operationId": "refresh",
+        "parameters": [
+          {
+            "name": "refresh_token",
+            "in": "cookie",
+            "description": "로그인 시 발급된 HttpOnly 리프레시 토큰 쿠키",
+            "required": true
+          },
+          {
+            "name": "X-Swagger-Client-Origin",
+            "in": "header",
+            "description": "Swagger UI 테스트 시 실제 프론트엔드 Origin. 일반 프론트 요청에서는 생략합니다.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "http://localhost:5173"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "액세스 토큰 재발급 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RefreshTokenResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "REFRESH_TOKEN_INVALID 토큰 누락·만료·위조 · REFRESH_IDENTITY_CHANGED 역할·기관이 바뀌어 재로그인 필요",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "REFRESH_TOKEN_INVALID": {
+                    "summary": "REFRESH_TOKEN_INVALID",
+                    "value": {
+                      "code": "REFRESH_TOKEN_INVALID",
+                      "message": "유효한 리프레시 토큰이 필요합니다."
+                    }
+                  },
+                  "REFRESH_IDENTITY_CHANGED": {
+                    "summary": "REFRESH_IDENTITY_CHANGED",
+                    "value": {
+                      "code": "REFRESH_IDENTITY_CHANGED",
+                      "message": "인증 정보가 변경되어 다시 로그인해야 합니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "LOGIN_ACCOUNT_INACTIVE 정지 계정 · LOGIN_ORG_SUSPENDED 기관 정지 · LOGIN_ORIGIN_NOT_ALLOWED 허용되지 않은 출처",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "LOGIN_ACCOUNT_INACTIVE": {
+                    "summary": "LOGIN_ACCOUNT_INACTIVE",
+                    "value": {
+                      "code": "LOGIN_ACCOUNT_INACTIVE",
+                      "message": "정지된 계정입니다. 관리자에게 문의해 주세요."
+                    }
+                  },
+                  "LOGIN_ORG_SUSPENDED": {
+                    "summary": "LOGIN_ORG_SUSPENDED",
+                    "value": {
+                      "code": "LOGIN_ORG_SUSPENDED",
+                      "message": "소속 기관이 정지되어 로그인할 수 없습니다."
+                    }
+                  },
+                  "LOGIN_ORIGIN_NOT_ALLOWED": {
+                    "summary": "LOGIN_ORIGIN_NOT_ALLOWED",
+                    "value": {
+                      "code": "LOGIN_ORIGIN_NOT_ALLOWED",
+                      "message": "허용되지 않은 요청 출처입니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "LOGIN_TEMPORARILY_BLOCKED 일시 차단. retryAfter(초) 동봉",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "LOGIN_TEMPORARILY_BLOCKED": {
+                    "summary": "LOGIN_TEMPORARILY_BLOCKED",
+                    "value": {
+                      "code": "LOGIN_TEMPORARILY_BLOCKED",
+                      "message": "로그인 시도가 많아 잠시 차단되었습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "LOGIN_NO_ORG_CONTEXT 기관 소속이 없는 계정",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "LOGIN_NO_ORG_CONTEXT": {
+                    "summary": "LOGIN_NO_ORG_CONTEXT",
+                    "value": {
+                      "code": "LOGIN_NO_ORG_CONTEXT",
+                      "message": "기관 인증 컨텍스트를 발급할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [],
+        "x-readiness": "available"
+      }
+    },
+    "/api/v0/auth/password-reset/validations": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "재설정 토큰 사전 검증 | ✅ 사용 가능",
+        "description": "비밀번호 재설정 메일 링크로 들어온 화면이 **입력폼을 그리기 전에** 호출한다. 인증 없이 호출한다.\n\n**요청**\n- token (필수, 최대 512자): 메일 링크에 담긴 원문 토큰. 서버에는 해시만 저장된다\n\n**응답**\n- email: 재설정 대상 이메일. 읽기 전용으로 표시한다\n- expiresAt: 이 토큰이 만료되는 시각\n\n**토큰을 소비하지 않는다.** 확인만 하므로 이 호출 뒤에도 같은 토큰으로\n`POST /auth/password-reset/confirmations`를 그대로 진행할 수 있고, 화면을 새로고침해도 된다.\n\n조회성 동작이지만 **토큰을 경로가 아니라 본문으로 받는다.** 30분간 비밀번호를 바꿀 수 있는\n자격증명이 URL에 실리면 접근 로그·프록시 로그·APM 트레이스에 평문으로 남기 때문이다.\n초대 링크를 확인하는 `POST /auth/invitations/resolve`와 같은 이유·같은 모양이다.\n\n**오류 구분은 확정 API와 같다.** 죽은 링크에 비밀번호 입력폼을 그려놓고 제출 시점에야\n실패를 알리지 않기 위한 API이므로, 아래 상태를 받으면 폼 대신 안내 화면을 띄운다.\n- 400: 토큰이 없거나 위변조됨, 계정이 활성 상태가 아님\n- 409: 이미 사용된 토큰\n- 410: 만료된 토큰 → 화면은 재발송 안내를 띄운다\n",
+        "operationId": "validatePasswordResetToken",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PasswordResetValidationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "아직 사용할 수 있는 토큰",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PasswordResetValidationResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "RESET_TOKEN_INVALID 유효하지 않은 토큰 또는 활성 상태가 아닌 계정",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "RESET_TOKEN_INVALID": {
+                    "summary": "RESET_TOKEN_INVALID",
+                    "value": {
+                      "code": "RESET_TOKEN_INVALID",
+                      "message": "유효하지 않은 비밀번호 재설정 링크입니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "RESET_TOKEN_USED 이미 사용된 토큰",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "RESET_TOKEN_USED": {
+                    "summary": "RESET_TOKEN_USED",
+                    "value": {
+                      "code": "RESET_TOKEN_USED",
+                      "message": "이미 사용된 비밀번호 재설정 링크입니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "RESET_TOKEN_EXPIRED 만료된 토큰",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "RESET_TOKEN_EXPIRED": {
+                    "summary": "RESET_TOKEN_EXPIRED",
+                    "value": {
+                      "code": "RESET_TOKEN_EXPIRED",
+                      "message": "비밀번호 재설정 링크가 만료되었습니다."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [],
+        "x-readiness": "available"
+      }
+    },
+    "/api/v0/auth/password-reset/requests": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "비밀번호 재설정 안내 요청 | ✅ 사용 가능",
+        "description": "비밀번호 재설정 안내 메일 발송을 요청한다. 인증 없이 호출한다.\n\n**요청**\n- email (필수, 최대 320자): 안내를 받을 이메일\n\n**응답 (202)**\n- message: 계정 존재 여부와 무관하게 **항상 같은 문구**를 반환한다\n\n**계정 유무를 알려주지 않는 것이 이 API의 핵심이다.** 등록되지 않은 주소든, 정지된 계정이든,\n아직 활성화되지 않은 계정이든 응답이 동일하다 — 응답이 갈리면 그 자체가 계정 존재 여부를\n확인하는 수단이 된다. 그래서 화면도 \"메일이 도착하지 않았다\"를 오류로 처리하면 안 된다.\n\n아직 활성화되지 않은 초대 계정이 요청하면 재설정이 아니라 **계정 활성화 안내**가 발송된다.\n",
+        "operationId": "requestPasswordReset",
+        "parameters": [
+          {
+            "name": "X-Request-Id",
+            "in": "header",
+            "description": "요청 추적용 식별자이며 생략 시 서버가 생성합니다.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PasswordResetRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "계정 상태와 무관한 동일 안내 응답",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PasswordResetRequestResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "VALIDATION_FAILED 이메일 형식 오류",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "VALIDATION_FAILED": {
+                    "summary": "VALIDATION_FAILED",
+                    "value": {
+                      "code": "VALIDATION_FAILED",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [],
+        "x-readiness": "available"
+      }
+    },
+    "/api/v0/auth/password-reset/confirmations": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "비밀번호 재설정 확정 | ✅ 사용 가능",
+        "description": "메일 링크의 1회용 토큰으로 비밀번호를 실제로 바꾼다. 인증 없이 호출한다.\n\n**요청**\n- token (필수, 최대 512자): 메일 링크에 담긴 원문 토큰. 서버에는 해시만 저장된다\n- newPassword (필수, 8~64자): 영문·숫자·특수문자를 포함해야 한다\n- newPasswordConfirmation (필수): newPassword와 같아야 한다. 다르면 400\n\n**응답**\n- status: `COMPLETED`\n- message: 재로그인을 안내하는 문구\n\n**성공하면 그 계정의 모든 리프레시 토큰이 폐기된다.** 비밀번호를 바꾸는 상황은 대개\n탈취를 의심하는 상황이라, 다른 기기에 남아 있던 세션도 함께 끊는다 — 사용자는 모든 기기에서\n다시 로그인해야 한다.\n\n**오류 구분**\n- 400: 토큰이 없거나 위변조됨, 요청 형식 오류\n- 409: 이미 사용된 토큰(같은 링크를 두 번 눌렀을 때)\n- 410: 만료된 토큰 → 화면은 재발송 안내를 띄운다\n- 422: 비밀번호 정책 미충족 또는 현재 비밀번호와 동일\n",
+        "operationId": "confirmPasswordReset",
+        "parameters": [
+          {
+            "name": "X-Request-Id",
+            "in": "header",
+            "description": "요청 추적용 식별자이며 생략 시 서버가 생성합니다.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PasswordResetConfirmationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "비밀번호 변경 완료",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PasswordResetConfirmationResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "RESET_TOKEN_INVALID 유효하지 않은 토큰 · VALIDATION_FAILED 요청 형식 오류",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "RESET_TOKEN_INVALID": {
+                    "summary": "RESET_TOKEN_INVALID",
+                    "value": {
+                      "code": "RESET_TOKEN_INVALID",
+                      "message": "유효하지 않은 비밀번호 재설정 링크입니다."
+                    }
+                  },
+                  "VALIDATION_FAILED": {
+                    "summary": "VALIDATION_FAILED",
+                    "value": {
+                      "code": "VALIDATION_FAILED",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "RESET_TOKEN_USED 이미 사용된 토큰",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "RESET_TOKEN_USED": {
+                    "summary": "RESET_TOKEN_USED",
+                    "value": {
+                      "code": "RESET_TOKEN_USED",
+                      "message": "이미 사용된 비밀번호 재설정 링크입니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "RESET_TOKEN_EXPIRED 만료된 토큰",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "RESET_TOKEN_EXPIRED": {
+                    "summary": "RESET_TOKEN_EXPIRED",
+                    "value": {
+                      "code": "RESET_TOKEN_EXPIRED",
+                      "message": "비밀번호 재설정 링크가 만료되었습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "WEAK_PASSWORD 비밀번호 정책 미충족 · SAME_AS_CURRENT 현재 비밀번호와 동일",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "WEAK_PASSWORD": {
+                    "summary": "WEAK_PASSWORD",
+                    "value": {
+                      "code": "WEAK_PASSWORD",
+                      "message": "비밀번호는 8~64자이며 영문, 숫자, 특수문자를 포함해야 합니다."
+                    }
+                  },
+                  "SAME_AS_CURRENT": {
+                    "summary": "SAME_AS_CURRENT",
+                    "value": {
+                      "code": "SAME_AS_CURRENT",
+                      "message": "지금 쓰는 비밀번호와 달라야 합니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "RESET_FAILED 변경 저장 실패. 비밀번호는 바뀌지 않았다",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "RESET_FAILED": {
+                    "summary": "RESET_FAILED",
+                    "value": {
+                      "code": "RESET_FAILED",
+                      "message": "비밀번호는 아직 바뀌지 않았습니다. 잠시 후 다시 시도해 주세요."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [],
+        "x-readiness": "available"
+      }
+    },
+    "/api/v0/auth/manager-signup": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "초대받은 오퍼레이터·매니저 가입 | ✅ 사용 가능",
+        "description": "초대받은 오퍼레이터 또는 매니저가 이름·비밀번호를 정해 계정을 활성화한다(AU-02).\n인증 없이 호출하며, 신원은 초대 토큰이 증명한다. 앞서 `/auth/invitations/resolve`로 받은\nuser_id를 그대로 넘긴다.\n\n**요청**\n- user_id (필수): 초대 토큰 해석 응답의 사용자 ID\n- invitationToken (필수, 최대 512자): 초대 링크의 원문 토큰\n- name (필수, 최대 200자): 표시 이름\n- password (필수, 8~64자): 영문·숫자·특수문자를 각각 하나 이상 포함해야 한다\n- passwordConfirmation (필수): password와 같아야 한다\n- serviceTermsAgreed (필수, true): 서비스 이용약관 동의\n- privacyCollectionAgreed (필수, true): 개인정보 수집 동의\n\n필수 동의 2개는 **false로 보내면 400**이다. 화면에서 체크하지 않으면 제출 버튼을 막아야 한다.\n\n**응답**\n- user_id / email / name / role (OPERATOR 또는 MANAGER) / activated\n\n**이메일은 요청에 없다.** 초대 원장의 주소를 그대로 쓰며, 링크를 여는 것으로 소유가 확인된 것으로\n본다 — 그래서 가입 직후 별도 이메일 인증 단계가 없다.\n\n계정 활성화·이메일 검증·동의 기록·초대 수락·토큰 사용 처리가 **한 트랜잭션**으로 함께 확정된다.\n409는 같은 링크로 동시에 두 번 제출한 경우이며, 화면은 로그인 화면으로 보내면 된다.\n",
+        "operationId": "signupManager",
+        "parameters": [
+          {
+            "name": "X-Request-Id",
+            "in": "header",
+            "description": "활성화 요청 추적용 식별자이며 생략 시 서버가 생성합니다.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "signup-request-001"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ManagerSignupRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OPERATOR 또는 MANAGER 계정 활성화와 초대 ACCEPTED 전환 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivateAccountResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "INVITATION_INVALID 초대 토큰·대상 역할이 유효하지 않음 · PASSWORD_CONFIRMATION_MISMATCH 비밀번호 확인 불일치 · REQUIRED_CONSENT_MISSING 필수 동의 누락",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "INVITATION_INVALID": {
+                    "summary": "INVITATION_INVALID",
+                    "value": {
+                      "code": "INVITATION_INVALID",
+                      "message": "유효하지 않은 초대 링크입니다."
+                    }
+                  },
+                  "PASSWORD_CONFIRMATION_MISMATCH": {
+                    "summary": "PASSWORD_CONFIRMATION_MISMATCH",
+                    "value": {
+                      "code": "PASSWORD_CONFIRMATION_MISMATCH",
+                      "message": "비밀번호 확인이 일치하지 않습니다."
+                    }
+                  },
+                  "REQUIRED_CONSENT_MISSING": {
+                    "summary": "REQUIRED_CONSENT_MISSING",
+                    "value": {
+                      "code": "REQUIRED_CONSENT_MISSING",
+                      "message": "필수 동의 항목에 모두 동의해야 합니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "ACTIVATION_STATE_CHANGED 동시 요청으로 계정·초대·토큰 상태가 먼저 변경됨",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "ACTIVATION_STATE_CHANGED": {
+                    "summary": "ACTIVATION_STATE_CHANGED",
+                    "value": {
+                      "code": "ACTIVATION_STATE_CHANGED",
+                      "message": "계정 활성화 상태가 변경되었습니다. 다시 시도해 주세요."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "WEAK_PASSWORD 비밀번호 정책 미충족",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "WEAK_PASSWORD": {
+                    "summary": "WEAK_PASSWORD",
+                    "value": {
+                      "code": "WEAK_PASSWORD",
+                      "message": "비밀번호는 8~64자이며 영문, 숫자, 특수문자를 포함해야 합니다."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [],
+        "x-readiness": "available"
+      }
+    },
+    "/api/v0/auth/logout": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "로그아웃 | ✅ 사용 가능",
+        "description": "서버에서 리프레시 토큰을 폐기하고 인증 쿠키를 만료시킨다.\n\n**요청**\n- refresh_token (쿠키, 선택): 없어도 204로 응답한다\n- X-Swagger-Client-Origin (헤더, 선택): Swagger UI 테스트 전용\n\n**응답 (204)**\n- 본문 없음. 쿠키를 지우는 `Set-Cookie`가 함께 나간다\n\n**쿠키가 없어도 실패하지 않는다.** 이미 로그아웃된 상태에서 다시 눌러도 화면이 오류를 띄우면\n안 되기 때문이다. 다만 이미 발급된 **액세스 토큰은 만료 시각까지 유효하다** —\n서버가 액세스 토큰을 따로 무효화하지 않으므로 클라이언트가 메모리에서 지워야 한다.\n",
+        "operationId": "logout",
+        "parameters": [
+          {
+            "name": "refresh_token",
+            "in": "cookie",
+            "description": "폐기할 HttpOnly 리프레시 토큰 쿠키"
+          },
+          {
+            "name": "X-Swagger-Client-Origin",
+            "in": "header",
+            "description": "Swagger UI 테스트 시 실제 프론트엔드 Origin. 일반 프론트 요청에서는 생략합니다.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "http://localhost:5173"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "로그아웃 처리 및 인증 쿠키 삭제"
+          },
+          "403": {
+            "description": "LOGIN_ORIGIN_NOT_ALLOWED 허용되지 않은 요청 출처",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "LOGIN_ORIGIN_NOT_ALLOWED": {
+                    "summary": "LOGIN_ORIGIN_NOT_ALLOWED",
+                    "value": {
+                      "code": "LOGIN_ORIGIN_NOT_ALLOWED",
+                      "message": "허용되지 않은 요청 출처입니다."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [],
+        "x-readiness": "available"
+      }
+    },
+    "/api/v0/auth/login": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "통합 로그인 | ✅ 사용 가능",
+        "description": "슈퍼어드민·오퍼레이터·매니저·교육생이 **같은 화면에서** 로그인한다. 역할별 로그인 URL이 따로 없다.\n\n**요청**\n- email (필수) / password (필수)\n- X-Swagger-Client-Origin (헤더, 선택): Swagger UI에서 테스트할 때만 실제 프론트엔드 Origin을\n  넣는다. 일반 프론트 요청에서는 생략한다(브라우저가 보내는 Origin 헤더를 그대로 쓴다)\n\n**응답**\n- memberId / email / name / role / organizationId (슈퍼어드민은 organizationId가 null)\n- redirectPath: 로그인 후 이동할 경로 제안. 낼 수 있는 값은 넷뿐이다.\n  | role | 값 |\n  |---|---|\n  | SUPER_ADMIN | `/admin/orgs` |\n  | OPERATOR | 기관의 최신 기수가 있으면 `/cohorts/{기수명 URL 인코딩}`, 없으면 `/cohorts` |\n  | MANAGER | 담당 최신 기수가 있으면 `/cohorts/{기수명 URL 인코딩}`, 없으면 `/cohorts` |\n  | TRAINEE | `/home` |\n\n  즉 `role` 외에 담기는 정보는 **최신 기수의 이름 하나**이며, 그것도 ID가 아니라 표시명이다.\n  라우트 구조는 프론트 지식이므로 **이 값을 따르지 않고 `role`로 라우팅해도 된다** —\n  기수명이 필요하면 기수 목록 API에서 ID와 함께 받는 편이 낫다.\n- accessToken: 액세스 토큰(Authorization: Bearer)\n- accessTokenExpiresIn: 만료까지 남은 시간 — **단위는 밀리초다**(1시간이면 `3600000`).\n  `Date.now() + accessTokenExpiresIn`이 만료 시각이며, 만료 전 미리 재발급할 때 이 값을 쓴다\n\n**리프레시 토큰은 응답 본문에 없다.** `Set-Cookie`로 HttpOnly 쿠키에 담겨 나가므로\n자바스크립트가 읽을 수 없고, 재발급은 `POST /auth/refresh`가 쿠키를 자동으로 실어 보내 처리한다.\n쿠키는 `SameSite=None; Secure`라 다른 사이트인 프론트에서 보내는 fetch에도 실린다 —\n`credentials: 'include'`만 켜면 된다.\n\n**연속 실패는 잠시 지연된다.** 같은 **이메일+IP**로 5회 연속 실패하면 60초,\n이후 실패마다 2배로 늘어 최대 15분까지 `429 LOGIN_TEMPORARILY_BLOCKED`가 나간다.\n한 번 성공하면 카운터는 0으로 돌아간다. 계정을 잠그는 것이 아니므로 해제 절차는 없고,\n다른 자리(다른 IP)에서의 로그인은 영향받지 않는다.\n\n**오류 구분** — `code`로 분기한다. `message`는 사람이 읽는 문구라 바뀔 수 있다.\n\n| code | 뜻 | 화면이 할 일 |\n|---|---|---|\n| `LOGIN_INVALID` | 이메일이 없거나 비밀번호가 틀림 | 문구만. **둘을 구분해 주지 않는다** — 구분하면 어떤 이메일이 가입돼 있는지 외부에서 확인할 수 있다 |\n| `LOGIN_TEMPORARILY_BLOCKED` | 이메일+IP 5회 연속 실패 | 응답의 `retryAfter`(**초**)와 `Retry-After` 헤더만큼 버튼을 잠근다 |\n| `LOGIN_ACCOUNT_INACTIVE` | 정지·퇴사 계정 | 문의 안내. 재시도해도 같다 |\n| `LOGIN_ORG_SUSPENDED` | 계정은 정상이나 소속 기관이 정지 | 기관 문의 안내 |\n| `LOGIN_ORIGIN_NOT_ALLOWED` | 허용되지 않은 Origin | 계정 문제가 아니다 |\n| `LOGIN_NO_ORG_CONTEXT` | 기관 소속이 없는 비-슈퍼어드민 계정 | **계정 데이터 결함**이라 5xx다. 관리자 문의 |\n\n**아직 활성화하지 않은 계정은 `LOGIN_INVALID`로 온다.** 그 계정은 비밀번호가 아예 없어\n상태 검사에 도달하지 못한다. 구분해 주려면 비밀번호 검사 앞에서 상태를 봐야 하는데\n그러면 계정 열거가 가능해지므로 <b>의도적으로 합쳤다.</b>\n",
+        "operationId": "login",
+        "parameters": [
+          {
+            "name": "X-Swagger-Client-Origin",
+            "in": "header",
+            "description": "Swagger UI 테스트 시 실제 프론트엔드 Origin. 일반 프론트 요청에서는 생략합니다.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "http://localhost:5173"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LoginRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "로그인 성공 및 토큰 발급",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LoginResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "VALIDATION_FAILED 요청 형식 오류 · LOGIN_INVALID 로그인 정보 불일치",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "VALIDATION_FAILED": {
+                    "summary": "VALIDATION_FAILED",
+                    "value": {
+                      "code": "VALIDATION_FAILED",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  },
+                  "LOGIN_INVALID": {
+                    "summary": "LOGIN_INVALID",
+                    "value": {
+                      "code": "LOGIN_INVALID",
+                      "message": "이메일 또는 비밀번호가 올바르지 않습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "LOGIN_ACCOUNT_INACTIVE 정지 계정 · LOGIN_ORG_SUSPENDED 기관 정지 · LOGIN_ORIGIN_NOT_ALLOWED 허용되지 않은 출처",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "LOGIN_ACCOUNT_INACTIVE": {
+                    "summary": "LOGIN_ACCOUNT_INACTIVE",
+                    "value": {
+                      "code": "LOGIN_ACCOUNT_INACTIVE",
+                      "message": "정지된 계정입니다. 관리자에게 문의해 주세요."
+                    }
+                  },
+                  "LOGIN_ORG_SUSPENDED": {
+                    "summary": "LOGIN_ORG_SUSPENDED",
+                    "value": {
+                      "code": "LOGIN_ORG_SUSPENDED",
+                      "message": "소속 기관이 정지되어 로그인할 수 없습니다."
+                    }
+                  },
+                  "LOGIN_ORIGIN_NOT_ALLOWED": {
+                    "summary": "LOGIN_ORIGIN_NOT_ALLOWED",
+                    "value": {
+                      "code": "LOGIN_ORIGIN_NOT_ALLOWED",
+                      "message": "허용되지 않은 요청 출처입니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "LOGIN_TEMPORARILY_BLOCKED 연속 실패로 일시 차단. retryAfter(초) 동봉",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "LOGIN_TEMPORARILY_BLOCKED": {
+                    "summary": "LOGIN_TEMPORARILY_BLOCKED",
+                    "value": {
+                      "code": "LOGIN_TEMPORARILY_BLOCKED",
+                      "message": "로그인 시도가 많아 잠시 차단되었습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "LOGIN_NO_ORG_CONTEXT 기관 소속이 없는 계정",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "LOGIN_NO_ORG_CONTEXT": {
+                    "summary": "LOGIN_NO_ORG_CONTEXT",
+                    "value": {
+                      "code": "LOGIN_NO_ORG_CONTEXT",
+                      "message": "기관 인증 컨텍스트를 발급할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [],
+        "x-readiness": "available"
+      }
+    },
+    "/api/v0/auth/invitations/resolve": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "초대 토큰 해석 | ✅ 사용 가능",
+        "description": "초대 메일 링크를 열었을 때 **가장 먼저** 호출한다. 토큰이 아직 쓸 수 있는지 확인하고,\n가입 화면에 뿌릴 대상 사용자 ID와 이메일을 받아온다. 인증 없이 호출한다.\n\n**요청**\n- invitationToken (필수): 초대 링크에 담긴 원문 토큰. 서버에는 해시만 저장된다\n\n**응답**\n- user_id: 후속 가입·활성화 요청(`/auth/manager-signup`, `/auth/trainee-activation`)에 그대로 넘긴다\n- email: 초대 원장에서 확인한 이메일. **읽기 전용으로 표시하고 수정 입력을 열지 않는다** —\n  초대받은 주소가 아닌 곳으로 계정이 만들어지면 안 되기 때문이다\n- role: **초대 대상자**의 역할(`SUPER_ADMIN` · `OPERATOR` · `MANAGER` · `TRAINEE`)\n\n슈퍼어드민·오퍼레이터·매니저·교육생 초대를 **모두 이 한 API로** 해석한다.\nrole 을 링크나 화면에서 추측하지 말고 이 응답을 따라간다 — 활성화 단계에서 필수 동의를\n강제하는 값과 같은 값이라, 화면이 보여준 동의 항목과 서버가 검증하는 항목이 어긋나지 않는다.\n\n**후속 흐름**\n1. `GET /consents?role={role}` 로 표시할 동의 항목을 받는다\n2. TRAINEE 면 `POST /auth/trainee-activation`, 그 외에는 `POST /auth/manager-signup`\n\n**400이면 링크가 죽은 것이다** — 만료, 이미 사용됨, 재발송으로 교체됨, 초대가 취소됨 중 하나다.\n모두 400 하나로 합쳐 응답하므로 화면은 \"링크가 유효하지 않습니다 · 재발송을 요청하세요\"로 안내한다.\n",
+        "operationId": "resolveInvitation",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InvitationResolveRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "현재 유효한 SUPER_ADMIN·OPERATOR·MANAGER·TRAINEE 초대 대상 해석 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvitationResolveResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "INVITATION_INVALID 토큰 누락·위변조·사용 완료·교체 또는 초대 상태가 SENT가 아님",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "INVITATION_INVALID": {
+                    "summary": "INVITATION_INVALID",
+                    "value": {
+                      "code": "INVITATION_INVALID",
+                      "message": "유효하지 않은 초대 링크입니다."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [],
+        "x-readiness": "available"
+      }
+    },
+    "/api/v0/auth/invitations/resend": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "초대 메일 재발송 | ✅ 사용 가능",
+        "description": "초대 링크가 만료됐거나 아직 활성화하지 않은 계정이 초대 메일을 다시 받는다. 인증 없이 호출한다.\n\n**요청**\n- email (필수, 최대 320자): 초대받았던 이메일\n\n**응답 (202)**\n- message: 계정 존재 여부와 무관하게 **항상 같은 문구**를 반환한다\n\n`POST /auth/password-reset/requests`와 같은 이유로 응답을 하나로 합친다 — 응답이 갈리면\n그 자체가 계정 존재 여부를 확인하는 수단이 된다. 화면도 \"메일이 도착하지 않았다\"를\n오류로 처리하면 안 된다.\n\n**재발송하면 이전 링크는 즉시 죽는다.** 새 토큰이 발급되고 기존 토큰은 교체 처리되므로,\n사용자가 예전 메일의 링크를 누르면 400이 난다. 화면 안내에 \"가장 최근 메일을 사용하세요\"를 포함한다.\n\n**이미 활성화된 계정에는 아무것도 보내지 않는다**(응답은 동일하다). 비밀번호를 잊은 경우이므로\n`POST /auth/password-reset/requests`로 안내한다.\n\n재설정 안내 요청과 **같은 쿨다운 창을 공유한다.** 짧은 간격으로 다시 호출하면 응답은 202지만\n메일은 나가지 않는다.\n",
+        "operationId": "resendAccountInvitation",
+        "parameters": [
+          {
+            "name": "X-Request-Id",
+            "in": "header",
+            "description": "요청 추적용 식별자이며 생략 시 서버가 생성합니다.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InvitationResendRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "계정 상태와 무관한 동일 안내 응답",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvitationResendResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "VALIDATION_FAILED 이메일 형식 오류",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "VALIDATION_FAILED": {
+                    "summary": "VALIDATION_FAILED",
+                    "value": {
+                      "code": "VALIDATION_FAILED",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [],
+        "x-readiness": "available"
+      }
+    },
+    "/api/v0/platform/operations/super-admins/{memberId}/status": {
+      "patch": {
+        "tags": [
+          "Platform Governance"
+        ],
+        "summary": "슈퍼어드민 정지 · 재활성 | ✅ 사용 가능",
+        "description": "SA-03 ② 표의 행별 액션 `정지` / `재활성`.\n\n## 요청\n\n**경로 변수**\n\n| 변수 | 필수 | 타입 | 설명 |\n|---|---|---|---|\n| `memberId` | **필수** | UUID | 목록 응답의 `memberId` |\n\n**JSON 본문**\n\n| 필드 | 필수 | 타입 | 설명 |\n|---|---|---|---|\n| `status` | **필수** | enum | `ACTIVE`(재활성) 또는 `INACTIVE`(정지)만. 그 외는 400 |\n| `reason` | 선택 | string | 변경 사유(예: `휴직 처리`). 감사 이력에 남는다 |\n\n`PENDING` 은 지정할 수 없다 — 초대 흐름이 설정하는 값이다.\n\n## 응답\n\n**변경 후의 슈퍼어드민 목록 전체**(`GET /super-admins` 와 같은 구조).\n`deactivatable` 이 함께 갱신되므로 **표를 그대로 다시 그리면 된다.**\n\n## 마지막 활성 슈퍼어드민은 정지할 수 없다\n\n409 `LAST_SUPER_ADMIN`. 정지하면 플랫폼에 들어갈 사람이 아무도 없어지고,\n오퍼레이터와 달리 **풀어 줄 상위 권한이 아예 없어 복구가 불가능하다.**\n\n화면은 `deactivatable=false` 인 행의 정지 버튼을 **미리 잠가** 이 오류를 만나지 않게 한다.\n\n⚠️ **`PENDING` 계정은 활성 수에 포함되지 않는다.** 목록에 2명이 보여도 하나가 `PENDING`\n이면 `activeCount=1` 이라 정지가 차단된다 — 초대장만으로는 플랫폼에 들어올 수 없기 때문이다.\n\n## ⚠️ 자기 자신도 정지된다 (알려진 이슈)\n\n**서버는 호출자와 대상이 같은지 확인하지 않는다.** 활성 슈퍼어드민이 2명 이상이면\n`LAST_SUPER_ADMIN` 방어에 걸리지 않으므로, 자기 `memberId` 를 넣으면 **본인 계정이\n정지되고 즉시 로그인 불가 상태가 된다.** 응답은 200 이고 경고도 없다.\n\n정지된 계정은 스스로 풀 수 없고 슈퍼어드민 위에 상위 권한이 없으므로, **다른 활성\n슈퍼어드민이 재활성해 주어야만 복구된다.** 활성 2명 중 서로를 정지시키면 둘 다 잠긴다.\n\n목록 응답의 `deactivatable` 은 이 경우를 **걸러 주지 않는다** — 마지막 1명 여부만 본다.\n따라서 화면이 방어해야 한다. 로그인한 사용자의 `memberId` 와 같은 행은 정지 버튼을\n잠그거나, 최소한 되돌릴 수 없다는 확인 절차를 두는 것을 권한다.\n\n> 서버에서 막지 않는 이유는 의도가 아니라 **누락**이다. 자기 정지를 금지할지, 확인 절차를\n> 거쳐 허용할지 정책이 정해지면 서버 쪽 검증을 추가한다.\n\n## 오류\n\n| 코드 | 상황 |\n|---|---|\n| 400 | `status` 누락, 또는 `ACTIVE`·`INACTIVE` 외의 값 |\n| 404 `SUPER_ADMIN_NOT_FOUND` | 없는 계정이거나 슈퍼어드민이 아님 |\n| 409 `LAST_SUPER_ADMIN` | 마지막 활성 슈퍼어드민 정지 시도 |\n",
+        "operationId": "updateSuperAdminStatus",
+        "parameters": [
+          {
+            "name": "memberId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateOperatorStatusForPlatformRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "변경 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuperAdminListResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "SUPER_ADMIN_NOT_FOUND",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "SUPER_ADMIN_NOT_FOUND": {
+                    "summary": "SUPER_ADMIN_NOT_FOUND",
+                    "value": {
+                      "code": "SUPER_ADMIN_NOT_FOUND",
+                      "message": "슈퍼어드민 계정을 찾을 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "LAST_SUPER_ADMIN · 마지막 슈퍼어드민은 정지 불가",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "LAST_SUPER_ADMIN": {
+                    "summary": "LAST_SUPER_ADMIN",
+                    "value": {
+                      "code": "LAST_SUPER_ADMIN",
+                      "message": "이 플랫폼의 마지막 슈퍼어드민입니다."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "available"
+      }
+    },
+    "/api/v0/organizations/{organizationId}": {
+      "get": {
+        "tags": [
+          "Organization"
+        ],
+        "summary": "기관 상세 조회 | ✅ 사용 가능",
+        "description": "SA-02 ① 개요 탭의 지표 카드와 정보 행을 채운다.\n\n## 요청 (경로 변수)\n\n| 변수 | 필수 | 타입 | 설명 |\n|---|---|---|---|\n| `organizationId` | **필수** | UUID | 목록 응답의 `organizationId` |\n\n본문·쿼리 파라미터는 없다.\n\n## 응답\n\n**목록 조회 `content[]` 항목과 완전히 같은 구조다.** 필드 설명은\n`GET /organizations` 문서를 참고하세요.\n\n## 화면을 채우려면 이것만으로 부족하다\n\n개요 탭에 필요한 값이 여러 API 에 흩어져 있다.\n\n| 화면 요소 | 어디서 |\n|---|---|\n| 기관명·상태·오퍼레이터·기수 수·교육생 수·AI 비용 | **이 API** |\n| 저장량 (`9.4 GB · 전월 대비 +8%`) | `GET .../operations/usage` 의 `storage` |\n| 기수 목록 표 | `GET .../cohorts` |\n\n## 오류\n\n| 코드 | 상황 |\n|---|---|\n| 404 `ORG_NOT_FOUND` | 없는 기관 |\n\n**삭제된 기관도 조회된다**(`status=DELETED`, `deletedAt` 채워짐). 복구 화면에서 쓰기 위함이다.\n",
+        "operationId": "findOrganization",
+        "parameters": [
+          {
+            "name": "organizationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "available"
+      },
+      "delete": {
+        "tags": [
+          "Organization"
+        ],
+        "summary": "기관 soft-delete | ✅ 사용 가능",
+        "description": "SA-02 ④ 설정 탭의 `기관 삭제` + 확인 모달(case 7).\n**즉시 파기가 아니라 보존기간을 두는 soft-delete 다.**\n\n## 요청\n\n**경로 변수**\n\n| 변수 | 필수 | 타입 | 설명 |\n|---|---|---|---|\n| `organizationId` | **필수** | UUID | 기관 식별자 |\n\n**JSON 본문**\n\n| 필드 | 필수 | 타입 | 설명 |\n|---|---|---|---|\n| `confirmName` | **필수** | string | **삭제할 기관의 정확한 이름.** 저장된 이름과 다르면 400 |\n\n기관명 입력을 요구하는 이유 — 소속 오퍼레이터·매니저·교육생 **전원이 못 들어오게 되는**\n액션이라 버튼 한 번으로 끝나면 안 된다. 화면 모달에서 사용자가 직접 타이핑하게 하세요.\n\n**헤더 (선택)** — `Idempotency-Key: {UUID}` (생성 API 와 동일한 규칙)\n\n## 응답\n\n| 필드 | 타입 | 설명 |\n|---|---|---|\n| `organizationId` | UUID | 삭제된 기관 |\n| `deletedAt` | datetime | 삭제 처리 시각 |\n| `purgeAvailableAt` | datetime | **실제 파기 가능 시각.** 활성 정책의 보존기간(90/180/365일)만큼 뒤 |\n\n화면에는 *\"보존기간(N일)이 지난 뒤 파기됩니다. 그전까지는 복구할 수 있습니다\"* 로 안내한다.\n\n## 삭제 후\n\n- 목록·상세에서 `status=DELETED`, `deletedAt` 이 채워진 상태로 **계속 조회된다**\n- **운영 설정 변경이 막힌다** — 상태를 되돌리려면 설정 API 가 아니라 복구 API 를 쓴다\n- 기관명은 **파기 전까지 선점 상태**라 같은 이름으로 새 기관을 만들 수 없다\n- 복구: `POST /organizations/{organizationId}/restore`\n\n**계약만 끝난 경우라면 삭제하지 마세요.** 설정에서 상태를 `SUSPENDED` 로 두면\n로그인만 막히고 데이터는 그대로 남습니다.\n\n## 오류\n\n| 코드 | 상황 |\n|---|---|\n| 400 `ORG_DELETE_CONFIRM_MISMATCH` | `confirmName` 이 기관명과 다름 |\n| 404 `ORG_NOT_FOUND` | 없는 기관 |\n| 409 `ORG_ALREADY_DELETED` | 이미 삭제됨 |\n| 409 `ORG_POLICY_NOT_FOUND` | 활성 정책이 없어 보존기간을 계산할 수 없음 |\n| 409 `ORG_IDEMPOTENCY_CONFLICT` | 같은 멱등키로 다른 내용을 보냄 |\n",
+        "operationId": "deleteOrganization",
+        "parameters": [
+          {
+            "name": "organizationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "재시도 안전을 위한 멱등성 키(UUID). 생략 가능.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeleteOrganizationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "soft-delete 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteOrganizationResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "ORG_DELETE_CONFIRM_MISMATCH · 기관명이 일치하지 않음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "ORG_DELETE_CONFIRM_MISMATCH": {
+                    "summary": "ORG_DELETE_CONFIRM_MISMATCH",
+                    "value": {
+                      "code": "ORG_DELETE_CONFIRM_MISMATCH",
+                      "message": "기관명이 일치하지 않습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "ORG_NOT_FOUND",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "ORG_NOT_FOUND": {
+                    "summary": "ORG_NOT_FOUND",
+                    "value": {
+                      "code": "ORG_NOT_FOUND",
+                      "message": "기관을 찾을 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "ORG_ALREADY_DELETED · ORG_POLICY_NOT_FOUND · ORG_IDEMPOTENCY_CONFLICT",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "ORG_ALREADY_DELETED": {
+                    "summary": "ORG_ALREADY_DELETED",
+                    "value": {
+                      "code": "ORG_ALREADY_DELETED",
+                      "message": "이미 삭제된 기관입니다."
+                    }
+                  },
+                  "ORG_POLICY_NOT_FOUND": {
+                    "summary": "ORG_POLICY_NOT_FOUND",
+                    "value": {
+                      "code": "ORG_POLICY_NOT_FOUND",
+                      "message": "기관에 활성 운영 정책이 없습니다."
+                    }
+                  },
+                  "ORG_IDEMPOTENCY_CONFLICT": {
+                    "summary": "ORG_IDEMPOTENCY_CONFLICT",
+                    "value": {
+                      "code": "ORG_IDEMPOTENCY_CONFLICT",
+                      "message": "같은 요청 키로 다른 내용이 이미 처리되었습니다."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "available"
+      },
+      "patch": {
+        "tags": [
+          "Organization"
+        ],
+        "summary": "기관 이름 또는 운영 상태 변경 | ✅ 사용 가능",
+        "description": "**기관명을 바꿀 수 있는 유일한 API 다.** 운영 설정(`PUT .../operations/settings`)에는\n이름 필드가 없다.\n\n상태(`status`) 변경은 설정 탭 API 와 기능이 겹친다. 화면 진입점이 설정 탭 한 곳이므로\n**상태만 바꿀 때는 그쪽을 쓰고, 이 API 는 이름 변경 용도로** 사용하세요.\n\n## 요청\n\n**경로 변수**\n\n| 변수 | 필수 | 타입 | 설명 |\n|---|---|---|---|\n| `organizationId` | **필수** | UUID | 기관 식별자 |\n\n**JSON 본문**\n\n| 필드 | 필수 | 타입 | 설명 |\n|---|---|---|---|\n| `status` | **필수** | enum | `ACTIVE`(활성) 또는 `SUSPENDED`(정지)만 지정 가능 |\n| `name` | 선택 | string | 새 기관명. `null`·빈 값이면 **이름을 바꾸지 않는다** |\n\n⚠️ **`status` 는 이름만 바꿀 때도 필수다.** 현재 상태를 그대로 실어 보내세요.\n빠뜨리면 400 이다.\n\n⚠️ Swagger UI 의 `name` 예시값 `\"string\"` 을 지우지 않고 실행하면 **기관명이 실제로\n`string` 으로 바뀐다.** 이름을 안 바꿀 거면 필드를 비우세요.\n\n## 응답\n\n변경된 기관 정보. **목록 조회 `content[]` 항목과 같은 구조**다.\n\n## 오류\n\n| 코드 | 상황 |\n|---|---|\n| 400 | `status` 누락, 또는 `ACTIVE`·`SUSPENDED` 외의 값 |\n| 404 `ORG_NOT_FOUND` | 없는 기관 |\n| 409 `ORG_ALREADY_DELETED` | 삭제된 기관. 되살리려면 `POST /{organizationId}/restore` |\n",
+        "operationId": "updateOrganization",
+        "parameters": [
+          {
+            "name": "organizationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateOrganizationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "available"
+      }
+    },
+    "/api/v0/organizations/{organizationId}/operators/{memberId}/status": {
+      "patch": {
+        "tags": [
+          "Organization"
+        ],
+        "summary": "오퍼레이터 계정 정지 / 재활성 | ✅ 사용 가능",
+        "description": "SA-02 ② 표의 행별 액션 `정지` / `재활성`.\n\n## 요청\n\n**경로 변수**\n\n| 변수 | 필수 | 타입 | 설명 |\n|---|---|---|---|\n| `organizationId` | **필수** | UUID | 기관 식별자 |\n| `memberId` | **필수** | UUID | 목록 응답의 `memberId` |\n\n**JSON 본문**\n\n| 필드 | 필수 | 타입 | 설명 |\n|---|---|---|---|\n| `status` | **필수** | enum | `ACTIVE`(재활성) 또는 `INACTIVE`(정지)만. 그 외는 400 |\n| `reason` | 선택 | string | 변경 사유(예: `퇴사 처리`). 감사 이력에 남는다 |\n\n`PENDING` 은 지정할 수 없다 — 초대 흐름이 설정하는 값이다.\n\n## 응답\n\n**변경 후의 오퍼레이터 목록 전체**를 돌려준다(`GET .../operators` 와 같은 구조).\n`suspendable` 플래그가 함께 갱신되므로 **표를 그대로 다시 그리면 된다** —\n목록을 따로 재조회할 필요가 없다.\n\n## 마지막 활성 오퍼레이터는 정지할 수 없다\n\n409 `LAST_OPERATOR`. 목업: *\"정지하면 기관에 들어갈 수 있는 사람이 아무도 없어지고,\n기수·명단·매니저를 손댈 방법이 사라진다.\"*\n\n화면은 `suspendable=false` 인 행의 정지 버튼을 **미리 잠가** 이 오류를 만나지 않게 한다.\n\n**기관 자체를 멈추려면** 계정이 아니라 `PUT .../operations/settings` 로 기관 상태를\n`SUSPENDED` 로 바꾼다 — 계정은 남고 로그인만 막힌다.\n\n## 오류\n\n| 코드 | 상황 |\n|---|---|\n| 400 | `status` 누락, 또는 `ACTIVE`·`INACTIVE` 외의 값 |\n| 404 `OPERATOR_NOT_FOUND` | 이 기관의 오퍼레이터가 아님 |\n| 409 `LAST_OPERATOR` | 마지막 활성 오퍼레이터 정지 시도 |\n",
+        "operationId": "updateOperatorStatus",
+        "parameters": [
+          {
+            "name": "organizationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "memberId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateOperatorStatusRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "상태 변경 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OperatorListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "ACTIVE/INACTIVE 외의 상태를 지정함",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "VALIDATION_FAILED": {
+                    "summary": "VALIDATION_FAILED",
+                    "value": {
+                      "code": "VALIDATION_FAILED",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  },
+                  "BAD_REQUEST": {
+                    "summary": "BAD_REQUEST",
+                    "value": {
+                      "code": "BAD_REQUEST",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "OPERATOR_NOT_FOUND",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "OPERATOR_NOT_FOUND": {
+                    "summary": "OPERATOR_NOT_FOUND",
+                    "value": {
+                      "code": "OPERATOR_NOT_FOUND",
+                      "message": "이 기관의 오퍼레이터 계정을 찾을 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "LAST_OPERATOR · 마지막 활성 오퍼레이터는 정지할 수 없음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "LAST_OPERATOR": {
+                    "summary": "LAST_OPERATOR",
+                    "value": {
+                      "code": "LAST_OPERATOR",
+                      "message": "이 기관의 마지막 오퍼레이터입니다."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "available"
+      }
+    },
+    "/api/v0/cohorts/{cohortId}/end": {
+      "patch": {
+        "tags": [
+          "Academic Operations"
+        ],
+        "summary": "기수 종료 | ✅ 사용 가능",
+        "description": "진행 중인 기수를 CLOSED로 전환한다. 종료 대상 기관은 액세스 토큰에서 가져오므로\n다른 기관의 기수를 종료할 수 없다(404).\n\n**요청**\n- cohortId (경로): 종료할 기수 ID\n- reason (필수): 종료 사유. 빈 문자열이면 400\n\n**응답 (200)**\n- 종료 처리된 기수 정보(응답 필드는 \"기수 상세 조회\"와 동일). status가 CLOSED로 바뀐다\n\n종료는 삭제가 아니다. 명단·과거 이력은 그대로 남고 새 활동만 막힌다. 이미 종료된 기수를\n다시 종료하면 아무 변화 없이 그대로 성공 응답한다(멱등).\n",
+        "operationId": "endCohort",
+        "parameters": [
+          {
+            "name": "cohortId",
+            "in": "path",
+            "description": "종료할 기수 ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EndCohortRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "기수 종료 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CohortResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "VALIDATION_FAILED 종료 사유가 비어 있음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "VALIDATION_FAILED": {
+                    "summary": "VALIDATION_FAILED",
+                    "value": {
+                      "code": "VALIDATION_FAILED",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "액세스 토큰이 없거나 유효하지 않음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "UNAUTHENTICATED": {
+                    "summary": "UNAUTHENTICATED",
+                    "value": {
+                      "code": "UNAUTHENTICATED",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "오퍼레이터 권한이 없음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "ACCESS_DENIED": {
+                    "summary": "ACCESS_DENIED",
+                    "value": {
+                      "code": "ACCESS_DENIED",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "COHORT_NOT_FOUND 기수를 찾을 수 없음(다른 기관의 기수 포함)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "COHORT_NOT_FOUND": {
+                    "summary": "COHORT_NOT_FOUND",
+                    "value": {
+                      "code": "COHORT_NOT_FOUND",
+                      "message": "기수를 찾을 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "available"
+      }
+    },
+    "/api/v0/cohorts/{cohortId}/classrooms/{classroomId}/managers": {
+      "patch": {
+        "tags": [
+          "Academic Operations"
+        ],
+        "summary": "반 담당 매니저 변경 | ✅ 사용 가능",
+        "description": "반의 담당 매니저를 **전체 교체**한다. 부분 추가·삭제가 아니라 보낸 목록이 그대로 최종 상태가 된다 —\n기존 활성 배정을 모두 해제(사유 `REASSIGNED`)한 뒤 요청받은 매니저로 새 배정을 만든다.\n빈 배열을 보내면 전체 해제가 되어 담당자가 없는 반이 된다.\n\n**요청**\n- cohortId / classroomId (경로): 대상 반. classroomId가 그 기수 소속이 아니면 404\n- managerIds (필수): 최종 담당 매니저 ID 목록. 중복은 서버가 제거한다. 빈 배열 허용(전체 해제)\n\n**응답 (200)**\n- 변경 후의 반 정보(응답 필드는 \"기수 반 목록 조회\"의 classrooms[] 항목과 동일,\n  managers·managerAssignmentRequired가 갱신되어 표를 그대로 다시 그릴 수 있다)\n\n해제된 배정은 지워지지 않고 이력으로 남는다 — 과거 기수의 담당자를 추적할 수 있어야 하기 때문이다.\n\n⚠️ managerIds에 담긴 UUID가 실제 매니저인지 검증하지 않는다. 존재하지 않거나 다른 역할인 사용자\nID를 보내도 배정 행이 만들어진다. 화면은 매니저 목록에서 고른 값만 보내야 한다.\n",
+        "operationId": "updateManagers",
+        "parameters": [
+          {
+            "name": "cohortId",
+            "in": "path",
+            "description": "대상 반이 속한 기수 ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          {
+            "name": "classroomId",
+            "in": "path",
+            "description": "담당 매니저를 바꿀 반 ID. cohortId 소속이 아니면 404",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateClassroomManagersRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "담당 매니저 변경 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClassroomResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "VALIDATION_FAILED managerIds가 누락됨",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "VALIDATION_FAILED": {
+                    "summary": "VALIDATION_FAILED",
+                    "value": {
+                      "code": "VALIDATION_FAILED",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "액세스 토큰이 없거나 유효하지 않음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "UNAUTHENTICATED": {
+                    "summary": "UNAUTHENTICATED",
+                    "value": {
+                      "code": "UNAUTHENTICATED",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "오퍼레이터 권한이 없음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "ACCESS_DENIED": {
+                    "summary": "ACCESS_DENIED",
+                    "value": {
+                      "code": "ACCESS_DENIED",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "CLASSROOM_NOT_FOUND 반을 찾을 수 없거나 지정한 기수에 속하지 않음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "CLASSROOM_NOT_FOUND": {
+                    "summary": "CLASSROOM_NOT_FOUND",
+                    "value": {
+                      "code": "CLASSROOM_NOT_FOUND",
+                      "message": "반을 찾을 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "available"
+      }
+    },
+    "/api/v0/cohorts/{cohortId}/classrooms/trainee-assignments": {
+      "patch": {
+        "tags": [
+          "Academic Operations"
+        ],
+        "summary": "교육생 일괄 반 배정 | ✅ 사용 가능",
+        "description": "교육생 여러 명을 한 반으로 **옮긴다**(이동 배정). 대상자가 이미 다른 반에 있으면 그 배정을\n해제(사유 `REASSIGNED`)한 뒤 새 반에 넣으므로, 교육생은 항상 기수 안에서 반 하나에만 속한다.\n\n**요청**\n- cohortId (경로): 대상 기수\n- classroomId (필수): 배정할 반 ID. 그 기수 소속이 아니면 404\n- traineeIds (필수, 1건 이상): 배정할 교육생의 사용자 ID(user_id) 목록. 중복은 서버가 제거한다\n\n**응답 (200)**\n- classroomId: 배정된 반\n- assignedTraineeIds: 실제 배정된 교육생 ID 목록(중복 제거 후)\n- assignedCount: 배정 인원 수\n\n전부 성공하거나 전부 실패한다. 요청한 교육생 중 한 명이라도 그 기수 소속이 아니면\n배정을 시작하지 않고 400으로 거절하며, 어느 ID가 문제인지 메시지에 담는다 —\n일부만 반영되면 어디까지 처리됐는지 화면에서 알 수 없기 때문이다.\n\n⚠️ 정원(capacity)을 초과해도 막지 않는다. 반 정원은 현재 표시용 값이다.\n",
+        "operationId": "assignTrainees",
+        "parameters": [
+          {
+            "name": "cohortId",
+            "in": "path",
+            "description": "대상 기수 ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AssignTraineesRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "반 배정 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssignTraineesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "VALIDATION_FAILED traineeIds가 비었음 · TRAINEE_NOT_IN_COHORT 기수에 속하지 않은 교육생이 포함됨(일부만 처리하지 않고 전체를 거부한다)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "VALIDATION_FAILED": {
+                    "summary": "VALIDATION_FAILED",
+                    "value": {
+                      "code": "VALIDATION_FAILED",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  },
+                  "TRAINEE_NOT_IN_COHORT": {
+                    "summary": "TRAINEE_NOT_IN_COHORT",
+                    "value": {
+                      "code": "TRAINEE_NOT_IN_COHORT",
+                      "message": "기수에 속하지 않은 교육생입니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "액세스 토큰이 없거나 유효하지 않음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "UNAUTHENTICATED": {
+                    "summary": "UNAUTHENTICATED",
+                    "value": {
+                      "code": "UNAUTHENTICATED",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "오퍼레이터 권한이 없음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "ACCESS_DENIED": {
+                    "summary": "ACCESS_DENIED",
+                    "value": {
+                      "code": "ACCESS_DENIED",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "CLASSROOM_NOT_FOUND 반을 찾을 수 없거나 지정한 기수에 속하지 않음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "CLASSROOM_NOT_FOUND": {
+                    "summary": "CLASSROOM_NOT_FOUND",
+                    "value": {
+                      "code": "CLASSROOM_NOT_FOUND",
+                      "message": "반을 찾을 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "available"
+      }
+    },
+    "/api/v0/cohorts/{cohortId}/classrooms/trainee-assignments/rollback": {
+      "patch": {
+        "tags": [
+          "Academic Operations"
+        ],
+        "summary": "교육생 반 배정 되돌리기 | ✅ 사용 가능",
+        "description": "교육생의 현재 반 배정을 **해제만** 한다(사유 `IMMEDIATE_ROLLBACK`). `assignTrainees`(이동 배정)와\n달리 새 배정을 만들지 않으므로, 처리 후 해당 교육생은 어느 반에도 속하지 않는 상태가 된다.\n\n**요청**\n- cohortId (경로): 대상 기수\n- traineeIds (필수, 1건 이상): 되돌릴 교육생의 사용자 ID(user_id) 목록. 중복은 서버가 제거한다\n\n**응답 (200)**\n- rolledBackTraineeIds: 실제로 배정이 해제된 교육생 ID 목록(중복 제거 후)\n- rolledBackCount: 해제 인원 수\n\n전부 성공하거나 전부 실패한다. 요청한 교육생 중 한 명이라도 그 기수 소속이 아니거나\n현재 활성 배정이 없으면(이미 무소속이면) 처리를 시작하지 않고 400으로 거절한다 — 이미\n무소속인 사람을 \"되돌리기\"하는 건 의미 있는 동작이 아니기 때문이다.\n",
+        "operationId": "rollbackAssignment",
+        "parameters": [
+          {
+            "name": "cohortId",
+            "in": "path",
+            "description": "대상 기수 ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RollbackAssignmentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "반 배정 되돌리기 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RollbackAssignmentResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "VALIDATION_FAILED traineeIds가 비었음 · TRAINEE_NOT_IN_COHORT 기수에 속하지 않은 교육생 · ASSIGNMENT_NOT_FOUND 되돌릴 활성 배정이 없는 교육생",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "VALIDATION_FAILED": {
+                    "summary": "VALIDATION_FAILED",
+                    "value": {
+                      "code": "VALIDATION_FAILED",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  },
+                  "TRAINEE_NOT_IN_COHORT": {
+                    "summary": "TRAINEE_NOT_IN_COHORT",
+                    "value": {
+                      "code": "TRAINEE_NOT_IN_COHORT",
+                      "message": "기수에 속하지 않은 교육생입니다."
+                    }
+                  },
+                  "ASSIGNMENT_NOT_FOUND": {
+                    "summary": "ASSIGNMENT_NOT_FOUND",
+                    "value": {
+                      "code": "ASSIGNMENT_NOT_FOUND",
+                      "message": "되돌릴 반 배정이 없는 교육생입니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "액세스 토큰이 없거나 유효하지 않음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "UNAUTHENTICATED": {
+                    "summary": "UNAUTHENTICATED",
+                    "value": {
+                      "code": "UNAUTHENTICATED",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "오퍼레이터 권한이 없음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "ACCESS_DENIED": {
+                    "summary": "ACCESS_DENIED",
+                    "value": {
+                      "code": "ACCESS_DENIED",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "COHORT_NOT_FOUND 기수를 찾을 수 없음(다른 기관의 기수 포함)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "COHORT_NOT_FOUND": {
+                    "summary": "COHORT_NOT_FOUND",
+                    "value": {
+                      "code": "COHORT_NOT_FOUND",
+                      "message": "기수를 찾을 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "available"
+      }
+    },
+    "/api/v0/reports": {
+      "get": {
+        "tags": [
+          "Reporting"
+        ],
+        "summary": "내 리포트 전량 조회 | ⚠️ 사용 불가",
+        "description": "TR-04 `내 리포트` 화면 전체를 이 응답 하나로 그린다.\n좌측 회차 레일(`rounds`)과 우측 본문(`reportsById`)이 함께 온다.\n\n**교육생 본인 것만 나간다.** `traineeId` 파라미터를 받지 않는다 —\n인증 주체로 결정하므로 남의 리포트를 지정할 방법 자체가 없다.\n\n## 요청\n\n파라미터 없음. 본문 없음.\n\n## 응답 — 최상위\n\n| 필드 | 타입 | 설명 |\n|---|---|---|\n| `rounds[]` | array | 좌측 레일. **최신 회차가 앞**이다(서버가 정렬한다) |\n| `reportsById` | object | `rounds[].id`로 찾는 회차별 본문 |\n\n**rounds[] 각 항목**\n\n| 필드 | 타입 | 설명 |\n|---|---|---|\n| `id` | UUID | 회차 식별자(`assessmentRoundId`). **리포트 id가 아니다** |\n| `label` | string | 회차 이름(예: `미프 3차`) |\n| `hasPendingRetry` | boolean | 아직 안 한 다시 보기가 있다 — 레일에 점으로 표시 |\n\n## 회차 상태 6종 — `reportsById[id].status`\n\n| 값 | 언제 | 함께 오는 것 |\n|---|---|---|\n| `NOT_ATTEMPTED` | 응시 기록이 없거나 미제출·미출석으로 끝남 | — |\n| `VOID_ATTEMPT` | 무효 응시(검토 중 또는 무효 확정) | — |\n| `STOPPED` | 세션을 시작했지만 끝내지 못함 | — |\n| `PENDING_PUBLISH` | 아직 발행 전 | `publishAfter` |\n| `PENDING_VISIBILITY` | 발행됐지만 **공개 범위 미지정** | — |\n| `PUBLISHED` | 공개됨 | `publishedAt` · `curriculum` · `concepts[]` · `retryState` |\n\n⚠️ **`PENDING_VISIBILITY`를 빈 리포트로 그리면 안 된다.** 발행과 공개는 다른\n사건이라, 결과는 이미 확정됐고 공개 범위만 안 정해진 상태다.\n\n## concepts[] — `PUBLISHED`에서만\n\n| 필드 | 타입 | 설명 |\n|---|---|---|\n| `name` | string | 개념 이름 |\n| `level` | int | 도달 단계 **0~4** |\n| `said` | string? | 학생에게 보여주는 서술 |\n| `isRetryTarget` | boolean | 다시 보기 대상 |\n| `curriculumRef` | object? | `{chapter, pages, title}` — 공개 범위 SUMMARY 이상 |\n| `qa[]` | array? | `{questionLabel, question, answer}` — **공개 범위 FULL에서만** |\n| `explain[]` | array? | 막힌 이유 해설. 다시 보기 대상일 때만 |\n| `comparedReach` | object? | `{before, after}` — 다시 보기를 마쳤을 때만 |\n\n🔴 **`level` 은 0~4 다섯 단계다.** `0` 은 통과한 축이 하나도 없다는 뜻이며\n**`1`(무엇을 하는지까지 설명함)과 전혀 다르다.** 0을 1로 올려 그리면\n학생에게 사실과 다른 말을 하게 된다.\n\n`level = 0` 과 \"안 물어본 것\"도 다르다 — 전자는 물었는데 못 한 것이다.\n\n## 공개 범위가 응답을 바꾼다\n\n| 범위 | `said` | `curriculumRef` | `qa[]` |\n|---|---|---|---|\n| `PRIVATE` | ❌ 상태가 `PENDING_VISIBILITY`/비공개 | ❌ | ❌ |\n| `SUMMARY` | ⭕ | ⭕ | ❌ |\n| `FULL` | ⭕ | ⭕ | ⭕ |\n\n**선택 필드는 키 자체가 빠진다**(null 을 싣지 않는다). `qa` 가 없으면\n`[내 답변] 펼침`을 그리지 않으면 된다.\n",
+        "operationId": "findMyReports",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TraineeReportsResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "unavailable"
+      }
+    },
+    "/api/v0/reports/{reportId}": {
+      "get": {
+        "tags": [
+          "Reporting"
+        ],
+        "summary": "리포트 단건 조회 | ⚠️ 사용 불가",
+        "description": "리포트 1건의 본문. `GET /reports` 응답의 `reportsById[id]` 한 덩어리와 **같은 모양**이다.\n\n## 화면은 이 API를 쓰지 않는다\n\nTR-04는 `GET /reports` 한 번으로 전 회차 본문을 받으므로 이 API를 부르지 않는다.\n그래도 두는 이유는 **리포트가 주소를 가진 리소스여야 하기 때문**이다 —\n`GET /reports/{reportId}/disclosure`(공개 범위 조회)가 같은 식별자를 쓴다.\n\n## 요청\n\n| 변수 | 필수 | 타입 | 설명 |\n|---|---|---|---|\n| `reportId` | **필수** | UUID | 리포트 식별자. `assessmentRoundId` 가 아니다 |\n\n## 오류\n\n| 코드 | 상황 |\n|---|---|\n| 404 `REPORT_NOT_FOUND` | 없는 리포트 **또는 남의 리포트** |\n\n⚠️ 남의 리포트를 403이 아니라 **404로 돌려준다.** 403으로 구분해 주면\n\"그 id의 리포트가 존재한다\"는 사실이 새어 나간다.\n",
+        "operationId": "findMyReport",
+        "parameters": [
+          {
+            "name": "reportId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoundReportResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "unavailable"
+      }
+    },
+    "/api/v0/reports/class-diagnosis": {
+      "get": {
+        "tags": [
+          "Reporting"
+        ],
+        "summary": "수업 진단 리포트 조회 | ⚠️ 사용 불가",
+        "description": "OP-05 `리포트` 화면 전체를 이 응답 하나로 그린다. **섹션 5개가 한 문서**다 —\n① 요약 · ② 회차별 · ③ 개념별 도달 분포 · ④ 반별 위험자·집단 미달 · ⑤ 우수 교육생.\n\n## 매핑표의 4개가 1개로 합쳐졌다\n\n매핑표에는 `class-diagnosis` · `cohort-closing` · `.../group-gaps` ·\n`.../top-performers` 4개였다. 빅프로젝트가 제품에서 빠지면서\n(Frontend #93·#94) `수업 진단`·`기수 결산` 2탭의 존재 이유가 사라져 탭이\n하나로 합쳐졌고, 나머지 셋은 이 응답의 **필드**가 됐다.\n\n**발행 시점에 얼린 스냅샷**이라 나눠 부르면 서로 다른 스냅샷을 볼 위험도 있다.\n\n## 요청\n\n| 파라미터 | 위치 | 필수 | 타입 | 설명 |\n|---|---|---|---|---|\n| `cohortId` | 쿼리 | **필수** | UUID | 기수 식별자 |\n\n필터·드릴다운이 없는 고정 스냅샷이라 파라미터가 이것 하나뿐이다(정의서 §4).\n\n## `status` 가 응답의 절반을 결정한다\n\n| 값 | 뜻 | 함께 오는 것 |\n|---|---|---|\n| `IN_PROGRESS` | 기수 결산이 아직 발행 전 | `publishedAt`·`periodEnd` 가 `null`, **`topStudents`·`classRisk`·`groupShortfalls` 가 빈 배열** |\n| `CONFIRMED` | 결산까지 발행됨 | 전부 채워짐 |\n\n⚠️ **`IN_PROGRESS` 에서 세 배열이 빈 것은 오류가 아니다.** 아직 끝나지 않은\n회차의 결과를 미리 보여주지 않기 위한 것이다. `publishedAt` 이 `null` 인 것이\nPDF 를 잠그는 근거이기도 하다.\n\n서버 내부적으로는 리포트가 **두 벌**(수업 진단·기수 결산)이고 스냅샷도 따로다.\n이 API 가 둘을 합쳐 문서 하나로 낸다.\n\n## 도달 단계 분포 — `distribution`\n\n| 필드 | 설명 |\n|---|---|\n| `level0` | **통과한 축이 하나도 없음.** 물었는데 못한 것 |\n| `level1`~`level4` | 그 단계까지 통과 |\n| `unasked` | **묻지 못함** — 그 학생 코드에 개념이 없어 문항이 안 만들어짐 |\n\n🔴 **`level0` 과 `unasked` 를 합치면 안 된다.** \"못한 것\"과 \"안 물어본 것\"은 다르다.\n`belowLevel2Count` 는 **`level0 + level1 + level2`** 이며 `unasked` 는 빠진다.\n\n## 표기 형식\n\n| 필드 | 형식 | 예 |\n|---|---|---|\n| `curriculumVersion` | `v` + 버전 번호 | `v2` |\n| `section` | `제목 (p.시작–끝)` | `네트워킹 (p.28–40)` |\n\n`section` 의 구분자는 하이픈이 아니라 **en-dash(–, U+2013)** 다.\n\n## 아직 비어 있는 값\n\n| 필드 | 상태 |\n|---|---|\n| `excluded` | **항상 `{0,0,0}`.** 제외 사유별 집계가 지표에 없다. 생성 파이프라인이 스냅샷에 적재하도록 추가한 뒤 채운다 |\n| `groupShortfalls[].round` | **항상 `\"\"`.** 이 지표의 grain 이 반×개념이라 회차 축이 없다 |\n\n## 오류\n\n| 코드 | 상황 |\n|---|---|\n| 404 `COHORT_REPORT_NOT_FOUND` | 없는 기수 **또는 수업 진단 리포트가 아직 만들어지지 않음** |\n\n회차가 하나도 안 끝났으면 정상적으로 404 다 — 빈 문서를 그리지 않는다.\n",
+        "operationId": "findClassDiagnosis",
+        "parameters": [
+          {
+            "name": "cohortId",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CohortDiagnosisResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "unavailable"
+      }
+    },
+    "/api/v0/platform/operations/super-admins": {
+      "get": {
+        "tags": [
+          "Platform Governance"
+        ],
+        "summary": "슈퍼어드민 계정 목록 | ✅ 사용 가능",
+        "description": "SA-03 ② `슈퍼어드민 계정` 탭의 목록.\n\n## 요청\n\n없다. 파라미터·본문 모두 필요 없다.\n\n## 응답\n\n| 필드 | 타입 | 설명 |\n|---|---|---|\n| `activeCount` | int | **활성**(`ACTIVE`) 슈퍼어드민 수 |\n| `content[]` | array | 계정 목록. 생성순 |\n\n**content[] 각 항목**\n\n| 필드 | 타입 | 설명 |\n|---|---|---|\n| `memberId` | UUID | 계정 식별자. 정지·재활성에 쓴다 |\n| `name` | string? | 이름. **초대만 되고 가입 전이면 `null`** → 화면에 `—` |\n| `email` | string | 이메일 |\n| `status` | enum | `ACTIVE`(활성) · `PENDING`(초대됨) · `INACTIVE`(정지) |\n| `lastLoginAt` | datetime? | 최근 로그인. 없으면 `null` → `대기 중` |\n| `createdAt` | datetime | 계정 생성 시각 |\n| `deactivatable` | boolean | `false` 면 **정지 버튼을 잠근다** |\n\n## `deactivatable` 이 핵심이다\n\n활성 슈퍼어드민이 **1명뿐이면 그 계정은 `false`** 다.\n목업: *\"마지막 한 명은 정지할 수 없다.\"* 정지하면 플랫폼에 들어갈 사람이 아무도 없어지고,\n오퍼레이터와 달리 **풀어 줄 상위 권한이 아예 없어** 복구가 불가능하다.\n\n화면에서 미리 잠가야 사용자가 409 를 만나지 않는다.\n\n## 기관 컬럼이 없다\n\n슈퍼어드민은 어느 기관에도 속하지 않는다(`app_user.org_id IS NULL`).\n`PENDING` 계정도 목록에 포함되므로 초대 현황을 이 목록에서 볼 수 있다.\n",
+        "operationId": "findSuperAdmins",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuperAdminListResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "available"
+      }
+    },
+    "/api/v0/platform/operations/model-settings": {
+      "get": {
+        "tags": [
+          "Platform Governance"
+        ],
+        "summary": "플랫폼 모델·단가 설정 조회 | ✅ 사용 가능",
+        "description": "SA-03 ① `모델 · 단가` 탭 **전체를 한 번에** 채운다. 이 화면에서 다른 조회 API 는 필요 없다.\n\n## 요청\n\n없다. 파라미터·본문 모두 필요 없다.\n\n## 응답 — 최상위\n\n| 필드 | 타입 | 설명 |\n|---|---|---|\n| `gradingPolicy` | object? | 채점 모델 정책(전 기관 공통). **`null` 이면 플랫폼 초기 설정 전** |\n| `tierMappings[]` | array | 기능 × 티어 → 모델 매핑 |\n| `modelPricings[]` | array | 모델별 단가. **단가 미설정 모델도 포함** |\n\n**gradingPolicy** — 목업 `채점 · 고정 · claude-x` 행\n\n| 필드 | 타입 | 설명 |\n|---|---|---|\n| `gradingPolicyId` | UUID | 정책 식별자 |\n| `policyVersion` | int | 정책 버전. 바꿀 때마다 올라간다 |\n| `modelId` | UUID | 현재 채점 모델 |\n| `modelDisplayName` | string | 표시명(예: `claude-opus-5`) |\n| `modelCode` | string | 모델 코드 |\n| `effectiveFrom` | datetime | 적용 시작 시각 |\n| `changeReason` | string? | 변경 사유 |\n| `activeCalibration` | object? | 현재 유효한 캘리브레이션 버전 |\n| `runningCalibration` | object? | **진행 중인 재캘리브레이션.** 없으면 `null` |\n\n**calibration 객체** — `calibrationVersionId` · `versionCode` ·\n`status`(`PENDING`·`RUNNING`·`ACTIVE`·`FAILED`·`SUPERSEDED`) · `startedAt` · `completedAt` ·\n`progress`\n\n**progress** — `totalOrganizations` · `pending` · `running` · `succeeded` · `failed` ·\n`completionRate`(0~1). 확인 모달의 `전 기관 재캘리브레이션` 진행률에 쓴다.\n\n**tierMappings[]**\n\n| 필드 | 타입 | 설명 |\n|---|---|---|\n| `tierPolicyId` | UUID | 매핑 식별자 |\n| `featureCode` | string | 적용 기능. **v07 기준 `CODE_SESSION` 하나뿐** |\n| `tierCode` | enum | `ACCURACY_FIRST` · `BALANCED` · `COST_FIRST` |\n| `modelId` · `modelDisplayName` · `modelCode` | | 이 티어가 실제로 호출할 모델 |\n| `policyVersion` | int | 매핑 버전 |\n| `effectiveFrom` | datetime | 적용 시작 시각 |\n\n**modelPricings[]** — 목업 `단가 · 100만 토큰당`\n\n| 필드 | 타입 | 설명 |\n|---|---|---|\n| `modelId` · `modelCode` · `modelDisplayName` · `provider` | | 모델 정보 |\n| `status` | string | `ACTIVE` · `INACTIVE`. INACTIVE 모델은 선택 대상에서 빼야 한다 |\n| `inputPricePerMillionTokens` | decimal? | 100만 토큰당 입력 단가. **미설정이면 `null`** |\n| `outputPricePerMillionTokens` | decimal? | 출력 단가. 미설정이면 `null` |\n| `cachedInputPricePerMillionTokens` | decimal? | 캐시 입력 단가 |\n| `currencyCode` | string? | 통화. `USD` |\n| `pricingMissing` | boolean | **`true` 면 화면에 `단가 미설정`으로 표시**하고 합계에서 뺀다 |\n| `priceEffectiveFrom` · `priceUpdatedAt` | datetime? | 단가 적용·수정 시각 |\n\n⚠️ `pricingMissing=true` 인 모델을 **0원으로 계산하지 마세요.**\n목업 SA-03: *\"0으로 합산하면 청구액이 실제보다 작아 보인다.\"*\n\n## 초기 설정 전이면\n\n`gradingPolicy` 가 `null` 이고 `tierMappings` 가 비어 있을 수 있다.\n`ai_model` · `platform_grading_model_policy` 에 시드 데이터가 들어가야 채워진다.\n화면은 이 경우 빈 상태를 그려야 한다(오류가 아니다).\n",
+        "operationId": "findModelSettings",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlatformModelSettingResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "available"
+      }
+    },
+    "/api/v0/organizations/{organizationId}/operators": {
+      "get": {
+        "tags": [
+          "Organization"
+        ],
+        "summary": "기관 오퍼레이터 계정 목록 조회 | ✅ 사용 가능",
+        "description": "\nSA-02 ② `이 기관의 오퍼레이터 계정` 표를 채운다.\n\n## 요청\n\n| 변수 | 필수 | 타입 | 설명 |\n|---|---|---|---|\n| `organizationId` | **필수** | UUID | 기관 식별자 |\n\n페이지네이션 없음. 오퍼레이터는 기관당 소수라 전부 내려준다.\n\n## 응답\n\n| 필드 | 타입 | 설명 |\n|---|---|---|\n| `organizationId` | UUID | 요청한 기관 |\n| `activeCount` | int | **활성** 오퍼레이터 수. `0` 이면 `오퍼레이터 미배정` 상태 |\n| `content[]` | array | 계정 목록. 생성순 |\n\n**content[] 각 항목**\n\n| 필드 | 타입 | 설명 |\n|---|---|---|\n| `memberId` | UUID | 계정 식별자. 정지·재활성에 쓴다 |\n| `name` | string? | 이름. **초대만 되고 가입 전이면 `null`** → 화면에 `—` |\n| `email` | string | 이메일 |\n| `status` | enum | `ACTIVE`(활성) · `PENDING`(초대됨) · `INACTIVE`(정지) |\n| `invitedAt` | datetime? | 최초 초대 시각. 초대 이력이 없으면 `null` |\n| `lastLoginAt` | datetime? | 최근 로그인. 없으면 `null` → 화면에 `대기 중` |\n| `pendingInvitationTokenId` | UUID? | 대기 중 초대 토큰. **`null` 이 아니면 취소·재발송 가능** |\n| `suspendable` | boolean | `false` 면 정지 버튼을 잠근다(마지막 활성 오퍼레이터) |\n| `invitationDeliveryFailed` | boolean | `true` 면 **메일이 나가지 않았다** → 재발송 유도 |\n\n## 행별 버튼 노출 기준\n\n| 버튼 | 조건 |\n|---|---|\n| 정지 | `suspendable === true` |\n| 재활성 | `status === 'INACTIVE'` |\n| 재발송 | `invitationDeliveryFailed === true` |\n| 취소 | `pendingInvitationTokenId !== null` |\n\n## 상태 배지를 그리는 법\n\n`status` 와 `invitationDeliveryFailed` **두 값을 조합**한다. 둘 다 \"활성화 전\"이지만\n화면이 할 말이 다르다.\n\n| status | invitationDeliveryFailed | 배지 |\n|---|---|---|\n| `ACTIVE` | `false` | 활성 |\n| `PENDING` | `false` | 초대됨 (수락 대기) |\n| `PENDING` | **`true`** | **메일 발송 실패** (목업 case 4·5) |\n| `INACTIVE` | — | 정지 |\n\n정지된 계정도 목록에 남는다 — 목업: *\"퇴사한 계정도 지우지 않고 정지로 남긴다.\n과거 기수의 배정 이력에 이름이 붙어 있고, 지우면 그 이력이 끊긴다.\"*\n",
+        "operationId": "findOperators",
+        "parameters": [
+          {
+            "name": "organizationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OperatorListResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "available"
+      }
+    },
+    "/api/v0/organizations/{organizationId}/operations/usage": {
+      "get": {
+        "tags": [
+          "Usage Metering"
+        ],
+        "summary": "기관 월별 저장량·활동·AI 비용 조회 | ✅ 사용 가능",
+        "description": "SA-02 ③ `사용량 · AI 비용` 탭(슈퍼어드민)과 OP-06 ⑤ `비용` 탭(오퍼레이터)이 함께 쓴다.\n\n**권한** — 슈퍼어드민은 모든 기관, 오퍼레이터는 **자기 기관만**(다른 기관이면 403).\n매니저·교육생은 접근 불가 — 목업: *\"매니저에게는 비용을 보여주지 않는다.\n보이면 '비싸니까 세션 짧게'라는 잘못된 압력이 생긴다.\"*\n\n## 요청\n\n| 파라미터 | 위치 | 필수 | 타입 | 설명 |\n|---|---|---|---|---|\n| `organizationId` | 경로 | **필수** | UUID | 기관 식별자 |\n| `period` | 쿼리 | 선택 | `yyyy-MM` | 조회 월(예: `2026-07`). 생략하면 **이번 달(UTC)** |\n| `cohortId` | 쿼리 | 선택 | UUID | 반별 내역(`classCosts`)의 범위. **생략하면 `classCosts` 가 빈 배열** |\n\n`cohortId` 는 OP-06 비용 탭의 상단 기수 스위처 값을 넘기면 된다.\nSA-02(슈퍼어드민)는 기관 전체를 보므로 생략한다.\n\n## 응답 — 최상위\n\n| 필드 | 타입 | 설명 |\n|---|---|---|\n| `organizationId` | UUID | 요청한 기관 |\n| `period` | string | 집계 월(`yyyy-MM`) |\n| `currencyCode` | string? | 통화. 플랫폼 공통 `USD` |\n| `aggregationSource` | enum | `SNAPSHOT`(배치 집계) · `LIVE`(즉시 합산). 배치가 붙기 전에는 항상 `LIVE` |\n| `storage` | object | 저장량 |\n| `activity` | object | 사용 규모 |\n| `aiCost` | object | AI 비용 |\n| `cohortCosts[]` | array | 기수별 비용 |\n| `classCosts[]` | array | 반별 비용. **`cohortId` 를 안 보내면 빈 배열** |\n\n**storage** — 목업 `저장량 구성 총 9.4 GB`\n\n| 필드 | 타입 | 설명 |\n|---|---|---|\n| `totalBytes` | long | 총 저장 바이트 |\n| `codeSubmissionBytes` | long | 코드 제출물(레포·ZIP) |\n| `sessionLogBytes` | long | 문답 원문 |\n| `gradingEvidenceBytes` | long | 채점 근거 |\n| `reportBytes` | long | 리포트·내보내기 PDF |\n| `changeRateVsPrevMonth` | decimal? | 전월 대비 증감률. 전월이 0이면 `null` |\n\n**activity** — 목업 `활성 교육생 148 / 완료 세션 612 / 채점 회차 1,840 / 발행 리포트 96`\n\n| 필드 | 타입 | 설명 |\n|---|---|---|\n| `activeTrainees` | int | 활성 교육생 수 |\n| `completedSessions` | long | 완료 세션 수(`ended_at` 기준) |\n| `gradingRounds` | long | 채점 회차 수(제출 마감 `submission_due_at` 기준) |\n| `generatedReports` | long | 발행 리포트 수(`published_at` 기준) |\n\n**aiCost** — 목업 `AI 비용 · 이번 달 $412 / 예산 $600 · 전월 +12%`\n\n| 필드 | 타입 | 설명 |\n|---|---|---|\n| `totalCost` | decimal | 비용 합계. **단가 미설정 호출은 제외** |\n| `monthlyBudget` | decimal | 월 예산 |\n| `budgetUsageRate` | decimal? | 소진율(0~1). 예산이 0이면 `null` |\n| `budgetExceeded` | boolean | 예산 초과 여부. 초과해도 서비스는 중단되지 않는다 |\n| `changeRateVsPrevMonth` | decimal? | 전월 대비 증감률 |\n| `costComplete` | boolean | **`false` 면 합계가 실제보다 작다**(단가 미설정 호출 존재) |\n| `unpricedCallCount` | long | 단가가 없어 합계에서 빠진 호출 수 |\n| `total` | object | `{ calls, inputTokens, outputTokens, cost }` 합계 행 |\n| `models[]` | array | (용도, 모델) 조합별 내역 |\n\n**models[] 각 항목** — `usageType` · `tier` · `model` · `calls` · `inputTokens` ·\n`outputTokens` · `inputPricePerMillionTokens` · `outputPricePerMillionTokens` ·\n`pricingMissing`(단가 미설정) · `cost`\n\n**cohortCosts[]** — `cohortId` · `name` · `traineeCount` · `cost` ·\n`costPerTrainee`(인원 0이면 `null`) · `unpricedCallCount`\n\n**classCosts[]** — `classId` · `name` · `managerName`(담당 없으면 `null`) ·\n`traineeCount` · `sessionCount` · `cost` · `unpricedCallCount`\n\n## 화면에서 주의할 것\n\n**① `costComplete=false` 면 금액에 주석을 달아야 한다.**\n단가 미설정 호출을 0으로 더하지 않고 **빼기** 때문에 합계가 실제보다 작다.\n`unpricedCallCount` 건이 빠졌다고 표시하세요 — 목업 SA-03 `단가 미설정` 원칙.\n\n**② 증감률 `null` 은 0%가 아니다.** 전월 값이 없어 계산 불가라는 뜻이라 `—` 로 그린다.\n\n## 오류\n\n| 코드 | 상황 |\n|---|---|\n| 403 | 오퍼레이터가 다른 기관을 조회 |\n| 404 `ORG_NOT_FOUND` | 없는 기관 |\n| 503 `USAGE_UNAVAILABLE` | **기간 집계가 실패한 상태**(목업 case 6) |\n\n503 일 때 화면은 **사용량 패널만** 오류 상태로 바꾸고 기관 정보·다른 탭은 그대로 보여준다.\n실패분을 빼고 남은 것만 더해 0 처럼 보여주지 않는다 — *\"안 쓴 것\"과 \"못 읽은 것\"은 다르다.*\n",
+        "operationId": "findUsage",
+        "parameters": [
+          {
+            "name": "organizationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "period",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "cohortId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationUsageResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "available"
+      }
+    },
+    "/api/v0/organizations/{organizationId}/operations/cost": {
+      "get": {
+        "tags": [
+          "Usage Metering"
+        ],
+        "summary": "기수 비용 조회 (OP-06 ⑤) | ✅ 사용 가능",
+        "description": "OP-06 `운영 관리 › 비용` 탭 전체를 이 응답 하나로 그린다.\n프론트 `getCost()` 반환 타입과 **필드명까지 1:1**이라 매핑 코드가 필요 없다.\n\n## `/usage`와 나눈 이유 — 축이 다르다\n\n| | `/usage` (SA-02 ③) | `/cost` (OP-06 ⑤) |\n|---|---|---|\n| 묻는 것 | 이번 달에 **무엇을** 얼마나 썼나 | 기수 동안 **어느 달 어느 반이** 튀었나 |\n| 기간 | 한 달 | 기수 시작월 ~ 이번 달 |\n| 형태 | 모델별·기수별·반별 한 달 합계 | **월 × 반 매트릭스** |\n\n`/usage`에 월 배열을 얹으면 SA-02가 안 쓰는 데이터를 매번 받게 되고,\n월마다 `/usage`를 반복 호출하면 7개월 × 10반을 7번 왕복으로 모으게 된다.\n\n## 요청\n\n| 파라미터 | 위치 | 필수 | 타입 | 설명 |\n|---|---|---|---|---|\n| `organizationId` | 경로 | **필수** | UUID | 기관 식별자 |\n| `cohortId` | 쿼리 | **필수** | UUID | 이 탭의 범위는 기수다 |\n| `sort` | 쿼리 | | enum | `NAME`(기본) · `COHORT_AMOUNT` |\n\n**정렬이 둘뿐인 이유** — 월이 열로 펼쳐졌으므로 *어느 달에 누가 많이 썼나*는\n눈으로 훑는 일이다. 달마다 정렬을 만들면 일곱 개가 되고, 그건 매트릭스가 이미 하는 일이다.\n\n## 월 범위\n\n`기수 시작월 ~ min(이번 달, 기수 종료월)`. **아직 오지 않은 달은 담지 않는다** —\n기수가 9월까지여도 7월이면 다섯 칸이다.\n\n## 방향이 반대인 두 배열 ⚠️\n\n| 배열 | 순서 | 이유 |\n|---|---|---|\n| `summary.monthly` | **최근이 앞** | 월별 표는 최신이 위 |\n| `classes[].monthly` | **오래된 것이 앞** | 매트릭스는 왼쪽에서 오른쪽으로 시간이 흐른다 |\n\n## 범위가 섞여 있다\n\n`summary.total`·`previousTotal`은 **기관 전체**, 나머지는 **선택 기수**다.\n화면도 제목에 각각의 범위를 쓴다.\n\n## 계산 규칙\n\n| 값 | 규칙 |\n|---|---|\n| 금액 | **단가가 설정된 호출만** 합산(`pricing_status <> 'UNPRICED'`). 0으로 더하면 청구액이 작아 보인다 |\n| `budget` | `월 예산 × 기수 개월 수`로 **파생**. 기수 단위 예산 컬럼이 스키마에 없다. 정책이 없거나 예산 0이면 `null` |\n| `changePct` | 전월 대비 **퍼센트**(`+12.0`). ⚠️ 다른 API의 `changeRate`(0~1)와 단위가 다르다 |\n| `previousTotal` | 지난달 행이 아예 없으면 `null` — **0과 구분**해야 화면이 `—`를 그린다 |\n| 월 버킷 | **UTC 고정**. 서버 로컬 존을 쓰면 배포 환경에 따라 월 경계가 흔들린다 |\n| `cohorts[]` | 기준 월에 **실제로 비용이 난** 기수만. 평시 1건, 전환기 2건 |\n\n## 오류\n\n| 코드 | 상황 |\n|---|---|\n| 404 `ORG_NOT_FOUND` | 없는 기관 **또는 없는 기수** |\n| 403 `ORG_ACCESS_DENIED` | 오퍼레이터가 다른 기관을 조회 |\n",
+        "operationId": "findCohortCost",
+        "parameters": [
+          {
+            "name": "organizationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "cohortId",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "반별 정렬 기준",
+              "enum": [
+                "NAME",
+                "COHORT_AMOUNT"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CohortCostResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "available"
+      }
+    },
+    "/api/v0/organizations/{organizationId}/cohorts": {
+      "get": {
+        "tags": [
+          "Organization"
+        ],
+        "summary": "기관 기수 목록 조회 (읽기전용) | ✅ 사용 가능",
+        "description": "SA-02 ① 개요 하단의 `기수 · 읽기전용` 표를 채운다.\n\n## 요청 (경로 변수)\n\n| 변수 | 필수 | 타입 | 설명 |\n|---|---|---|---|\n| `organizationId` | **필수** | UUID | 기관 식별자 |\n\n**페이지네이션이 없다.** 기수는 기관당 많아야 수십 개라 전부 내려준다.\n\n## 응답\n\n| 필드 | 타입 | 설명 |\n|---|---|---|\n| `organizationId` | UUID | 요청한 기관 |\n| `content[]` | array | 기수 목록. **시작일 내림차순**(최근 기수가 위) |\n\n**content[] 각 항목**\n\n| 필드 | 타입 | 설명 |\n|---|---|---|\n| `cohortId` | UUID | 기수 식별자 |\n| `name` | string | 기수명 (예: `7기`) |\n| `status` | string | `PLANNED`(예정) · `RUNNING`(진행 중) · `CLOSED`(종료) |\n| `classCount` | int | 이 기수의 반 수(삭제된 반 제외) |\n| `traineeCount` | int | 현재 소속 교육생 수(**나간 인원 제외**) |\n| `startDate` | date? | 시작일 (`yyyy-MM-dd`). 미정이면 `null` |\n| `endDate` | date? | 종료일. 미정이면 `null` |\n\n## 조회 전용이다\n\n기수 개설·반 편성·명단 등록은 **기관 안에서 오퍼레이터가** 한다(OP-06).\n목업: *\"기수를 여기서 열지 않는다. 지원·과금 맥락의 읽기전용 가시성만 둔다.\"*\n따라서 이 화면에 생성·수정 버튼을 두지 않는다.\n",
+        "operationId": "findOrganizationCohorts",
+        "parameters": [
+          {
+            "name": "organizationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationCohortListResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "available"
+      }
+    },
+    "/api/v0/organizations/summary": {
+      "get": {
+        "tags": [
+          "Organization"
+        ],
+        "summary": "플랫폼 전체 집계 조회 | ✅ 사용 가능",
+        "description": "SA-01 상단 지표 카드 4개를 채운다. 전 기관을 합산한 값이다.\n\n목록 조회(`GET /organizations`)와 **의존 관계가 없으므로 병렬로 호출**하면 된다.\n\n## 요청\n\n없다. 파라미터·본문 모두 필요 없다.\n\n## 응답\n\n| 필드 | 타입 | 설명 |\n|---|---|---|\n| `period` | string | 집계 기준 월 (`yyyy-MM`, UTC) |\n| `organizations.total` | int | 총 기관 수 (**삭제된 기관 제외**) |\n| `organizations.active` | int | 활성 기관 수 |\n| `organizations.suspended` | int | 정지 기관 수 |\n| `traineeCount` | int | 플랫폼 전체 활성 교육생 수 |\n| `activeSessionCount` | int | 진행 중 세션 수(`IN_PROGRESS`·`PAUSED`) |\n| `aiCost.totalCost` | decimal | 이번 달 AI 비용 합계 |\n| `aiCost.totalMonthlyBudget` | decimal | 전 기관 월 예산 합계 |\n| `aiCost.budgetUsageRate` | decimal? | 소진율(0~1). 예산 합계가 0이면 `null` |\n| `aiCost.changeRateVsPrevMonth` | decimal? | 전월 대비 증감률. 전월이 0이면 `null` |\n| `aiCost.currencyCode` | string | 통화. 플랫폼 공통 `USD` |\n| `storage.totalBytes` | long | 총 저장 바이트 |\n| `storage.changeRateVsPrevMonth` | decimal? | 전월 대비 증감률. 전월이 0이면 `null` |\n| `storage.averageBytesPerOrganization` | long | 기관 1곳당 평균 바이트 |\n\n**증감률이 `null`인 경우** 화면에서 `—`로 표시한다. 0%와 구분해야 한다 —\n전월 값이 없어 계산할 수 없는 것이지 변화가 없다는 뜻이 아니다.\n",
+        "operationId": "findPlatformSummary",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlatformSummaryResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "available"
+      }
+    },
+    "/api/v0/organizations/name-availability": {
+      "get": {
+        "tags": [
+          "Organization"
+        ],
+        "summary": "기관명 중복 확인 | ✅ 사용 가능",
+        "description": "SA-01 생성 모달의 \"입력 중 실시간 중복 확인\"(✓/✗)에 쓴다.\n타이핑마다 호출하지 말고 **디바운스(300ms 정도)** 를 걸어 주세요.\n\n## 요청 (쿼리 파라미터)\n\n| 파라미터 | 필수 | 타입 | 설명 |\n|---|---|---|---|\n| `name` | **필수** | string | 확인할 기관명. 빈 문자열이면 400 |\n\n## 응답\n\n| 필드 | 타입 | 설명 |\n|---|---|---|\n| `name` | string | 확인을 요청한 원본 이름 |\n| `normalizedName` | string | 중복 판정 기준값(트림 + 소문자) |\n| `available` | boolean | `true`면 사용 가능 |\n| `reason` | string? | 사용 불가 사유. `available=true`면 `null` |\n\n⚠️ **이건 입력 중 힌트일 뿐 보장이 아니다.** 확인과 생성 사이에 다른 요청이 같은 이름을\n선점할 수 있으므로, 최종 방어는 생성 API 의 409 다. 화면은 생성 실패도 처리해야 한다.\n\n**삭제된 기관의 이름도 사용 불가로 나온다.** `normalized_name` 이 전체 UNIQUE 라\n물리 파기 전까지 이름이 선점 상태로 남는다.\n",
+        "operationId": "checkNameAvailability",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationNameAvailabilityResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "available"
+      }
+    },
+    "/api/v0/members/me": {
+      "get": {
+        "tags": [
+          "Member"
+        ],
+        "summary": "내 정보 조회 | ✅ 사용 가능",
+        "description": "**지금 이 액세스 토큰의 주인**을 서버에서 다시 읽어 내려줍니다. 역할에 관계없이 호출할 수 있습니다.\n\n**요청**\n- 본문·경로 파라미터 없음. `Authorization: Bearer {accessToken}`만 필요합니다\n\n**응답**\n- memberId / email / name / role / organizationId(슈퍼어드민은 null) / status\n\n**세션 복원용입니다.** 새로고침하면 브라우저 메모리가 비워지는데 `POST /auth/refresh`는\n토큰만 돌려주고 역할을 주지 않습니다. 역할을 모르면 사이드바도 라우팅도 그릴 수 없어\n역할을 브라우저 저장소에 남기게 되는데, 그러면 **정지·역할 변경을 화면이 모릅니다.**\n`부팅 → refresh → /members/me` 순서로 부르면 역할이 서버 진실이 되고 저장소에 신원 정보를\n남기지 않아도 됩니다.\n\n**값은 로그인 응답과 같습니다** — `redirectPath`와 토큰만 빠집니다. 즉 로그인 직후에는\n부를 필요가 없고, 새로고침·권한 재확인 시점에 부르면 됩니다.\n\n`status`가 `INACTIVE`로 오는 것은 **세션 도중에 계정이 정지된 것**입니다. 액세스 토큰은\n만료 전까지 계속 통과하므로, 그 사이에 알아채려면 이 값을 봐야 합니다.\n",
+        "operationId": "getCurrentMember",
+        "responses": {
+          "200": {
+            "description": "현재 로그인한 사용자 정보",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MemberProfileResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UNAUTHENTICATED 액세스 토큰이 없거나 만료됨 · MEMBER_NOT_FOUND 토큰은 유효하지만 계정이 삭제됨",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "MEMBER_NOT_FOUND": {
+                    "summary": "MEMBER_NOT_FOUND",
+                    "value": {
+                      "code": "MEMBER_NOT_FOUND",
+                      "message": "인증 사용자를 찾을 수 없습니다."
+                    }
+                  },
+                  "UNAUTHENTICATED": {
+                    "summary": "UNAUTHENTICATED",
+                    "value": {
+                      "code": "UNAUTHENTICATED",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "available"
+      }
+    },
+    "/api/v0/members/me/enrollments": {
+      "get": {
+        "tags": [
+          "Academic Operations"
+        ],
+        "summary": "내 소속 기수·반 조회 | ✅ 사용 가능",
+        "description": "로그인한 사용자가 현재 유효하게(LEFT 아닌) 소속된 기수와, 기수별 현재 반 배정을 조회한다.\n조회 범위인 기관은 액세스 토큰에서 가져오므로 다른 기관 소속은 조회되지 않는다.\n\n**요청**\n- 파라미터 없음(토큰의 사용자 본인 기준)\n\n**응답 (200)**\n- enrollments[].cohortId: 기수 ID\n- enrollments[].cohortName: 기수명\n- enrollments[].classroom: 현재 배정된 반. 아직 배정 전이면 null\n- enrollments[].classroom.classroomId / name: 반 ID·이름\n\n**아직 채워지지 않는 값** — 반 배정 전이면 classroom은 null이다. 오퍼레이터가\n`PATCH /cohorts/{cohortId}/classrooms/trainee-assignments`를 실행하기 전 구간에서\n정상적으로 발생하는 상태다.\n",
+        "operationId": "findMyEnrollments",
+        "responses": {
+          "200": {
+            "description": "조회 성공(소속이 없으면 빈 배열)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EnrollmentListResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "액세스 토큰이 없거나 유효하지 않음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "UNAUTHENTICATED": {
+                    "summary": "UNAUTHENTICATED",
+                    "value": {
+                      "code": "UNAUTHENTICATED",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "ORGANIZATION_CONTEXT_MISSING 인증 정보에서 organizationId를 확인할 수 없음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "ORGANIZATION_CONTEXT_MISSING": {
+                    "summary": "ORGANIZATION_CONTEXT_MISSING",
+                    "value": {
+                      "code": "ORGANIZATION_CONTEXT_MISSING",
+                      "message": "기관 컨텍스트를 확인할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "available"
+      }
+    },
+    "/api/v0/consents": {
+      "get": {
+        "tags": [
+          "Consent"
+        ],
+        "summary": "약관 목록 조회 | ✅ 사용 가능",
+        "description": "가입 화면이 표시할 동의 항목을 역할별로 받아온다. 인증 없이 호출한다.\n\n**요청**\n- role (선택, 기본 MANAGER): `SUPER_ADMIN` · `OPERATOR` · `MANAGER` · `TRAINEE`\n\n**응답**\n- 오퍼레이터·매니저·슈퍼어드민: 필수 2건\n- 교육생: 필수 4건 + 선택 1건(`ANONYMIZED_DATA_USAGE`)\n- requestField: 이 항목의 동의 여부를 후속 가입 요청(`/auth/manager-signup`,\n  `/auth/trainee-activation`)에서 실어 보낼 **필드명**이다. 코드-필드 대응표를\n  화면이 따로 들고 있지 않아도 되도록 서버가 내려준다\n- policyVersion: 표시한 동의 문서 버전이며 동의 기록에 그대로 저장된다\n\n**required=true 항목을 false로 제출하면 가입이 400으로 거부된다.** 화면은 필수 항목이\n모두 체크되기 전까지 제출 버튼을 막아야 한다. 교육생의 익명 활용 동의만 거부해도 가입된다.\n\n항목 구성은 서버가 정하므로 화면에 항목을 하드코딩하지 않는다.\n",
+        "operationId": "findConsents",
+        "parameters": [
+          {
+            "name": "role",
+            "in": "query",
+            "description": "동의 항목을 조회할 대상 역할입니다. 생략하면 오퍼레이터·매니저 기준으로 응답합니다.",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/Role",
+              "default": "MANAGER"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "역할별 동의 항목 목록",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ConsentItemResponse"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "지원하지 않는 role 값",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "VALIDATION_FAILED": {
+                    "summary": "VALIDATION_FAILED",
+                    "value": {
+                      "code": "VALIDATION_FAILED",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  },
+                  "BAD_REQUEST": {
+                    "summary": "BAD_REQUEST",
+                    "value": {
+                      "code": "BAD_REQUEST",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [],
+        "x-readiness": "available"
+      }
+    },
+    "/api/v0/cohorts/{cohortId}": {
+      "get": {
+        "tags": [
+          "Academic Operations"
+        ],
+        "summary": "기수 상세 조회 | ✅ 사용 가능",
+        "description": "기수 하나의 상세 정보를 조회한다. 조회 범위인 기관은 액세스 토큰에서 가져오며,\n다른 기관의 기수를 요청하면 404다(존재 여부 자체를 알려주지 않기 위해 403이 아니라 404로 응답한다).\n삭제된 기수도 404다.\n\n**요청**\n- cohortId (경로): 조회할 기수 ID\n\n**응답 (200)**\n- cohortId: 기수 ID\n- organizationId: 소속 기관 ID\n- name: 기수명\n- status: PLANNED(개설 예정) / RUNNING(진행 중) / CLOSED(종료)\n- startDate / endDate: 기수 기간\n- traineeCount: 소속 교육생 수\n- managers[]: 담당 매니저 목록\n\n**아직 채워지지 않는 값** — traineeCount는 항상 0, managers는 항상 빈 배열이다(목록 조회와 동일).\n",
+        "operationId": "findCohort",
+        "parameters": [
+          {
+            "name": "cohortId",
+            "in": "path",
+            "description": "조회할 기수 ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "기수 상세 조회 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CohortResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "액세스 토큰이 없거나 유효하지 않음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "UNAUTHENTICATED": {
+                    "summary": "UNAUTHENTICATED",
+                    "value": {
+                      "code": "UNAUTHENTICATED",
+                      "message": "요청을 처리할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "COHORT_NOT_FOUND 기수를 찾을 수 없음(다른 기관의 기수·삭제된 기수 포함)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "COHORT_NOT_FOUND": {
+                    "summary": "COHORT_NOT_FOUND",
+                    "value": {
+                      "code": "COHORT_NOT_FOUND",
+                      "message": "기수를 찾을 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "ORGANIZATION_CONTEXT_MISSING 인증 정보에서 organizationId를 확인할 수 없음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "ORGANIZATION_CONTEXT_MISSING": {
+                    "summary": "ORGANIZATION_CONTEXT_MISSING",
+                    "value": {
+                      "code": "ORGANIZATION_CONTEXT_MISSING",
+                      "message": "기관 컨텍스트를 확인할 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "available"
+      }
+    },
+    "/api/v0/organizations/{organizationId}/operators/invitations/{tokenId}": {
+      "delete": {
+        "tags": [
+          "Organization"
+        ],
+        "summary": "오퍼레이터 초대 취소 | ⚠️ 사용 보류",
+        "description": "SA-02 ② 표의 `취소` 액션. 아직 수락되지 않은 초대를 무효화한다.\n\n## 요청\n\n| 변수 | 필수 | 타입 | 설명 |\n|---|---|---|---|\n| `organizationId` | **필수** | UUID | 기관 식별자 |\n| `tokenId` | **필수** | UUID | 목록 응답의 **`pendingInvitationTokenId`** |\n\n본문 없음.\n\n`pendingInvitationTokenId` 가 `null` 인 행은 **취소 버튼을 노출하지 않는다** —\n이미 수락됐거나 취소된 초대라 넘길 토큰이 없다.\n\n## 응답\n\n**취소 후의 오퍼레이터 목록 전체**(`GET .../operators` 와 같은 구조).\n표를 그대로 다시 그리면 된다.\n\n해당 계정은 이렇게 바뀐다.\n\n| 필드 | 취소 후 |\n|---|---|\n| `status` | `INACTIVE` |\n| `pendingInvitationTokenId` | `null` |\n| `invitationDeliveryFailed` | `false` |\n\n## 세 가지가 함께 처리된다\n\n1. **초대 토큰 무효화** — 이미 나간 메일의 링크가 죽는다\n2. **초대 원장을 `CANCELLED` 로 닫기** — 감사·통계에서 발송된 초대로 세지 않는다\n3. **계정 자리는 남기고 `INACTIVE` 로** — 이력 보존\n   (*\"퇴사한 계정도 지우지 않고 정지로 남긴다\"* 와 같은 처리)\n\n## 같은 이메일로 다시 초대할 수 있다\n\n취소된 자리는 활성화된 적이 없으므로, 재초대 시 **새 계정을 만들지 않고 그 자리를 되살린다.**\n`memberId` 가 그대로 유지되어 이력이 한 줄로 이어진다.\n\n재초대는 이 API 가 아니라 `POST .../operators/invitations` 를 쓴다(재발송이 아니다 —\n취소된 초대는 토큰이 없어 재발송 대상이 아니다).\n\n## 오류\n\n| 코드 | 상황 |\n|---|---|\n| 404 `OPERATOR_INVITATION_NOT_FOUND` | 이미 수락·취소된 초대이거나 다른 기관의 토큰 |\n",
+        "operationId": "cancelInvitation",
+        "parameters": [
+          {
+            "name": "organizationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "tokenId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "초대 취소 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OperatorListResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "OPERATOR_INVITATION_NOT_FOUND · 이미 수락·취소된 초대",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "OPERATOR_INVITATION_NOT_FOUND": {
+                    "summary": "OPERATOR_INVITATION_NOT_FOUND",
+                    "value": {
+                      "code": "OPERATOR_INVITATION_NOT_FOUND",
+                      "message": "취소할 수 있는 오퍼레이터 초대를 찾을 수 없습니다."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-readiness": "hold"
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "DisclosureScope": {
+        "type": "string",
+        "description": "리포트 공개 범위. SUMMARY(요약만) · PRIVATE(비공개) · FULL(전문)",
+        "enum": [
+          "SUMMARY",
+          "PRIVATE",
+          "FULL"
+        ]
+      },
+      "UpdateReportDisclosureRequest": {
+        "type": "object",
+        "description": "리포트 공개 범위 설정 요청.\n\n`scope`의 `PRIVATE`은 비공개 확정(withhold), `SUMMARY`·`FULL`은 공개(release)다.\n`SUMMARY`는 축별 서술과 교안 위치까지, `FULL`은 문답 원문까지 연다.",
+        "properties": {
+          "scope": {
+            "$ref": "#/components/schemas/DisclosureScope"
+          }
+        },
+        "required": [
+          "scope"
+        ]
+      },
+      "ReportDisclosureResponse": {
+        "type": "object",
+        "description": "리포트 공개 상태. `releaseStatus`가 판별자이고 나머지는 그 값에 딸린다.\n\n`scope`는 NOT_CONFIGURED이면 키가 없다. `publishedAt`은 발행 전이면, `releasedAt`은 RELEASED가\n아니면 마찬가지로 키가 없다 — null을 실어 보내지 않는다.",
+        "properties": {
+          "reportId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "리포트 식별자"
+          },
+          "assessmentRoundId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "어느 회차의 리포트인가"
+          },
+          "releaseStatus": {
+            "$ref": "#/components/schemas/TraineeReleaseStatus"
+          },
+          "scope": {
+            "$ref": "#/components/schemas/DisclosureScope"
+          },
+          "publishedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "발행 시각. 발행 전이면 키가 없다"
+          },
+          "releasedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "공개 처리 시각. RELEASED에서만 있다"
+          },
+          "bodyVisible": {
+            "type": "boolean",
+            "description": "교육생이 본문을 읽을 수 있는가"
+          },
+          "visibleFields": {
+            "$ref": "#/components/schemas/VisibleFields",
+            "description": "공개 범위별로 열리는 본문 필드"
+          }
+        }
+      },
+      "TraineeReleaseStatus": {
+        "type": "string",
+        "description": "교육생 리포트 공개 상태. NOT_CONFIGURED(공개 범위 미지정) · WITHHELD(비공개) · RELEASED(공개)",
+        "enum": [
+          "NOT_CONFIGURED",
+          "WITHHELD",
+          "RELEASED"
+        ]
+      },
+      "VisibleFields": {
+        "type": "object",
+        "description": "공개 범위별 본문 필드 노출 여부",
+        "properties": {
+          "said": {
+            "type": "boolean"
+          },
+          "curriculumRef": {
+            "type": "boolean"
+          },
+          "qa": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "curriculumRef",
+          "qa",
+          "said"
+        ]
+      },
+      "AiTier": {
+        "type": "string",
+        "description": "AI 모델 티어. ACCURACY_FIRST(정확도 우선) · BALANCED(균형) · COST_FIRST(비용 우선)",
+        "enum": [
+          "ACCURACY_FIRST",
+          "BALANCED",
+          "COST_FIRST"
+        ]
+      },
+      "UpdateTierModelRequest": {
+        "type": "object",
+        "description": "티어 ↔ 모델 매핑 변경 요청",
+        "properties": {
+          "featureCode": {
+            "type": "string",
+            "description": "적용 기능. v07 기준 티어 선택 대상은 CODE_SESSION 하나뿐이다.",
+            "enum": [
+              "CODE_SESSION"
+            ],
+            "example": "CODE_SESSION"
+          },
+          "tierCode": {
+            "$ref": "#/components/schemas/AiTier"
+          },
+          "modelId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "이 (기능, 티어)가 사용할 ai_model.model_id"
+          },
+          "changeReason": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "변경 사유",
+            "example": "비용 최적화"
+          }
+        },
+        "required": [
+          "featureCode",
+          "modelId",
+          "tierCode"
+        ]
+      },
+      "CalibrationProgress": {
+        "type": "object",
+        "description": "기관별 재캘리브레이션 진행 현황",
+        "properties": {
+          "totalOrganizations": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pending": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "running": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "succeeded": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "failed": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "completionRate": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "완료율(0~1). 대상 기관이 0이면 null",
+            "example": 0.75
+          }
+        },
+        "required": [
+          "completionRate",
+          "failed",
+          "pending",
+          "running",
+          "succeeded",
+          "totalOrganizations"
+        ]
+      },
+      "CalibrationSummary": {
+        "type": "object",
+        "description": "캘리브레이션 버전 요약",
+        "properties": {
+          "calibrationVersionId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "versionCode": {
+            "type": "string",
+            "description": "화면·비교에 쓰는 불변 버전 코드",
+            "example": "CAL_2026_08_V1"
+          },
+          "status": {
+            "type": "string",
+            "description": "PENDING / RUNNING / ACTIVE / FAILED / SUPERSEDED"
+          },
+          "startedAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "재캘리브레이션 시작 시각. PENDING이면 null"
+          },
+          "completedAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "재캘리브레이션 완료 시각. 끝나지 않았으면 null"
+          },
+          "progress": {
+            "description": "기관별 진행 현황. 목업 확인 모달의 `전 기관 재캘리브레이션` 진행률에 쓴다.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/CalibrationProgress"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "calibrationVersionId",
+          "completedAt",
+          "progress",
+          "startedAt",
+          "status",
+          "versionCode"
+        ]
+      },
+      "GradingPolicy": {
+        "type": "object",
+        "description": "채점 모델 정책 (플랫폼 고정)",
+        "properties": {
+          "gradingPolicyId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "policyVersion": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "modelId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "modelDisplayName": {
+            "type": "string",
+            "description": "모델 표시명",
+            "example": "claude-opus-5"
+          },
+          "modelCode": {
+            "type": "string",
+            "description": "모델 코드",
+            "example": "CLAUDE_OPUS_5"
+          },
+          "effectiveFrom": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "changeReason": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "변경 사유"
+          },
+          "activeCalibration": {
+            "description": "현재 결과 비교의 기준이 되는 캘리브레이션 버전. 재캘리브레이션이 진행 중이면\nactiveCalibration은 이전 버전이고 runningCalibration에 진행 중 버전이 담긴다.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/CalibrationSummary"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "runningCalibration": {
+            "description": "진행 중인 재캘리브레이션. 없으면 null",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/CalibrationSummary"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "activeCalibration",
+          "changeReason",
+          "effectiveFrom",
+          "gradingPolicyId",
+          "modelCode",
+          "modelDisplayName",
+          "modelId",
+          "policyVersion",
+          "runningCalibration"
+        ]
+      },
+      "ModelPricing": {
+        "type": "object",
+        "description": "모델별 단가",
+        "properties": {
+          "modelId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "modelCode": {
+            "type": "string"
+          },
+          "modelDisplayName": {
+            "type": "string"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "description": "모델 사용 가능 상태. ACTIVE / INACTIVE"
+          },
+          "inputPricePerMillionTokens": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "100만 토큰당 입력 단가. 미설정이면 null",
+            "example": 5
+          },
+          "outputPricePerMillionTokens": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "100만 토큰당 출력 단가. 미설정이면 null",
+            "example": 25
+          },
+          "cachedInputPricePerMillionTokens": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "100만 토큰당 캐시 입력 단가. 미설정이면 null"
+          },
+          "currencyCode": {
+            "type": "string",
+            "description": "단가 통화. 플랫폼 공통 USD",
+            "example": "USD"
+          },
+          "pricingMissing": {
+            "type": "boolean",
+            "description": "단가 미설정 여부. true면 이 모델의 호출 비용을 계산할 수 없고,\n사용량 집계에서도 0으로 더하지 않고 제외된다\n(목업: \"0으로 합산하면 청구액이 실제보다 작아 보인다\")."
+          },
+          "priceEffectiveFrom": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "단가 적용 시작 시각. 단가 미설정이면 null"
+          },
+          "priceUpdatedAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "단가 최종 수정 시각. 단가 미설정이면 null"
+          }
+        },
+        "required": [
+          "cachedInputPricePerMillionTokens",
+          "currencyCode",
+          "inputPricePerMillionTokens",
+          "modelCode",
+          "modelDisplayName",
+          "modelId",
+          "outputPricePerMillionTokens",
+          "priceEffectiveFrom",
+          "priceUpdatedAt",
+          "pricingMissing",
+          "provider",
+          "status"
+        ]
+      },
+      "PlatformModelSettingResponse": {
+        "type": "object",
+        "description": "플랫폼 모델·단가 설정 (SA-03 ① 모델·단가 탭)",
+        "properties": {
+          "gradingPolicy": {
+            "$ref": "#/components/schemas/GradingPolicy",
+            "description": "채점 모델 정책. 전 기관 공통이며 기관이 바꿀 수 없다."
+          },
+          "tierMappings": {
+            "type": "array",
+            "description": "기능별 티어 ↔ 모델 매핑. 기관은 티어 이름만 고르고 실제 모델은 이 매핑이 정한다.\n모델이 단종되면 이 매핑만 바꾸면 되므로 기관 쪽에서 할 일이 없다.",
+            "items": {
+              "$ref": "#/components/schemas/TierMapping"
+            }
+          },
+          "modelPricings": {
+            "type": "array",
+            "description": "모델별 단가 목록. 단가 미설정 모델도 포함되며 pricingMissing=true로 표시된다.",
+            "items": {
+              "$ref": "#/components/schemas/ModelPricing"
+            }
+          }
+        },
+        "required": [
+          "gradingPolicy",
+          "modelPricings",
+          "tierMappings"
+        ]
+      },
+      "TierMapping": {
+        "type": "object",
+        "description": "기능 × 티어 → 모델 매핑 한 줄",
+        "properties": {
+          "tierPolicyId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "featureCode": {
+            "type": "string",
+            "description": "적용 기능. v07 기준 티어 선택 대상은 CODE_SESSION(코드 세션) 하나뿐이다.",
+            "example": "CODE_SESSION"
+          },
+          "tierCode": {
+            "$ref": "#/components/schemas/AiTier"
+          },
+          "modelId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "modelDisplayName": {
+            "type": "string"
+          },
+          "modelCode": {
+            "type": "string"
+          },
+          "policyVersion": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "effectiveFrom": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "effectiveFrom",
+          "featureCode",
+          "modelCode",
+          "modelDisplayName",
+          "modelId",
+          "policyVersion",
+          "tierCode",
+          "tierPolicyId"
+        ]
+      },
+      "UpdateModelPricingRequest": {
+        "type": "object",
+        "description": "모델 단가 수정 요청",
+        "properties": {
+          "inputPricePerMillionTokens": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "100만 토큰당 입력 단가. null이면 단가 미설정으로 되돌린다.\n0은 '무료'를 의미하므로 미설정 용도로 쓰지 말 것.",
+            "example": 5,
+            "minimum": 0
+          },
+          "outputPricePerMillionTokens": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "100만 토큰당 출력 단가. null이면 단가 미설정.",
+            "example": 25,
+            "minimum": 0
+          },
+          "cachedInputPricePerMillionTokens": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "100만 토큰당 캐시 입력 단가. 선택.",
+            "example": 0.5,
+            "minimum": 0
+          },
+          "priceUnitTokenCount": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "단가의 기준 토큰 수. 생략하면 1,000,000을 사용한다.\n공급자가 다른 기준으로 고지하는 경우에만 바꾼다.",
+            "example": 1000000
+          },
+          "pricePairConsistent": {
+            "type": "boolean"
+          },
+          "cachedPriceConsistent": {
+            "type": "boolean"
+          }
+        }
+      },
+      "UpdateGradingModelRequest": {
+        "type": "object",
+        "description": "채점 모델 변경 요청 (전 기관 재캘리브레이션 유발)",
+        "properties": {
+          "modelId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "새 채점 논리 모델의 ai_model.model_id"
+          },
+          "calibrationVersionCode": {
+            "type": "string",
+            "description": "새로 만들 캘리브레이션 버전 코드. 화면·결과 비교에서 이 코드로 버전을 구분한다.\n영문 대문자로 시작하고 대문자·숫자·밑줄만 쓸 수 있다.",
+            "example": "CAL_2026_08_V1",
+            "maxLength": 100,
+            "minLength": 0,
+            "pattern": "^[A-Z][A-Z0-9_]*$"
+          },
+          "changeReason": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "변경 사유. 감사·이력 확인용",
+            "example": "claude-opus-5 로 상향"
+          },
+          "acknowledgeRecalibration": {
+            "type": "boolean",
+            "description": "전 기관 재캘리브레이션이 발생하고 되돌릴 수 없음을 확인했다는 표시.\n**true가 아니면 400으로 거절한다** — 화면 확인 모달을 우회한 호출을 막기 위한 안전장치다.",
+            "example": true
+          },
+          "recalibrationAcknowledged": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "acknowledgeRecalibration",
+          "calibrationVersionCode",
+          "modelId"
+        ]
+      },
+      "OrganizationStatus": {
+        "type": "string",
+        "description": "기관 운영 상태. ACTIVE(활성) · SUSPENDED(정지) · DELETION_PENDING(삭제 예정) · DELETED(삭제됨). `예산 초과`·`오퍼레이터 미배정`은 저장 상태가 아니라 파생 배지다.",
+        "enum": [
+          "ACTIVE",
+          "SUSPENDED",
+          "DELETION_PENDING",
+          "DELETED"
+        ]
+      },
+      "UpdateOperationSettingRequest": {
+        "type": "object",
+        "description": "기관 운영 설정 변경 요청 (전체 치환).\n\n`organizationStatus`는 **ACTIVE 또는 SUSPENDED만** 직접 지정할 수 있다 — 그 외 값은 400이다.\n삭제 상태를 되돌리는 것은 이 API가 아니라 `POST /organizations/{organizationId}/restore`다.",
+        "properties": {
+          "organizationStatus": {
+            "$ref": "#/components/schemas/OrganizationStatus"
+          },
+          "monthlyAiBudget": {
+            "type": "number",
+            "description": "AI 월 예산 상한. 0은 무제한이 아니라 예산 0을 의미한다.",
+            "example": 600,
+            "minimum": 0
+          },
+          "monthlyTokenLimit": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "기관 월 토큰 한도. 넘으면 새 세션이 열리지 않는다. null이면 무제한이다.",
+            "example": 200000000
+          },
+          "storageLimitBytes": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "저장량 상한(바이트). null이면 무제한이다.",
+            "example": 107374182400
+          },
+          "dataRetentionDays": {
+            "type": "integer",
+            "format": "int32",
+            "description": "데이터 보존기간(일)",
+            "enum": [
+              "90",
+              "180",
+              "365"
+            ],
+            "example": 180
+          },
+          "defaultDisclosureScope": {
+            "$ref": "#/components/schemas/DisclosureScope"
+          },
+          "codeSessionTierCode": {
+            "$ref": "#/components/schemas/AiTier"
+          },
+          "allowManagerInvite": {
+            "type": "boolean",
+            "description": "신규 매니저 초대·재발송 허용 여부"
+          },
+          "allowDataExport": {
+            "type": "boolean",
+            "description": "신규 데이터 export 생성 허용 여부"
+          },
+          "allowZipSubmission": {
+            "type": "boolean",
+            "description": "ZIP 코드 제출 허용 여부. 끄면 GitHub 연동만 남는다."
+          },
+          "allowGithubIntegration": {
+            "type": "boolean",
+            "description": "GitHub 조직 연동 허용 여부. 이 값은 정책(허용 여부)이며 실제 연결/해제는 별도 연동 흐름이다."
+          },
+          "enableBigProjectContributionAnalysis": {
+            "type": "boolean",
+            "description": "빅프로젝트 기여도 분석 실행 허용 여부"
+          },
+          "mutableOrganizationStatus": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "allowDataExport",
+          "allowGithubIntegration",
+          "allowManagerInvite",
+          "allowZipSubmission",
+          "codeSessionTierCode",
+          "dataRetentionDays",
+          "defaultDisclosureScope",
+          "enableBigProjectContributionAnalysis",
+          "monthlyAiBudget",
+          "organizationStatus"
+        ]
+      },
+      "OperationSettingResponse": {
+        "type": "object",
+        "description": "기관 운영 설정 (SA-02 ④ 설정 탭).\n\n`organizationStatus`를 SUSPENDED로 두면 소속 오퍼레이터·매니저·교육생의 로그인이 막히고 데이터는 보존된다.\n`codeSessionTierCode`는 코드 세션 기능의 모델 티어이며, 기관은 티어 이름만 고르고 실제 모델은 플랫폼이 정한다(SA-03).\n`defaultDisclosureScope`는 신규 기수의 공개 범위 기본값이고 회차별 조정은 매니저가 한다.",
+        "properties": {
+          "organizationId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "organizationStatus": {
+            "$ref": "#/components/schemas/OrganizationStatus"
+          },
+          "monthlyAiBudget": {
+            "type": "number",
+            "description": "AI 월 예산 상한. 넘으면 `예산 초과` 배지와 경고가 붙지만 서비스 중단은 아니다."
+          },
+          "currencyCode": {
+            "type": "string",
+            "description": "예산 통화 코드. 플랫폼 공통 USD 고정이며 기관별로 바꿀 수 없다.",
+            "example": "USD"
+          },
+          "monthlyTokenLimit": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "기관 월 토큰 한도. 넘으면 새 세션이 열리지 않고, 진행 중 세션은 완료된 문제까지 저장하고 종료한다.\nnull이면 무제한이다.",
+            "example": 200000000
+          },
+          "storageLimitBytes": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "저장량 상한(바이트). null이면 무제한이다.",
+            "example": 107374182400
+          },
+          "dataRetentionDays": {
+            "type": "integer",
+            "format": "int32",
+            "description": "데이터 보존기간(일). 종료 기수의 코드·문답 원문·채점 근거 보관 기간, 경과분 파기"
+          },
+          "defaultDisclosureScope": {
+            "$ref": "#/components/schemas/DisclosureScope"
+          },
+          "codeSessionTierCode": {
+            "$ref": "#/components/schemas/AiTier"
+          },
+          "allowManagerInvite": {
+            "type": "boolean",
+            "description": "신규 매니저 초대·재발송 허용 여부."
+          },
+          "allowDataExport": {
+            "type": "boolean",
+            "description": "신규 데이터 export 생성 허용 여부."
+          },
+          "allowZipSubmission": {
+            "type": "boolean",
+            "description": "ZIP 코드 제출 허용 여부. 끄면 GitHub 연동만 남는다."
+          },
+          "allowGithubIntegration": {
+            "type": "boolean",
+            "description": "GitHub 조직 연동 허용 여부. 이 값은 <b>정책(허용 여부)</b>이고,\n실제 연결 상태는 organization_github_integration이 따로 관리한다."
+          },
+          "enableBigProjectContributionAnalysis": {
+            "type": "boolean",
+            "description": "빅프로젝트 기여도 분석(커밋 기준) 실행 허용 여부. 미니프로젝트는 대상이 아니다."
+          },
+          "policyVersion": {
+            "type": "integer",
+            "format": "int32",
+            "description": "이 설정이 속한 정책 버전. organization_policy는 append-only 이력이라 변경할 때마다 올라간다."
+          }
+        },
+        "required": [
+          "allowDataExport",
+          "allowGithubIntegration",
+          "allowManagerInvite",
+          "allowZipSubmission",
+          "codeSessionTierCode",
+          "currencyCode",
+          "dataRetentionDays",
+          "defaultDisclosureScope",
+          "enableBigProjectContributionAnalysis",
+          "monthlyAiBudget",
+          "monthlyTokenLimit",
+          "organizationId",
+          "organizationStatus",
+          "policyVersion",
+          "storageLimitBytes"
+        ]
+      },
+      "InviteSuperAdminRequest": {
+        "type": "object",
+        "description": "슈퍼어드민 초대 요청 (이메일만)",
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email",
+            "description": "초대할 슈퍼어드민 이메일",
+            "example": "sera@iz-get.com",
+            "maxLength": 320,
+            "minLength": 0
+          }
+        },
+        "required": [
+          "email"
+        ]
+      },
+      "InviteSuperAdminResponse": {
+        "type": "object",
+        "description": "슈퍼어드민 초대 결과 (SA-03 ② 계정 초대). `status`는 수락 전까지 PENDING(목업 `초대됨`)이다.",
+        "properties": {
+          "memberId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "생성된 계정 자리 식별자"
+          },
+          "email": {
+            "type": "string",
+            "description": "초대 메일 수신 이메일"
+          },
+          "status": {
+            "$ref": "#/components/schemas/OperatorAccountStatus"
+          },
+          "invitedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "초대 원장과 최초 토큰을 생성한 시각"
+          },
+          "accounts": {
+            "$ref": "#/components/schemas/SuperAdminListResponse",
+            "description": "초대 반영 후의 슈퍼어드민 계정 목록 전체. deactivatable 플래그가 함께 갱신되므로 표를 그대로 다시 그릴 수 있다."
+          }
+        },
+        "required": [
+          "accounts",
+          "email",
+          "invitedAt",
+          "memberId",
+          "status"
+        ]
+      },
+      "OperatorAccountStatus": {
+        "type": "string",
+        "description": "오퍼레이터·슈퍼어드민 계정 상태. ACTIVE(활성) · PENDING(초대됨, 수락 전) · INACTIVE(정지·퇴사). v06에서 LOCKED는 폐지됐다 — 로그인 연속 실패로 인한 일시 차단은 상태가 아니라 login_blocked_until 시각이다.",
+        "enum": [
+          "PENDING",
+          "ACTIVE",
+          "INACTIVE"
+        ]
+      },
+      "SuperAdmin": {
+        "type": "object",
+        "description": "슈퍼어드민 계정",
+        "properties": {
+          "memberId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "이름. 초대만 되고 활성화 전이면 null"
+          },
+          "email": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/OperatorAccountStatus"
+          },
+          "lastLoginAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "최근 로그인 시각. 한 번도 로그인하지 않았으면 null"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "deactivatable": {
+            "type": "boolean",
+            "description": "이 계정을 정지할 수 있는지. 활성 슈퍼어드민이 1명뿐이면 그 계정은 false다\n(목업: \"마지막 한 명은 정지할 수 없다\")."
+          }
+        },
+        "required": [
+          "createdAt",
+          "deactivatable",
+          "email",
+          "lastLoginAt",
+          "memberId",
+          "name",
+          "status"
+        ]
+      },
+      "SuperAdminListResponse": {
+        "type": "object",
+        "description": "슈퍼어드민 계정 목록 (SA-03 ② 슈퍼어드민 계정 탭)",
+        "properties": {
+          "content": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SuperAdmin"
+            }
+          },
+          "activeCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "활성 슈퍼어드민 수. 1이면 그 계정은 정지할 수 없다 —\n정지하면 플랫폼에 들어갈 사람이 아무도 없어지고, 풀어 줄 상위 권한이 존재하지 않는다."
+          }
+        },
+        "required": [
+          "activeCount",
+          "content"
+        ]
+      },
+      "CreateOrganizationRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "기관명",
+            "example": "코드베이스 아카데미",
+            "minLength": 1
+          },
+          "emailDomain": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "초대 허용 이메일 도메인. 이 도메인 밖 주소로는 계정 초대를 보낼 수 없다.\n비우면 도메인 제한을 적용하지 않는다.",
+            "example": "codebase.ac.kr",
+            "pattern": "^(?=.{1,253}$)([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\\.)+[a-zA-Z]{2,63}$"
+          },
+          "slug": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "URL·외부 연동에 쓰는 짧은 기관 식별값(`/admin/orgs/greencompany`). 비우면 저장하지 않는다.\n소문자·숫자와 하이픈만 허용하며 전체에서 유일해야 한다.",
+            "example": "codebase-academy",
+            "maxLength": 64,
+            "minLength": 0,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$"
+          },
+          "displayCode": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "화면 표시용 기관 코드(`ORG_GRN_4F21`). 권한·테넌트 판정에는 사용하지 않는다.",
+            "example": "ORG_CODEBASE",
+            "maxLength": 32,
+            "minLength": 0,
+            "pattern": "^[A-Z][A-Z0-9_]*$"
+          },
+          "dataRetentionDays": {
+            "type": "integer",
+            "format": "int32",
+            "description": "데이터 보존기간(일). 종료 기수의 코드·문답·채점 근거 보관 기간",
+            "enum": [
+              "90",
+              "180",
+              "365"
+            ],
+            "example": 180
+          }
+        },
+        "required": [
+          "dataRetentionDays",
+          "name"
+        ]
+      },
+      "CohortCounts": {
+        "type": "object",
+        "description": "기수 수 분해. 목업 `기수 3 (진행 2 · 종료 1)`",
+        "properties": {
+          "total": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "running": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "closed": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "required": [
+          "closed",
+          "running",
+          "total"
+        ]
+      },
+      "Operator": {
+        "type": "object",
+        "description": "오퍼레이터 계정 요약",
+        "properties": {
+          "memberId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "email",
+          "memberId",
+          "name"
+        ]
+      },
+      "OrganizationResponse": {
+        "type": "object",
+        "description": "기관 정보 (SA-01 목록 행 / SA-02 상세 개요 공용)",
+        "properties": {
+          "organizationId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "slug": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "URL·외부 연동에 쓰는 기관 slug(예: greencompany). 지정하지 않은 기관은 null.",
+            "example": "greencompany"
+          },
+          "displayCode": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "화면 표시용 짧은 코드(예: ORG_GRN_4F21). 권한·테넌트 판정에는 쓰지 않는다. 미지정이면 null.",
+            "example": "ORG_GRN_4F21"
+          },
+          "name": {
+            "type": "string"
+          },
+          "emailDomain": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "초대 허용 이메일 도메인(예: codebase.ac.kr). 이 도메인 밖 주소로는 오퍼레이터를 초대할 수 없다.\nnull이면 도메인 제한을 적용하지 않는다.",
+            "example": "codebase.ac.kr"
+          },
+          "status": {
+            "$ref": "#/components/schemas/OrganizationStatus"
+          },
+          "operatorUnassigned": {
+            "type": "boolean",
+            "description": "파생 배지: 활성 오퍼레이터가 0명이라 기관이 아직 시작되지 않은 상태(목업 `오퍼레이터 미배정`).\n저장 상태가 아니므로 status는 그대로 ACTIVE다."
+          },
+          "budgetExceeded": {
+            "type": "boolean",
+            "description": "파생 배지: 이번 달 AI 비용이 월 예산을 초과한 상태(목업 `예산 초과`). 서비스 중단은 아니다.\n저장 상태가 아니므로 status는 그대로 ACTIVE다."
+          },
+          "operators": {
+            "type": "array",
+            "description": "기관 소속 오퍼레이터 계정. 목록의 `박지현 외 1`, 상세의 `박지현 · 이도윤`을 렌더링한다.",
+            "items": {
+              "$ref": "#/components/schemas/Operator"
+            }
+          },
+          "cohorts": {
+            "$ref": "#/components/schemas/CohortCounts",
+            "description": "기수 수(전체/진행/종료)"
+          },
+          "traineeCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "activeSessionCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "진행 중 세션 수. 시작됐고 아직 끝나지 않은 세션(IN_PROGRESS·PAUSED)만 센다."
+          },
+          "currentMonthAiCost": {
+            "type": "number"
+          },
+          "monthlyAiBudget": {
+            "type": "number",
+            "description": "활성 정책의 월 AI 예산. 상세 개요의 `예산 $600 대비 69%` 계산에 쓴다."
+          },
+          "budgetUsageRate": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "예산 소진율(0~1). 예산이 0이면 null."
+          },
+          "currencyCode": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "통화. 플랫폼 공통 USD. 활성 정책이 없으면 null"
+          },
+          "dataRetentionDays": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "defaultDisclosureScope": {
+            "description": "신규 기수 공개 범위 기본값. 활성 정책이 없으면 null",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/DisclosureScope"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "deletedAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "soft-delete 시각. 살아 있는 기관은 null"
+          }
+        },
+        "required": [
+          "activeSessionCount",
+          "budgetExceeded",
+          "budgetUsageRate",
+          "cohorts",
+          "createdAt",
+          "currencyCode",
+          "currentMonthAiCost",
+          "dataRetentionDays",
+          "defaultDisclosureScope",
+          "deletedAt",
+          "displayCode",
+          "emailDomain",
+          "monthlyAiBudget",
+          "name",
+          "operatorUnassigned",
+          "operators",
+          "organizationId",
+          "slug",
+          "status",
+          "traineeCount"
+        ]
+      },
+      "PurgeOrganizationResponse": {
+        "type": "object",
+        "description": "기관 파기 요청 접수 결과",
+        "properties": {
+          "organizationId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "deletedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "soft-delete 시각"
+          },
+          "retentionUntil": {
+            "type": "string",
+            "format": "date-time",
+            "description": "보존기간 종료(파기 가능) 시각"
+          },
+          "requestedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "파기 요청 접수 시각"
+          },
+          "purged": {
+            "type": "boolean",
+            "description": "실제 데이터 파기 진행 여부.\n⚠ 현재는 항상 false — 보존기간 검증(RETENTION_NOT_MET)까지만 구현돼 있고,\n테넌트 데이터 전체를 지우는 파기 배치는 아직 연결되지 않았습니다."
+          },
+          "message": {
+            "type": "string",
+            "description": "운영자에게 보여줄 안내 문구"
+          }
+        },
+        "required": [
+          "deletedAt",
+          "message",
+          "organizationId",
+          "purged",
+          "requestedAt",
+          "retentionUntil"
+        ]
+      },
+      "InviteOperatorRequest": {
+        "type": "object",
+        "description": "오퍼레이터 초대 요청 (이메일만)",
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email",
+            "description": "초대할 오퍼레이터 이메일",
+            "example": "choi@green.com",
+            "maxLength": 320,
+            "minLength": 0
+          }
+        },
+        "required": [
+          "email"
+        ]
+      },
+      "InviteOperatorResponse": {
+        "type": "object",
+        "description": "오퍼레이터 초대 결과. `status`는 수락 전까지 PENDING(목업 `초대됨`)이다.",
+        "properties": {
+          "organizationId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "memberId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "email": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/OperatorAccountStatus"
+          },
+          "invitedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "email",
+          "invitedAt",
+          "memberId",
+          "organizationId",
+          "status"
+        ]
+      },
+      "OperatorListResponse": {
+        "type": "object",
+        "description": "기관 오퍼레이터 계정 목록 (SA-02 ② 오퍼레이터 탭)",
+        "properties": {
+          "organizationId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "activeCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "활성 오퍼레이터 수. 0이면 기관이 아직 시작되지 않은 상태(`오퍼레이터 미배정`)"
+          },
+          "content": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Operator"
+            }
+          }
+        },
+        "required": [
+          "activeCount",
+          "content",
+          "organizationId"
+        ]
+      },
+      "InviteManagerRequest": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email",
+            "description": "초대 대상 이메일",
+            "example": "manager@example.com",
+            "maxLength": 320,
+            "minLength": 0
+          },
+          "cohortId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "담당할 기수 ID. 매니저 초대에서는 필수입니다. 반 배정은 초대 시점에 하지 않으며, 가입 후 반 편성 화면에서 따로 배정합니다.",
+            "example": "UUID"
+          }
+        },
+        "required": [
+          "email"
+        ]
+      },
+      "AccountStatus": {
+        "type": "string",
+        "description": "계정 상태. INVITED(초대됨) · ACTIVE(활성) · LOCKED(잠김) · INACTIVE(정지)",
+        "enum": [
+          "INVITED",
+          "ACTIVE",
+          "LOCKED",
+          "INACTIVE"
+        ]
+      },
+      "InviteManagerResponse": {
+        "type": "object",
+        "description": "오퍼레이터·매니저 초대 발송 결과. 초대 메일 발송 성공은 계정 활성화 완료를 의미하지 않습니다.\n\n`role`은 초대 경로별로 고정됩니다 — 매니저 초대는 MANAGER, 오퍼레이터 초대는 OPERATOR입니다.\n`status`는 발송 직후라 항상 INVITED입니다.",
+        "properties": {
+          "memberId": {
+            "type": "string",
+            "description": "초대 대상 계정 식별자",
+            "example": "UUID"
+          },
+          "email": {
+            "type": "string",
+            "description": "초대 메일 수신 이메일",
+            "example": "manager@example.com"
+          },
+          "role": {
+            "$ref": "#/components/schemas/Role"
+          },
+          "status": {
+            "$ref": "#/components/schemas/AccountStatus"
+          },
+          "invitedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "초대 원장과 최초 토큰을 생성한 시각",
+            "example": "2026-08-02T12:00:00Z"
+          }
+        },
+        "required": [
+          "email",
+          "invitedAt",
+          "memberId",
+          "role",
+          "status"
+        ]
+      },
+      "Role": {
+        "type": "string",
+        "description": "계정 역할. SUPER_ADMIN · OPERATOR · MANAGER · TRAINEE",
+        "enum": [
+          "SUPER_ADMIN",
+          "OPERATOR",
+          "MANAGER",
+          "TRAINEE"
+        ]
+      },
+      "CreateCohortRequest": {
+        "type": "object",
+        "description": "기수 생성 요청",
+        "properties": {
+          "organizationId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "기수를 개설할 기관 ID. 액세스 토큰의 기관과 다르면 403",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "name": {
+            "type": "string",
+            "description": "기수명. 같은 기관 안에서 중복되면 409",
+            "example": "7기",
+            "minLength": 1
+          },
+          "startDate": {
+            "type": "string",
+            "format": "date",
+            "description": "기수 시작일. endDate보다 늦으면 400",
+            "example": "2026-03-02"
+          },
+          "endDate": {
+            "type": "string",
+            "format": "date",
+            "description": "기수 종료일. startDate보다 빠르면 400",
+            "example": "2026-08-28"
+          },
+          "initialTrainees": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "description": "⚠ 요청에 넣어도 저장되지 않는다. 교육생 등록은 POST /cohorts/{cohortId}/trainees(CSV) 또는 .../trainees/invitations(직접 입력)로 별도 처리한다.",
+            "items": {
+              "$ref": "#/components/schemas/InitialTrainee"
+            }
+          }
+        },
+        "required": [
+          "endDate",
+          "name",
+          "organizationId",
+          "startDate"
+        ]
+      },
+      "InitialTrainee": {
+        "type": "object",
+        "description": "초기 교육생 한 명(⚠ 현재 서버가 사용하지 않음)",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "교육생 이름",
+            "minLength": 1
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "description": "교육생 이메일",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "email",
+          "name"
+        ]
+      },
+      "CohortResponse": {
+        "type": "object",
+        "description": "기수 정보",
+        "properties": {
+          "cohortId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "기수 ID"
+          },
+          "organizationId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "소속 기관 ID"
+          },
+          "name": {
+            "type": "string",
+            "description": "기수명",
+            "example": "7기"
+          },
+          "status": {
+            "$ref": "#/components/schemas/CohortStatus"
+          },
+          "startDate": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date",
+            "description": "기수 시작일"
+          },
+          "endDate": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date",
+            "description": "기수 종료일"
+          },
+          "traineeCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "⚠ 아직 채워지지 않는 값 — 항상 0이다. member 도메인 조인이 필요해 아직 연결되지 않았다.",
+            "example": 0
+          },
+          "managers": {
+            "type": "array",
+            "description": "⚠ 아직 채워지지 않는 값 — 항상 빈 배열이다. classroom 도메인 조인이 필요해 아직 연결되지 않았다. 담당 매니저가 필요하면 GET /cohorts/{cohortId}/classrooms를 함께 호출한다.",
+            "items": {
+              "$ref": "#/components/schemas/Manager"
+            }
+          }
+        },
+        "required": [
+          "cohortId",
+          "endDate",
+          "managers",
+          "name",
+          "organizationId",
+          "startDate",
+          "status",
+          "traineeCount"
+        ]
+      },
+      "CohortStatus": {
+        "type": "string",
+        "description": "기수 진행 상태. PLANNED(개설 예정) · RUNNING(진행 중) · CLOSED(종료)",
+        "enum": [
+          "PLANNED",
+          "RUNNING",
+          "CLOSED"
+        ]
+      },
+      "Manager": {
+        "type": "object",
+        "description": "담당 매니저 한 명(현재 미사용 — 항상 빈 배열로 내려감)",
+        "properties": {
+          "memberId": {
+            "type": "integer",
+            "format": "int64",
+            "description": "매니저의 회원 ID"
+          },
+          "name": {
+            "type": "string",
+            "description": "매니저 이름"
+          }
+        },
+        "required": [
+          "memberId",
+          "name"
+        ]
+      },
+      "Failure": {
+        "type": "object",
+        "description": "입력 행별 실패 정보",
+        "properties": {
+          "row": {
+            "type": "integer",
+            "format": "int32",
+            "description": "CSV는 헤더를 포함한 실제 행 번호, 직접 입력은 1부터 시작하는 배열 순번",
+            "example": 4
+          },
+          "email": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "해당 행에 입력된 이메일",
+            "example": "invalid-email"
+          },
+          "status": {
+            "type": "integer",
+            "format": "int32",
+            "description": "실패 상태: 1=유효하지 않은 이메일 형식, 2=요청 내부 중복 이메일, 3=기관에 이미 존재하는 교육생 역할 이메일 계정",
+            "enum": [
+              "1",
+              "2",
+              "3"
+            ],
+            "example": 1
+          }
+        },
+        "required": [
+          "email",
+          "row",
+          "status"
+        ]
+      },
+      "RegisterTraineesResponse": {
+        "type": "object",
+        "description": "교육생 일괄 등록·초대 처리 결과",
+        "properties": {
+          "requestedCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "처리 대상으로 받은 전체 교육생 행 수",
+            "example": 3
+          },
+          "registeredCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "PENDING 계정·기수 소속·초대 원장·토큰 등록에 성공한 교육생 수",
+            "example": 2
+          },
+          "invitationSentCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "초대 메일 발송과 초대 상태 SENT 전환이 완료된 교육생 수. 계정 활성화 수가 아닙니다.",
+            "example": 2
+          },
+          "failures": {
+            "type": "array",
+            "description": "수정 또는 재처리가 필요한 입력 행별 실패 목록",
+            "items": {
+              "$ref": "#/components/schemas/Failure"
+            }
+          }
+        },
+        "required": [
+          "failures",
+          "invitationSentCount",
+          "registeredCount",
+          "requestedCount"
+        ]
+      },
+      "RegisterTraineesRequest": {
+        "type": "object",
+        "properties": {
+          "trainees": {
+            "type": "array",
+            "description": "직접 입력으로 등록·초대할 교육생 목록. 각 행은 독립적으로 처리됩니다.",
+            "items": {
+              "$ref": "#/components/schemas/Trainee"
+            },
+            "minItems": 1
+          }
+        },
+        "required": [
+          "trainees"
+        ]
+      },
+      "Trainee": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "교육생 명단에 저장할 필수 이름",
+            "example": "홍길동",
+            "maxLength": 200,
+            "minLength": 0
+          },
+          "email": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "교육생 로그인·초대 이메일. 형식·요청 내부 중복·기존 기관 계정을 행별 검증합니다.",
+            "example": "trainee@example.com"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      },
+      "CreateClassroomRequest": {
+        "type": "object",
+        "description": "반 생성 요청",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "반 이름. 같은 기수 안에서 중복되면 409",
+            "example": "1반",
+            "minLength": 1
+          },
+          "capacity": {
+            "type": "integer",
+            "format": "int32",
+            "description": "정원. 1 이상이어야 하며, 배정 인원이 이 값을 넘어도 서버가 막지는 않는다(표시용 값)",
+            "example": 20,
+            "minimum": 1
+          },
+          "managerIds": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "description": "담당 매니저로 지정할 사용자 ID 목록. ⚠ 지금은 서버가 사용하지 않는다 — 담당 매니저 지정은 PATCH .../managers로 별도 호출해야 한다. 생략하거나 빈 배열을 보내도 무방하다.",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        },
+        "required": [
+          "capacity",
+          "name"
+        ]
+      },
+      "ClassroomResponse": {
+        "type": "object",
+        "description": "반 정보",
+        "properties": {
+          "classroomId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "반 ID"
+          },
+          "cohortId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "소속 기수 ID"
+          },
+          "name": {
+            "type": "string",
+            "description": "반 이름",
+            "example": "1반"
+          },
+          "managers": {
+            "type": "array",
+            "description": "담당 매니저 목록. 매니저가 하나도 없으면 빈 배열",
+            "items": {
+              "$ref": "#/components/schemas/Manager"
+            }
+          },
+          "traineeCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "현재 이 반에 소속된 교육생 수"
+          },
+          "managerAssignmentRequired": {
+            "type": "boolean",
+            "description": "담당 매니저가 없으면 true — 화면의 `매니저 미배정` 표시 근거"
+          }
+        },
+        "required": [
+          "classroomId",
+          "cohortId",
+          "managerAssignmentRequired",
+          "managers",
+          "name",
+          "traineeCount"
+        ]
+      },
+      "TraineeActivationRequest": {
+        "type": "object",
+        "properties": {
+          "user_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "초대 토큰 해석 응답의 PENDING 교육생 사용자 ID",
+            "example": "UUID"
+          },
+          "invitationToken": {
+            "type": "string",
+            "description": "INVITE_TRAINEE 초대 링크의 현재 일회용 원문 토큰",
+            "example": "invitation-token",
+            "maxLength": 512,
+            "minLength": 0
+          },
+          "password": {
+            "type": "string",
+            "description": "영문·숫자·특수문자를 포함한 8~64자 비밀번호",
+            "example": "Password1!",
+            "maxLength": 64,
+            "minLength": 8,
+            "pattern": "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[^A-Za-z0-9]).{8,}$"
+          },
+          "passwordConfirmation": {
+            "type": "string",
+            "description": "비밀번호와 동일하게 입력하는 확인 값",
+            "example": "Password1!",
+            "maxLength": 64,
+            "minLength": 0
+          },
+          "serviceTermsAgreed": {
+            "type": "boolean",
+            "description": "서비스 이용약관 필수 동의 여부",
+            "example": true
+          },
+          "privacyCollectionAgreed": {
+            "type": "boolean",
+            "description": "개인정보 수집 필수 동의 여부",
+            "example": true
+          },
+          "aiAnalysisAgreed": {
+            "type": "boolean",
+            "description": "AI 분석 필수 동의 여부",
+            "example": true
+          },
+          "organizationSharingAgreed": {
+            "type": "boolean",
+            "description": "기관 공유 필수 동의 여부",
+            "example": true
+          },
+          "anonymousImprovementAgreed": {
+            "type": "boolean",
+            "description": "익명 데이터 서비스 개선 선택 동의 여부. 유일한 선택 항목이라 생략하면 미동의로 처리한다.",
+            "example": false
+          }
+        },
+        "required": [
+          "aiAnalysisAgreed",
+          "invitationToken",
+          "organizationSharingAgreed",
+          "password",
+          "passwordConfirmation",
+          "privacyCollectionAgreed",
+          "serviceTermsAgreed",
+          "user_id"
+        ]
+      },
+      "ActivateAccountResponse": {
+        "type": "object",
+        "description": "초대 수락과 계정 활성화 결과. `role`은 이 흐름에서 OPERATOR·MANAGER·TRAINEE 중 하나다.",
+        "properties": {
+          "user_id": {
+            "type": "string",
+            "description": "활성화된 사용자 ID",
+            "example": "UUID"
+          },
+          "email": {
+            "type": "string",
+            "description": "초대 링크로 소유 확인된 로그인 이메일",
+            "example": "user@example.com"
+          },
+          "name": {
+            "type": "string",
+            "description": "활성화된 계정의 표시 이름",
+            "example": "홍길동"
+          },
+          "role": {
+            "$ref": "#/components/schemas/Role"
+          },
+          "activated": {
+            "type": "boolean",
+            "description": "계정·동의·초대 수락·토큰 사용 처리가 모두 완료되었는지 여부",
+            "example": true
+          }
+        },
+        "required": [
+          "activated",
+          "email",
+          "name",
+          "role"
+        ]
+      },
+      "RefreshTokenResponse": {
+        "type": "object",
+        "description": "재발급된 액세스 토큰. **역할·이름은 담기지 않는다** — 새로고침 후 세션을 복원할 때는\n이 호출 뒤에 `GET /members/me`를 부른다.",
+        "properties": {
+          "accessToken": {
+            "type": "string"
+          },
+          "accessTokenExpiresIn": {
+            "type": "integer",
+            "format": "int64",
+            "description": "만료까지 남은 시간. **단위는 밀리초(ms)**다 — 1시간이면 3600000이다. 만료 시각은 `Date.now() + accessTokenExpiresIn`이다.",
+            "example": 3600000
+          }
+        },
+        "required": [
+          "accessToken",
+          "accessTokenExpiresIn"
+        ]
+      },
+      "PasswordResetValidationRequest": {
+        "type": "object",
+        "properties": {
+          "token": {
+            "type": "string",
+            "description": "메일 링크에 담긴 원문 토큰. 서버에는 해시만 저장됩니다.",
+            "example": "password-reset-token",
+            "maxLength": 512,
+            "minLength": 0
+          }
+        },
+        "required": [
+          "token"
+        ]
+      },
+      "PasswordResetValidationResponse": {
+        "type": "object",
+        "description": "아직 사용할 수 있는 비밀번호 재설정 토큰의 확인 결과",
+        "properties": {
+          "email": {
+            "type": "string",
+            "description": "재설정 대상 이메일이며 읽기 전용으로 표시한다",
+            "example": "user@example.com"
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "이 토큰이 만료되는 시각"
+          }
+        },
+        "required": [
+          "email",
+          "expiresAt"
+        ]
+      },
+      "PasswordResetRequest": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email",
+            "description": "비밀번호 재설정 또는 계정 활성화 안내를 받을 이메일",
+            "example": "user@example.com",
+            "maxLength": 320,
+            "minLength": 0
+          }
+        },
+        "required": [
+          "email"
+        ]
+      },
+      "PasswordResetRequestResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "example": "입력하신 주소가 계정에 등록돼 있으면 안내 메일이 도착합니다."
+          }
+        },
+        "required": [
+          "message"
+        ]
+      },
+      "PasswordResetConfirmationRequest": {
+        "type": "object",
+        "properties": {
+          "token": {
+            "type": "string",
+            "description": "메일 링크에 포함된 비밀번호 재설정 원문 토큰",
+            "maxLength": 512,
+            "minLength": 0
+          },
+          "newPassword": {
+            "type": "string",
+            "description": "영문·숫자·특수문자를 포함한 8~64자 새 비밀번호",
+            "example": "Password1!",
+            "maxLength": 64,
+            "minLength": 0
+          },
+          "newPasswordConfirmation": {
+            "type": "string",
+            "description": "새 비밀번호 확인 값",
+            "example": "Password1!",
+            "maxLength": 64,
+            "minLength": 0
+          }
+        },
+        "required": [
+          "newPassword",
+          "newPasswordConfirmation",
+          "token"
+        ]
+      },
+      "PasswordResetConfirmationResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "example": "COMPLETED"
+          },
+          "message": {
+            "type": "string",
+            "example": "비밀번호가 바뀌었습니다. 새 비밀번호로 다시 로그인해 주세요."
+          }
+        },
+        "required": [
+          "message",
+          "status"
+        ]
+      },
+      "ManagerSignupRequest": {
+        "type": "object",
+        "properties": {
+          "user_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "초대 토큰 해석 응답의 OPERATOR 또는 MANAGER 대상 사용자 ID",
+            "example": "UUID"
+          },
+          "invitationToken": {
+            "type": "string",
+            "description": "INVITE_OPERATOR_MANAGER 초대 링크의 현재 일회용 원문 토큰",
+            "example": "invitation-token",
+            "maxLength": 512,
+            "minLength": 0
+          },
+          "name": {
+            "type": "string",
+            "description": "활성화할 오퍼레이터 또는 매니저의 표시 이름",
+            "example": "홍길동",
+            "maxLength": 200,
+            "minLength": 0
+          },
+          "password": {
+            "type": "string",
+            "description": "영문·숫자·특수문자를 포함한 8~64자 비밀번호",
+            "example": "Password1!",
+            "maxLength": 64,
+            "minLength": 8,
+            "pattern": "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[^A-Za-z0-9]).{8,}$"
+          },
+          "passwordConfirmation": {
+            "type": "string",
+            "description": "비밀번호와 동일하게 입력하는 확인 값",
+            "example": "Password1!",
+            "maxLength": 64,
+            "minLength": 0
+          },
+          "serviceTermsAgreed": {
+            "type": "boolean",
+            "description": "서비스 이용약관 필수 동의 여부",
+            "example": true
+          },
+          "privacyCollectionAgreed": {
+            "type": "boolean",
+            "description": "개인정보 수집 필수 동의 여부",
+            "example": true
+          }
+        },
+        "required": [
+          "invitationToken",
+          "name",
+          "password",
+          "passwordConfirmation",
+          "privacyCollectionAgreed",
+          "serviceTermsAgreed",
+          "user_id"
+        ]
+      },
+      "LoginRequest": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email",
+            "description": "로그인 계정 이메일",
+            "example": "manager@example.com",
+            "minLength": 1
+          },
+          "password": {
+            "type": "string",
+            "description": "로그인 계정 비밀번호",
+            "example": "Password1!",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "email",
+          "password"
+        ]
+      },
+      "LoginResponse": {
+        "type": "object",
+        "properties": {
+          "memberId": {
+            "type": "string",
+            "example": "UUID"
+          },
+          "email": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "role": {
+            "$ref": "#/components/schemas/Role"
+          },
+          "organizationId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "example": "UUID"
+          },
+          "redirectPath": {
+            "type": "string",
+            "description": "클라이언트 내부 이동 경로 제안. 백엔드가 프론트 라우트를 추측해 만든 값이라 **따르지 않아도 된다** — role로 라우팅해도 무방하다.",
+            "example": "/cohorts/12%EA%B8%B0"
+          },
+          "accessToken": {
+            "type": "string"
+          },
+          "accessTokenExpiresIn": {
+            "type": "integer",
+            "format": "int64",
+            "description": "만료까지 남은 시간. **단위는 밀리초(ms)**다 — 1시간이면 3600000이다. 만료 시각은 `Date.now() + accessTokenExpiresIn`이다.",
+            "example": 3600000
+          }
+        },
+        "required": [
+          "accessToken",
+          "accessTokenExpiresIn",
+          "email",
+          "memberId",
+          "name",
+          "organizationId",
+          "redirectPath",
+          "role"
+        ]
+      },
+      "InvitationResolveRequest": {
+        "type": "object",
+        "properties": {
+          "invitationToken": {
+            "type": "string",
+            "description": "초대 링크에 포함된 현재 일회용 원문 토큰. 서버에는 해시만 저장되며 교체·만료·사용된 토큰은 거부됩니다.",
+            "example": "invitation-token",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "invitationToken"
+        ]
+      },
+      "InvitationResolveResponse": {
+        "type": "object",
+        "description": "유효한 초대 토큰으로 확인한 가입/활성화 대상.\n\n표시할 동의 항목(`GET /consents?role=`)과 후속 활성화 API를 `role` 값으로 고른다.",
+        "properties": {
+          "user_id": {
+            "type": "string",
+            "description": "후속 가입 또는 활성화 요청에 전달할 초대 대상 사용자 ID",
+            "example": "UUID"
+          },
+          "email": {
+            "type": "string",
+            "description": "초대 원장과 토큰에서 확인한 읽기 전용 이메일",
+            "example": "user@example.com"
+          },
+          "role": {
+            "$ref": "#/components/schemas/Role"
+          }
+        },
+        "required": [
+          "email",
+          "role"
+        ]
+      },
+      "InvitationResendRequest": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email",
+            "description": "초대 메일을 다시 받을 이메일",
+            "example": "user@example.com",
+            "maxLength": 320,
+            "minLength": 0
+          }
+        },
+        "required": [
+          "email"
+        ]
+      },
+      "InvitationResendResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "example": "입력하신 주소로 초대를 보낸 기록이 있으면 초대 메일이 다시 도착합니다."
+          }
+        },
+        "required": [
+          "message"
+        ]
+      },
+      "UpdateOperatorStatusForPlatformRequest": {
+        "type": "object",
+        "description": "슈퍼어드민 계정 상태 변경 요청.\n\n`status`는 **ACTIVE(재활성) 또는 INACTIVE(정지)만** 지정할 수 있다 — 그 외 값은 400이다.\nPENDING은 초대 흐름이 설정한다.",
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/OperatorAccountStatus"
+          },
+          "reason": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "변경 사유(감사 로그용, 선택)",
+            "example": "퇴사 처리"
+          },
+          "mutableStatus": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "status"
+        ]
+      },
+      "UpdateOrganizationRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "새 기관명. null·빈 값이면 이름을 바꾸지 않는다."
+          },
+          "status": {
+            "$ref": "#/components/schemas/OrganizationStatus",
+            "description": "기관 운영 상태. 이름만 바꿀 때도 현재 상태를 그대로 실어 보내야 한다."
+          }
+        },
+        "required": [
+          "status"
+        ]
+      },
+      "UpdateOperatorStatusRequest": {
+        "type": "object",
+        "description": "오퍼레이터 계정 상태 변경 요청.\n\n`status`는 **ACTIVE(재활성) 또는 INACTIVE(정지)만** 지정할 수 있다 — 그 외 값은 400이다.\nPENDING은 초대 흐름이 설정한다.",
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/OperatorAccountStatus"
+          },
+          "reason": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "변경 사유(감사 로그용, 선택)",
+            "example": "퇴사 처리"
+          },
+          "mutableStatus": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "status"
+        ]
+      },
+      "EndCohortRequest": {
+        "type": "object",
+        "description": "기수 종료 요청",
+        "properties": {
+          "reason": {
+            "type": "string",
+            "description": "종료 사유. 빈 문자열이면 400",
+            "example": "교육 과정 정상 종료",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "reason"
+        ]
+      },
+      "UpdateClassroomManagersRequest": {
+        "type": "object",
+        "description": "반 담당 매니저 전체 교체 요청",
+        "properties": {
+          "managerIds": {
+            "type": "array",
+            "description": "최종 담당 매니저 ID 목록. 보낸 목록이 그대로 최종 상태가 된다(부분 추가·삭제 아님). 중복은 서버가 제거하고, 빈 배열을 보내면 전체 해제된다. null은 허용하지 않는다(빈 배열로 보낼 것).",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        },
+        "required": [
+          "managerIds"
+        ]
+      },
+      "AssignTraineesRequest": {
+        "type": "object",
+        "description": "교육생 일괄 반 배정 요청",
+        "properties": {
+          "traineeIds": {
+            "type": "array",
+            "description": "배정할 교육생의 사용자 ID(user_id) 목록. 1건 이상 필수. 중복은 서버가 제거한다. 그 기수 소속이 아닌 ID가 하나라도 섞여 있으면 전체가 400으로 거절된다.",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "minItems": 1
+          },
+          "classroomId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "배정할 반 ID. 요청한 cohortId 소속이 아니면 404",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          }
+        },
+        "required": [
+          "classroomId",
+          "traineeIds"
+        ]
+      },
+      "AssignTraineesResponse": {
+        "type": "object",
+        "description": "교육생 일괄 반 배정 결과",
+        "properties": {
+          "classroomId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "배정된 반 ID"
+          },
+          "assignedTraineeIds": {
+            "type": "array",
+            "description": "실제 배정된 교육생 ID 목록(중복 제거 후)",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          "assignedCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "배정 인원 수"
+          }
+        },
+        "required": [
+          "assignedCount",
+          "assignedTraineeIds",
+          "classroomId"
+        ]
+      },
+      "RollbackAssignmentRequest": {
+        "type": "object",
+        "description": "교육생 반 배정 되돌리기 요청",
+        "properties": {
+          "traineeIds": {
+            "type": "array",
+            "description": "되돌릴 교육생의 사용자 ID(user_id) 목록. 1건 이상 필수. 중복은 서버가 제거한다. 그 기수 소속이 아니거나 현재 활성 배정이 없는(이미 무소속인) ID가 섞여 있으면 전체가 400으로 거절된다.",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "minItems": 1
+          }
+        },
+        "required": [
+          "traineeIds"
+        ]
+      },
+      "RollbackAssignmentResponse": {
+        "type": "object",
+        "description": "교육생 반 배정 되돌리기 결과",
+        "properties": {
+          "rolledBackTraineeIds": {
+            "type": "array",
+            "description": "실제로 배정이 해제된 교육생 ID 목록(중복 제거 후)",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          "rolledBackCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "해제 인원 수"
+          }
+        },
+        "required": [
+          "rolledBackCount",
+          "rolledBackTraineeIds"
+        ]
+      },
+      "ComparedReachResponse": {
+        "type": "object",
+        "properties": {
+          "before": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "after": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "required": [
+          "after",
+          "before"
+        ]
+      },
+      "ConceptReportResponse": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "level": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "said": {
+            "type": "string"
+          },
+          "isRetryTarget": {
+            "type": "boolean"
+          },
+          "curriculumRef": {
+            "$ref": "#/components/schemas/CurriculumRefResponse"
+          },
+          "qa": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/QaEntryResponse"
+            }
+          },
+          "explain": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "comparedReach": {
+            "$ref": "#/components/schemas/ComparedReachResponse"
+          }
+        }
+      },
+      "CurriculumRefResponse": {
+        "type": "object",
+        "properties": {
+          "chapter": {
+            "type": "string"
+          },
+          "pages": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "chapter",
+          "pages",
+          "title"
+        ]
+      },
+      "QaEntryResponse": {
+        "type": "object",
+        "properties": {
+          "questionLabel": {
+            "type": "string"
+          },
+          "question": {
+            "type": "string"
+          },
+          "answer": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "answer",
+          "question",
+          "questionLabel"
+        ]
+      },
+      "RoundListItem": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "hasPendingRetry": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "hasPendingRetry",
+          "id",
+          "label"
+        ]
+      },
+      "RoundReportResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "publishAfter": {
+            "type": "string"
+          },
+          "publishedAt": {
+            "type": "string"
+          },
+          "curriculum": {
+            "type": "string"
+          },
+          "concepts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConceptReportResponse"
+            }
+          },
+          "retryState": {
+            "type": "string"
+          },
+          "retryDueAt": {
+            "type": "string"
+          },
+          "retryCompletedAt": {
+            "type": "string"
+          }
+        }
+      },
+      "TraineeReportsResponse": {
+        "type": "object",
+        "properties": {
+          "rounds": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RoundListItem"
+            }
+          },
+          "reportsById": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/RoundReportResponse"
+            }
+          }
+        },
+        "required": [
+          "reportsById",
+          "rounds"
+        ]
+      },
+      "ClassRiskRate": {
+        "type": "object",
+        "properties": {
+          "className": {
+            "type": "string"
+          },
+          "traineeCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "atRiskCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "required": [
+          "atRiskCount",
+          "className",
+          "traineeCount"
+        ]
+      },
+      "CohortDiagnosisResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string"
+          },
+          "cohortName": {
+            "type": "string"
+          },
+          "publishedAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "기수 결산 확정 시각. 확정 전이면 null — 화면이 PDF를 잠그는 근거다."
+          },
+          "completedRounds": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalRounds": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "periodStart": {
+            "type": "string"
+          },
+          "periodEnd": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "집계 종료일. 확정 전이면 아직 끝나지 않았으므로 null"
+          },
+          "traineeCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "classCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "conceptCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "curriculumCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "gradedCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalSubmissionCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "excluded": {
+            "$ref": "#/components/schemas/Excluded"
+          },
+          "concepts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConceptDiagnosis"
+            }
+          },
+          "rounds": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RoundDiagnosis"
+            }
+          },
+          "topStudents": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TopStudent"
+            }
+          },
+          "classRiskRoundLabel": {
+            "type": "string"
+          },
+          "classRisk": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ClassRiskRate"
+            }
+          },
+          "groupShortfalls": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GroupShortfall"
+            }
+          }
+        },
+        "required": [
+          "classCount",
+          "classRisk",
+          "classRiskRoundLabel",
+          "cohortName",
+          "completedRounds",
+          "conceptCount",
+          "concepts",
+          "curriculumCount",
+          "excluded",
+          "gradedCount",
+          "groupShortfalls",
+          "periodEnd",
+          "periodStart",
+          "publishedAt",
+          "rounds",
+          "status",
+          "topStudents",
+          "totalRounds",
+          "totalSubmissionCount",
+          "traineeCount"
+        ]
+      },
+      "ConceptDiagnosis": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "curriculumName": {
+            "type": "string"
+          },
+          "curriculumVersion": {
+            "type": "string"
+          },
+          "section": {
+            "type": "string"
+          },
+          "rounds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "distribution": {
+            "$ref": "#/components/schemas/ReachDistribution"
+          },
+          "gradedCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "belowLevel2Count": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "required": [
+          "belowLevel2Count",
+          "curriculumName",
+          "curriculumVersion",
+          "distribution",
+          "gradedCount",
+          "id",
+          "name",
+          "rounds",
+          "section",
+          "totalCount"
+        ]
+      },
+      "Excluded": {
+        "type": "object",
+        "properties": {
+          "notTaken": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "invalid": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "interrupted": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "required": [
+          "interrupted",
+          "invalid",
+          "notTaken"
+        ]
+      },
+      "GroupShortfall": {
+        "type": "object",
+        "properties": {
+          "conceptName": {
+            "type": "string"
+          },
+          "curriculumName": {
+            "type": "string"
+          },
+          "section": {
+            "type": "string"
+          },
+          "round": {
+            "type": "string"
+          },
+          "className": {
+            "type": "string"
+          },
+          "shortfallCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "required": [
+          "className",
+          "conceptName",
+          "curriculumName",
+          "round",
+          "section",
+          "shortfallCount",
+          "totalCount"
+        ]
+      },
+      "ReachDistribution": {
+        "type": "object",
+        "properties": {
+          "level0": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "level1": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "level2": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "level3": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "level4": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "unasked": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "required": [
+          "level0",
+          "level1",
+          "level2",
+          "level3",
+          "level4",
+          "unasked"
+        ]
+      },
+      "RoundDiagnosis": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "conceptNames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "distribution": {
+            "$ref": "#/components/schemas/ReachDistribution"
+          },
+          "gradedCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "belowLevel2Count": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "required": [
+          "belowLevel2Count",
+          "conceptNames",
+          "distribution",
+          "gradedCount",
+          "id",
+          "name",
+          "totalCount"
+        ]
+      },
+      "TopStudent": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "className": {
+            "type": "string"
+          },
+          "miniTopCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "miniTopRounds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        },
+        "required": [
+          "className",
+          "id",
+          "miniTopCount",
+          "miniTopRounds",
+          "name"
+        ]
+      },
+      "OrganizationSort": {
+        "type": "string",
+        "description": "기관 목록 정렬 기준",
+        "enum": [
+          "CREATED_AT_DESC",
+          "CREATED_AT_ASC",
+          "NAME_ASC",
+          "NAME_DESC"
+        ]
+      },
+      "OrganizationListResponse": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OrganizationResponse"
+            }
+          },
+          "page": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "size": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalElements": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "required": [
+          "content",
+          "page",
+          "size",
+          "totalElements",
+          "totalPages"
+        ]
+      },
+      "ActivityUsage": {
+        "type": "object",
+        "description": "사용 규모. 목업 `활성 교육생 148 / 완료 세션 612 / 채점 회차 1,840 / 발행 리포트 96`",
+        "properties": {
+          "activeTrainees": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "completedSessions": {
+            "type": "integer",
+            "format": "int64",
+            "description": "기간 내 완료된 세션 수. LIVE 경로에서는 세션이 끝난 시각(ended_at) 기준으로 센다."
+          },
+          "gradingRounds": {
+            "type": "integer",
+            "format": "int64",
+            "description": "기간 내 채점 회차 수. LIVE 경로에서는 채점 실행 시각 컬럼이 없어 제출 마감(submission_due_at)이 기간에 들어온 회차를 센다."
+          },
+          "generatedReports": {
+            "type": "integer",
+            "format": "int64",
+            "description": "기간 내 발행된 리포트 수. 발행 시각(published_at) 기준이며, 이후 대체(SUPERSEDED)된 리포트도 포함한다."
+          }
+        },
+        "required": [
+          "activeTrainees",
+          "completedSessions",
+          "generatedReports",
+          "gradingRounds"
+        ]
+      },
+      "AiCostUsage": {
+        "type": "object",
+        "description": "AI 비용. 목업 `AI 비용 · 모델별 · 이번 달 $412 / 예산 $600 · 전월 +12%`",
+        "properties": {
+          "totalCost": {
+            "type": "number",
+            "description": "단가가 설정된 호출만 합산한 비용. 단가 미설정 호출은 0으로 더하지 않고 제외한다."
+          },
+          "monthlyBudget": {
+            "type": "number"
+          },
+          "budgetUsageRate": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "예산 소진율(0~1). 예산이 0이면 null",
+            "example": 0.6867
+          },
+          "budgetExceeded": {
+            "type": "boolean",
+            "description": "예산 초과 여부. 초과해도 서비스 중단은 아니며 `예산 초과` 배지만 붙는다."
+          },
+          "changeRateVsPrevMonth": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "전월 대비 증감률. 전월 값이 0이거나 없으면 null",
+            "example": 0.12
+          },
+          "costComplete": {
+            "type": "boolean",
+            "description": "비용 합계가 모든 호출을 포함하는지. false면 단가 미설정 호출이 섞여 있어\n실제 청구액이 이 값보다 크다 — 화면은 `일부 단가 미설정`을 함께 표시해야 한다."
+          },
+          "unpricedCallCount": {
+            "type": "integer",
+            "format": "int64",
+            "description": "단가 미설정이라 비용 합계에서 빠진 호출 수. 0이면 합계가 완전하다."
+          },
+          "total": {
+            "$ref": "#/components/schemas/UsageTotal",
+            "description": "모델별 내역의 합계 행"
+          },
+          "models": {
+            "type": "array",
+            "description": "(용도, 모델) 조합별 내역",
+            "items": {
+              "$ref": "#/components/schemas/ModelUsage"
+            }
+          }
+        },
+        "required": [
+          "budgetExceeded",
+          "budgetUsageRate",
+          "changeRateVsPrevMonth",
+          "costComplete",
+          "models",
+          "monthlyBudget",
+          "total",
+          "totalCost",
+          "unpricedCallCount"
+        ]
+      },
+      "ClassCostUsage": {
+        "type": "object",
+        "description": "반별 비용",
+        "properties": {
+          "classId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "managerName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "반 담당 매니저 이름. 담당이 없으면 null(목업 `담당 없음`)"
+          },
+          "traineeCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "sessionCount": {
+            "type": "integer",
+            "format": "int64",
+            "description": "이 반 교육생의 기간 내 완료 세션 수. 반 배정이 해제된 교육생의 세션은 제외한다."
+          },
+          "cost": {
+            "type": "number"
+          },
+          "unpricedCallCount": {
+            "type": "integer",
+            "format": "int64",
+            "description": "단가 미설정이라 이 반 비용에서 빠진 호출 수"
+          }
+        },
+        "required": [
+          "classId",
+          "cost",
+          "managerName",
+          "name",
+          "sessionCount",
+          "traineeCount",
+          "unpricedCallCount"
+        ]
+      },
+      "CohortCostUsage": {
+        "type": "object",
+        "description": "기수별 비용",
+        "properties": {
+          "cohortId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "traineeCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "cost": {
+            "type": "number"
+          },
+          "costPerTrainee": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "교육생 1인당 비용. 교육생이 0명이면 null"
+          },
+          "unpricedCallCount": {
+            "type": "integer",
+            "format": "int64",
+            "description": "단가 미설정이라 이 기수 비용에서 빠진 호출 수"
+          }
+        },
+        "required": [
+          "cohortId",
+          "cost",
+          "costPerTrainee",
+          "name",
+          "traineeCount",
+          "unpricedCallCount"
+        ]
+      },
+      "ModelUsage": {
+        "type": "object",
+        "description": "모델별 사용 내역 한 줄",
+        "properties": {
+          "usageType": {
+            "type": "string",
+            "description": "용도. ANSWER_EVALUATION(답변 채점) / CODE_SESSION(코드 세션) /\nINTERVIEW_BRIEF_GENERATION(인터뷰 브리프 생성) / REPORT_GENERATION(리포트 생성) /\nCURRICULUM_ANALYSIS(교안 분석) / CODE_ANALYSIS(코드 분석)",
+            "example": "ANSWER_EVALUATION"
+          },
+          "tier": {
+            "description": "호출 시점에 기관이 선택했던 모델 티어 스냅샷. 목업 `정확도 우선` / `균형` / `비용 우선`.\n채점처럼 플랫폼이 모델을 고정하는 기능은 티어가 없어 null이다(화면 `플랫폼 고정`).",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AiTier"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "model": {
+            "type": "string",
+            "description": "모델 표시명",
+            "example": "claude-opus-5"
+          },
+          "calls": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "inputTokens": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "outputTokens": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "inputPricePerMillionTokens": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "100만 토큰당 입력 단가. 단가 미설정이면 null"
+          },
+          "outputPricePerMillionTokens": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "100만 토큰당 출력 단가. 단가 미설정이면 null"
+          },
+          "pricingMissing": {
+            "type": "boolean",
+            "description": "단가 미설정 여부. true면 비용을 0으로 계산하지 않고 합계에서 제외한다\n(목업: \"0으로 계산하면 청구액이 실제보다 작아 보인다\")."
+          },
+          "cost": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "이 행의 비용. 단가 미설정이면 null"
+          }
+        },
+        "required": [
+          "calls",
+          "cost",
+          "inputPricePerMillionTokens",
+          "inputTokens",
+          "model",
+          "outputPricePerMillionTokens",
+          "outputTokens",
+          "pricingMissing",
+          "tier",
+          "usageType"
+        ]
+      },
+      "OrganizationUsageResponse": {
+        "type": "object",
+        "description": "기관 월별 저장량·활동·AI 비용",
+        "properties": {
+          "organizationId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "period": {
+            "type": "string"
+          },
+          "currencyCode": {
+            "type": "string"
+          },
+          "aggregationSource": {
+            "type": "string",
+            "description": "이 응답이 미리 집계된 스냅샷에서 왔는지, 원장을 즉시 집계한 값인지.\nSNAPSHOT이면 organization_usage_snapshot 기준이고, LIVE면 ai_usage를 그 자리에서 합산한 값이다.",
+            "enum": [
+              "SNAPSHOT",
+              "LIVE"
+            ]
+          },
+          "storage": {
+            "$ref": "#/components/schemas/StorageUsage"
+          },
+          "activity": {
+            "$ref": "#/components/schemas/ActivityUsage"
+          },
+          "aiCost": {
+            "$ref": "#/components/schemas/AiCostUsage"
+          },
+          "cohortCosts": {
+            "type": "array",
+            "description": "기수별 비용 (목업 OP-06 ⑤ `7기 $268 · 250명 · 1인당 $1.07`)",
+            "items": {
+              "$ref": "#/components/schemas/CohortCostUsage"
+            }
+          },
+          "classCosts": {
+            "type": "array",
+            "description": "반별 비용 (목업 OP-06 ⑤ `A반 · 박지현 · 25명 · 69세션 · $29`).\n반 표는 항상 \"선택 기수\" 범위이므로 cohortId를 지정하지 않으면 빈 목록이다.",
+            "items": {
+              "$ref": "#/components/schemas/ClassCostUsage"
+            }
+          }
+        },
+        "required": [
+          "activity",
+          "aggregationSource",
+          "aiCost",
+          "classCosts",
+          "cohortCosts",
+          "currencyCode",
+          "organizationId",
+          "period",
+          "storage"
+        ]
+      },
+      "StorageUsage": {
+        "type": "object",
+        "description": "저장량 구성. 목업 `저장량 구성 총 9.4 GB`",
+        "properties": {
+          "totalBytes": {
+            "type": "integer",
+            "format": "int64",
+            "description": "기관 총 저장량. 원천이 ORG_TOTAL 행을 제공하면 그 값을 그대로 쓰고,\n없으면 세부 카테고리 합으로 계산한다 — 둘을 함께 더하면 이중 계산된다."
+          },
+          "codeSubmissionBytes": {
+            "type": "integer",
+            "format": "int64",
+            "description": "코드 제출물 (레포·ZIP)"
+          },
+          "sessionLogBytes": {
+            "type": "integer",
+            "format": "int64",
+            "description": "문답 원문"
+          },
+          "gradingEvidenceBytes": {
+            "type": "integer",
+            "format": "int64",
+            "description": "채점 근거 (evidence)"
+          },
+          "reportBytes": {
+            "type": "integer",
+            "format": "int64",
+            "description": "리포트 · 내보내기 PDF"
+          },
+          "changeRateVsPrevMonth": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "전월 대비 증감률. 전월 값이 0이거나 없으면 null",
+            "example": 0.08
+          }
+        },
+        "required": [
+          "changeRateVsPrevMonth",
+          "codeSubmissionBytes",
+          "gradingEvidenceBytes",
+          "reportBytes",
+          "sessionLogBytes",
+          "totalBytes"
+        ]
+      },
+      "UsageTotal": {
+        "type": "object",
+        "description": "모델별 내역 합계. 목업 `합계 5,080 / 29.7M / 6.1M / $412`",
+        "properties": {
+          "calls": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "inputTokens": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "outputTokens": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "cost": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "calls",
+          "cost",
+          "inputTokens",
+          "outputTokens"
+        ]
+      },
+      "ClassCost": {
+        "type": "object",
+        "description": "반별 비용 한 줄",
+        "properties": {
+          "classId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "cohortId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "이 반이 속한 기수"
+          },
+          "className": {
+            "type": "string"
+          },
+          "managerName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "반 담당 매니저 이름. 공동 담당이면 가장 먼저 배정된 1명. 없으면 null"
+          },
+          "monthly": {
+            "type": "array",
+            "description": "월별 비용. **오래된 달이 앞**이다(매트릭스는 왼쪽에서 오른쪽으로 시간이 흐른다).",
+            "items": {
+              "$ref": "#/components/schemas/MonthlyClassCost"
+            }
+          },
+          "cohortAmount": {
+            "type": "number",
+            "description": "기수 누적 사용액"
+          },
+          "cohortSessions": {
+            "type": "integer",
+            "format": "int64",
+            "description": "기수 누적 완료 세션 수. 배정이 해제된 교육생의 세션은 제외한다."
+          }
+        },
+        "required": [
+          "classId",
+          "className",
+          "cohortAmount",
+          "cohortId",
+          "cohortSessions",
+          "managerName",
+          "monthly"
+        ]
+      },
+      "CohortCard": {
+        "type": "object",
+        "description": "기수 카드",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "기수 식별자. 화면 계약이 `id`라 그대로 쓴다."
+          },
+          "name": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "number"
+          },
+          "trainees": {
+            "type": "integer",
+            "format": "int32",
+            "description": "현재 소속 교육생 수(나간 인원 제외). 1인당 비용은 화면이 만들지 않는다."
+          },
+          "period": {
+            "type": "string",
+            "description": "기간 표기. 전환기에 두 기수가 뜰 때 왜 같이 있는지를 카드가 스스로 말한다.",
+            "example": "2026-03 ~ 09"
+          }
+        },
+        "required": [
+          "amount",
+          "id",
+          "name",
+          "period",
+          "trainees"
+        ]
+      },
+      "CohortCostResponse": {
+        "type": "object",
+        "description": "기수 비용 (OP-06 ⑤ 비용 탭)",
+        "properties": {
+          "organizationId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "기관 식별자"
+          },
+          "cohortId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "조회한 기수 식별자"
+          },
+          "currencyCode": {
+            "type": "string",
+            "description": "통화 코드. 플랫폼 공통 USD",
+            "example": "USD"
+          },
+          "summary": {
+            "$ref": "#/components/schemas/CostSummary"
+          },
+          "classes": {
+            "type": "array",
+            "description": "반별 비용. 정렬은 요청의 sort가 정한다.",
+            "items": {
+              "$ref": "#/components/schemas/ClassCost"
+            }
+          }
+        },
+        "required": [
+          "classes",
+          "cohortId",
+          "currencyCode",
+          "organizationId",
+          "summary"
+        ]
+      },
+      "CostSummary": {
+        "type": "object",
+        "description": "비용 요약",
+        "properties": {
+          "month": {
+            "type": "string",
+            "description": "기준 월(yyyy-MM). 보통 이번 달",
+            "example": "2026-07"
+          },
+          "total": {
+            "type": "number",
+            "description": "**기관 전체** 기준 월 사용액"
+          },
+          "previousTotal": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "**기관 전체** 지난달 사용액. 증감만으로는 판단이 안 되므로 절대값을 함께 준다 —\n`+12%`가 `$400→$412`인지 `$50→$56`인지에 따라 할 일이 다르다.\n기준 월이 첫 달이면 null."
+          },
+          "changePct": {
+            "type": "number",
+            "description": "전월 대비 증감**률(%)**. 부호를 그대로 쓴다(`+12` / `-8`).\n⚠️ 다른 API의 `changeRate`(0~1)와 단위가 다르다 — 화면 계약에 맞춘 값이다.\n지난달이 0이거나 없으면 0.",
+            "example": 12
+          },
+          "cohortTotal": {
+            "type": "number",
+            "description": "**선택 기수** 시작월부터 기준 월까지 누적 사용액. 예산 비율을 이 값으로 잰다."
+          },
+          "budget": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "**기수 전체** 계약 예산. `organization_policy.monthly_ai_budget × 기수 개월 수`로 파생한다 —\n기수 단위 예산 컬럼이 스키마에 없어 월 예산에서 계산한다.\n활성 정책이 없거나 월 예산이 0이면 null이며, 그때 화면은 비율을 그리지 않는다."
+          },
+          "monthsLeft": {
+            "type": "integer",
+            "format": "int32",
+            "description": "기준 월 기준 기수 종료까지 남은 개월 수. 이미 종료됐으면 0",
+            "example": 2
+          },
+          "monthly": {
+            "type": "array",
+            "description": "**선택 기수** 월별 비용. **최근 달이 앞**이다(화면 월별 표는 최신이 위).\n아직 오지 않은 달은 담지 않는다.",
+            "items": {
+              "$ref": "#/components/schemas/MonthlyCost"
+            }
+          },
+          "cohorts": {
+            "type": "array",
+            "description": "기준 월에 **실제로 비용이 발생한** 기수만. 평시에는 1건, 기수 전환기에는 2건이다.\n비용 0인 기수를 실으면 화면에 늘 여러 기수가 보인다.",
+            "items": {
+              "$ref": "#/components/schemas/CohortCard"
+            }
+          }
+        },
+        "required": [
+          "budget",
+          "changePct",
+          "cohortTotal",
+          "cohorts",
+          "month",
+          "monthly",
+          "monthsLeft",
+          "previousTotal",
+          "total"
+        ]
+      },
+      "MonthlyClassCost": {
+        "type": "object",
+        "description": "반 하나의 한 달치",
+        "properties": {
+          "month": {
+            "type": "string",
+            "description": "월(yyyy-MM)",
+            "example": "2026-07"
+          },
+          "amount": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "amount",
+          "month"
+        ]
+      },
+      "MonthlyCost": {
+        "type": "object",
+        "description": "기수 월별 비용 한 줄",
+        "properties": {
+          "month": {
+            "type": "string",
+            "description": "월(yyyy-MM)",
+            "example": "2026-07"
+          },
+          "amount": {
+            "type": "number"
+          },
+          "sessions": {
+            "type": "integer",
+            "format": "int64",
+            "description": "그달에 완료된 세션 수. **비용의 원인**이라 금액 옆에 둔다."
+          },
+          "projectNames": {
+            "type": "array",
+            "description": "그달에 제출 마감된 회차 이름. **비어 있으면 회차 없이 재시험만 있던 달**이다.",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "amount",
+          "month",
+          "projectNames",
+          "sessions"
+        ]
+      },
+      "Cohort": {
+        "type": "object",
+        "description": "기수 요약",
+        "properties": {
+          "cohortId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "description": "기수 상태. PLANNED(예정) / RUNNING(진행 중) / CLOSED(종료)",
+            "example": "RUNNING"
+          },
+          "classCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "기수에 속한 반 수"
+          },
+          "traineeCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "현재 소속 교육생 수(기수를 나간 인원 제외)"
+          },
+          "startDate": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date",
+            "description": "기수 시작일. 미정이면 null"
+          },
+          "endDate": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date",
+            "description": "기수 종료일. 미정이면 null"
+          }
+        },
+        "required": [
+          "classCount",
+          "cohortId",
+          "endDate",
+          "name",
+          "startDate",
+          "status",
+          "traineeCount"
+        ]
+      },
+      "OrganizationCohortListResponse": {
+        "type": "object",
+        "description": "기관 기수 목록 (슈퍼어드민 읽기전용)",
+        "properties": {
+          "organizationId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "content": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Cohort"
+            }
+          }
+        },
+        "required": [
+          "content",
+          "organizationId"
+        ]
+      },
+      "AiCost": {
+        "type": "object",
+        "description": "AI 비용 집계",
+        "properties": {
+          "totalCost": {
+            "type": "number"
+          },
+          "totalMonthlyBudget": {
+            "type": "number",
+            "description": "전 기관 월 예산 합계"
+          },
+          "budgetUsageRate": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "예산 소진율(0~1). 예산 합계가 0이면 null"
+          },
+          "changeRateVsPrevMonth": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "전월 대비 증감률. 전월 값이 0이거나 없으면 null",
+            "example": 0.18
+          },
+          "currencyCode": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "budgetUsageRate",
+          "changeRateVsPrevMonth",
+          "currencyCode",
+          "totalCost",
+          "totalMonthlyBudget"
+        ]
+      },
+      "Organizations": {
+        "type": "object",
+        "description": "기관 수 (삭제된 기관 제외)",
+        "properties": {
+          "total": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "active": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "suspended": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "required": [
+          "active",
+          "suspended",
+          "total"
+        ]
+      },
+      "PlatformSummaryResponse": {
+        "type": "object",
+        "description": "플랫폼 전체 집계 (SA-01 상단 지표 카드)",
+        "properties": {
+          "period": {
+            "type": "string",
+            "description": "집계 기준 월(yyyy-MM)"
+          },
+          "organizations": {
+            "$ref": "#/components/schemas/Organizations"
+          },
+          "traineeCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "플랫폼 전체 활성 교육생 수"
+          },
+          "activeSessionCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "진행 중 세션 수. ⚠ session 계열 테이블이 아직 없어 항상 0입니다."
+          },
+          "aiCost": {
+            "$ref": "#/components/schemas/AiCost"
+          },
+          "storage": {
+            "$ref": "#/components/schemas/Storage"
+          }
+        },
+        "required": [
+          "activeSessionCount",
+          "aiCost",
+          "organizations",
+          "period",
+          "storage",
+          "traineeCount"
+        ]
+      },
+      "Storage": {
+        "type": "object",
+        "description": "저장량 집계",
+        "properties": {
+          "totalBytes": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "changeRateVsPrevMonth": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "전월 대비 증감률. 전월 값이 0이거나 없으면 null",
+            "example": 0.06
+          },
+          "averageBytesPerOrganization": {
+            "type": "integer",
+            "format": "int64",
+            "description": "기관 1곳당 평균 저장 바이트"
+          }
+        },
+        "required": [
+          "averageBytesPerOrganization",
+          "changeRateVsPrevMonth",
+          "totalBytes"
+        ]
+      },
+      "OrganizationNameAvailabilityResponse": {
+        "type": "object",
+        "description": "기관명 중복 확인 결과",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "확인한 기관명(원본)"
+          },
+          "normalizedName": {
+            "type": "string",
+            "description": "정규화된 기관명(트림 + 소문자). 중복 판정 기준값"
+          },
+          "available": {
+            "type": "boolean",
+            "description": "사용 가능 여부"
+          },
+          "reason": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "사용 불가 사유. 사용 가능하면 null",
+            "example": "이미 사용 중인 기관명입니다."
+          }
+        },
+        "required": [
+          "available",
+          "name",
+          "normalizedName",
+          "reason"
+        ]
+      },
+      "MemberProfileResponse": {
+        "type": "object",
+        "description": "지금 이 토큰의 주인. 로그인 응답과 같은 값들이며 <b>서버가 매번 다시 읽어</b> 내려줍니다.\n\n새로고침하면 브라우저 메모리가 비워지는데 재발급 응답(`RefreshTokenResponse`)에는 토큰만 있어\n역할을 알 수 없습니다. 이 API가 그 자리를 메우므로 역할·상태를 브라우저 저장소에 남길 필요가\n없고, 정지·역할 변경이 다음 호출에 바로 반영됩니다.",
+        "properties": {
+          "memberId": {
+            "type": "string",
+            "description": "계정 식별자. 로그인 응답의 memberId와 같은 값",
+            "example": "UUID"
+          },
+          "email": {
+            "type": "string",
+            "description": "로그인 이메일",
+            "example": "manager@example.com"
+          },
+          "name": {
+            "type": "string",
+            "description": "표시 이름",
+            "example": "홍길동"
+          },
+          "role": {
+            "$ref": "#/components/schemas/Role"
+          },
+          "organizationId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "소속 기관. SUPER_ADMIN은 null",
+            "example": "UUID"
+          },
+          "status": {
+            "$ref": "#/components/schemas/AccountStatus"
+          }
+        },
+        "required": [
+          "email",
+          "memberId",
+          "name",
+          "organizationId",
+          "role",
+          "status"
+        ]
+      },
+      "Classroom": {
+        "type": "object",
+        "description": "현재 반 정보",
+        "properties": {
+          "classroomId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "반 ID"
+          },
+          "name": {
+            "type": "string",
+            "description": "반 이름",
+            "example": "1반"
+          }
+        },
+        "required": [
+          "classroomId",
+          "name"
+        ]
+      },
+      "EnrollmentListResponse": {
+        "type": "object",
+        "description": "내 소속 기수·반 목록 응답",
+        "properties": {
+          "enrollments": {
+            "type": "array",
+            "description": "로그인한 사용자가 현재 유효하게 소속된 기수 전체. 소속이 없으면 빈 배열",
+            "items": {
+              "$ref": "#/components/schemas/EnrollmentResponse"
+            }
+          }
+        },
+        "required": [
+          "enrollments"
+        ]
+      },
+      "EnrollmentResponse": {
+        "type": "object",
+        "description": "교육생 개인의 소속 기수 하나(현재 반 배정 포함)",
+        "properties": {
+          "cohortId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "기수 ID"
+          },
+          "cohortName": {
+            "type": "string",
+            "description": "기수명",
+            "example": "7기"
+          },
+          "classroom": {
+            "description": "현재 배정된 반. 아직 배정 전이면 null",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Classroom"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "classroom",
+          "cohortId",
+          "cohortName"
+        ]
+      },
+      "ConsentItemResponse": {
+        "type": "object",
+        "description": "가입 화면에 표시할 동의 항목",
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "동의 항목 코드",
+            "example": "TERMS_OF_SERVICE"
+          },
+          "title": {
+            "type": "string",
+            "description": "화면에 표시할 항목명",
+            "example": "서비스 이용약관"
+          },
+          "description": {
+            "type": "string",
+            "description": "항목 설명 문구"
+          },
+          "requestField": {
+            "type": "string",
+            "description": "가입 요청에서 이 항목의 동의 여부를 담을 필드명",
+            "example": "serviceTermsAgreed"
+          },
+          "required": {
+            "type": "boolean",
+            "description": "필수 동의 여부이며 true인 항목은 false로 제출하면 가입이 400으로 거부된다"
+          },
+          "policyVersion": {
+            "type": "integer",
+            "format": "int32",
+            "description": "표시한 동의 문서 버전이며 가입 요청과 동의 기록에 그대로 쓰인다",
+            "example": 1
+          }
+        },
+        "required": [
+          "code",
+          "description",
+          "policyVersion",
+          "requestField",
+          "required",
+          "title"
+        ]
+      },
+      "CohortListResponse": {
+        "type": "object",
+        "description": "기수 목록 페이지 응답",
+        "properties": {
+          "content": {
+            "type": "array",
+            "description": "이 페이지의 기수 목록",
+            "items": {
+              "$ref": "#/components/schemas/CohortResponse"
+            }
+          },
+          "page": {
+            "type": "integer",
+            "format": "int32",
+            "description": "0부터 시작하는 현재 페이지 번호",
+            "example": 0
+          },
+          "size": {
+            "type": "integer",
+            "format": "int32",
+            "description": "페이지당 개수",
+            "example": 20
+          },
+          "totalElements": {
+            "type": "integer",
+            "format": "int64",
+            "description": "전체 기수 수"
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "description": "전체 페이지 수"
+          }
+        },
+        "required": [
+          "content",
+          "page",
+          "size",
+          "totalElements",
+          "totalPages"
+        ]
+      },
+      "ClassroomListResponse": {
+        "type": "object",
+        "description": "기수 반 목록 응답",
+        "properties": {
+          "classrooms": {
+            "type": "array",
+            "description": "그 기수에 편성된 반 전체. 하나도 없으면 빈 배열",
+            "items": {
+              "$ref": "#/components/schemas/ClassroomResponse"
+            }
+          }
+        },
+        "required": [
+          "classrooms"
+        ]
+      },
+      "DeleteOrganizationRequest": {
+        "type": "object",
+        "description": "기관 삭제 확인 요청",
+        "properties": {
+          "confirmName": {
+            "type": "string",
+            "description": "삭제할 기관의 정확한 이름. 저장된 기관명과 다르면 거절된다.",
+            "example": "그린컴퍼니 부트캠프",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "confirmName"
+        ]
+      },
+      "DeleteOrganizationResponse": {
+        "type": "object",
+        "properties": {
+          "organizationId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "deletedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "purgeAvailableAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "deletedAt",
+          "organizationId",
+          "purgeAvailableAt"
+        ]
+      },
+      "ErrorResponse": {
+        "description": "공통 오류 응답. 모든 4xx·5xx가 이 모양이다.\n\n프론트는 `code`로 분기한다 — `message`는 사람이 읽는 기본 문구라 바뀔 수 있다.\n응답별로 어떤 `code`가 오는지는 각 오퍼레이션 응답의 examples 키에 코드명으로 적혀 있다.",
+        "properties": {
+          "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "description": "오류 발생 시각 (ISO-8601 UTC)",
+            "example": "2026-08-07T04:21:33.512Z"
+          },
+          "status": {
+            "type": "integer",
+            "format": "int32",
+            "description": "HTTP 상태 코드",
+            "example": 409
+          },
+          "error": {
+            "type": "string",
+            "description": "HTTP 상태 문구. 통합 전 응답과의 하위호환용이며 분기에 쓰지 않는다.",
+            "example": "CONFLICT"
+          },
+          "code": {
+            "type": "string",
+            "description": "기계가 분기하는 안정 코드. 화면 문구는 프론트가 정한다.",
+            "example": "ORG_NAME_TAKEN"
+          },
+          "message": {
+            "type": "string",
+            "description": "사람이 읽는 기본 메시지(로그·폴백용)",
+            "example": "이미 있는 기관명입니다."
+          },
+          "fieldErrors": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "description": "필드 단위 검증 실패 목록. 검증 오류(400)가 아니면 키 자체가 없다.",
+            "items": {
+              "$ref": "#/components/schemas/FieldError"
+            }
+          },
+          "retryAfter": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "다시 시도할 수 있을 때까지 남은 초. 일시 차단(429)에서만 실리고 그 외에는 키 자체가 없다.\n\n같은 값이 `Retry-After` 헤더로도 나간다 — 화면이 남은 시간을 세려면 본문에서\n읽는 편이 간단하고, 프록시·클라이언트 라이브러리의 공통 재시도 처리는 헤더를 본다.",
+            "example": 300
+          }
+        },
+        "required": [
+          "code",
+          "error",
+          "message",
+          "status",
+          "timestamp"
+        ]
+      },
+      "FieldError": {
+        "description": "필드 단위 검증 실패",
+        "properties": {
+          "field": {
+            "type": "string",
+            "description": "요청 본문의 필드명",
+            "example": "dataRetentionDays"
+          },
+          "message": {
+            "type": "string",
+            "description": "거절 사유",
+            "example": "90, 180, 365 중 하나여야 합니다."
+          }
+        },
+        "required": [
+          "field",
+          "message"
+        ]
+      }
+    },
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "description": "로그인 API에서 발급받은 access token만 입력하세요. Bearer 접두사는 Swagger UI가 자동으로 추가합니다.",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,14 @@
         "@base-ui/react": "^1.6.0",
         "@fontsource-variable/inter": "^5.3.0",
         "@tailwindcss/vite": "^4.3.3",
+        "@tanstack/react-query": "^5.101.4",
         "@tanstack/react-table": "^8.21.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.4.0",
         "lucide-react": "^1.25.0",
         "next-themes": "^0.4.6",
+        "openapi-fetch": "^0.13.8",
         "react": "^19.2.7",
         "react-day-picker": "^10.0.1",
         "react-dom": "^19.2.7",
@@ -27,13 +29,15 @@
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.6.0",
         "tailwindcss": "^4.3.3",
-        "tw-animate-css": "^1.4.0"
+        "tw-animate-css": "^1.4.0",
+        "zustand": "^5.0.14"
       },
       "devDependencies": {
         "@types/node": "^24.13.2",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.3",
+        "openapi-typescript": "^7.13.0",
         "oxlint": "^1.71.0",
         "prettier": "^3.9.6",
         "typescript": "~6.0.2",
@@ -1264,6 +1268,82 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@redocly/ajv": {
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.11.2.tgz",
+      "integrity": "sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js-replace": "^1.0.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@redocly/config": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.22.0.tgz",
+      "integrity": "sha512-gAy93Ddo01Z3bHuVdPWfCwzgfaYgMdaZPcfL7JZ7hWJoK9V0lXDbigTWkhiPFAaLWzbOJ+kbUQG1+XwIm0KRGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@redocly/openapi-core": {
+      "version": "1.34.18",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.18.tgz",
+      "integrity": "sha512-UyKIm0wTPw5BcY7Z2PkbK1Ma260um96LSBWXHrdSMe+ZV0EPMyDfAcUcjjm3qEiGST9OK/1TriekdPCZkn4Q3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/ajv": "8.11.2",
+        "@redocly/config": "0.22.0",
+        "colorette": "1.4.0",
+        "https-proxy-agent": "7.0.6",
+        "js-levenshtein": "1.1.6",
+        "js-yaml": "4.3.0",
+        "minimatch": "5.1.9",
+        "pluralize": "8.0.0",
+        "yaml-ast-parser": "0.0.43"
+      },
+      "engines": {
+        "node": ">=18.17.0",
+        "npm": ">=9.5.0"
+      }
+    },
+    "node_modules/@redocly/openapi-core/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@redocly/openapi-core/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@redocly/openapi-core/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
@@ -1787,6 +1867,32 @@
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.101.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.4.tgz",
+      "integrity": "sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.101.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.4.tgz",
+      "integrity": "sha512-yRg2pfOCxIs4ZJW3XYYHU/WgtD04FHSnfHlpRT7h7pR77hwkdRG4wxbKe4aq6P0RvXUTBSQpQeadS1SUYUe+KA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.101.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
     "node_modules/@tanstack/react-table": {
       "version": "8.21.3",
       "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
@@ -1914,6 +2020,16 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -2203,6 +2319,13 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/change-case": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
@@ -2255,6 +2378,13 @@
       "version": "13.0.3",
       "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
       "integrity": "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==",
+      "license": "MIT"
+    },
+    "node_modules/colorette": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
@@ -3255,6 +3385,20 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/human-signals": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
@@ -3300,6 +3444,19 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/index-to-position": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
+      "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3525,6 +3682,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/js-tokens": {
@@ -4256,6 +4423,60 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openapi-fetch": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.13.8.tgz",
+      "integrity": "sha512-yJ4QKRyNxE44baQ9mY5+r/kAzZ8yXMemtNAOFwOzRXJscdjSxxzWSNlyBAr+o5JjkUw9Lc3W7OIoca0cY3PYnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi-typescript-helpers": "^0.0.15"
+      }
+    },
+    "node_modules/openapi-typescript": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-7.13.0.tgz",
+      "integrity": "sha512-EFP392gcqXS7ntPvbhBzbF8TyBA+baIYEm791Hy5YkjDYKTnk/Tn5OQeKm5BIZvJihpp8Zzr4hzx0Irde1LNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/openapi-core": "^1.34.6",
+        "ansi-colors": "^4.1.3",
+        "change-case": "^5.4.4",
+        "parse-json": "^8.3.0",
+        "supports-color": "^10.2.2",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "openapi-typescript": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "typescript": "^5.x"
+      }
+    },
+    "node_modules/openapi-typescript-helpers": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.0.15.tgz",
+      "integrity": "sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==",
+      "license": "MIT"
+    },
+    "node_modules/openapi-typescript/node_modules/parse-json": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+      "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "index-to-position": "^1.1.0",
+        "type-fest": "^4.39.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ora": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
@@ -4513,6 +4734,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/postcss": {
@@ -5348,6 +5579,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/systeminformation": {
       "version": "5.33.0",
       "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.33.0.tgz",
@@ -5485,6 +5729,19 @@
         "url": "https://github.com/sponsors/Wombosvideo"
       }
     },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/type-is": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
@@ -5605,6 +5862,13 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
+    },
+    "node_modules/uri-js-replace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uri-js-replace/-/uri-js-replace-1.0.1.tgz",
+      "integrity": "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
@@ -5759,6 +6023,23 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
     },
+    "node_modules/yaml-ast-parser": {
+      "version": "0.0.43",
+      "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
+      "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/yocto-spinner": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-1.2.2.tgz",
@@ -5802,6 +6083,35 @@
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
+      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "preview": "vite preview",
+    "api:pull": "node scripts/api-pull.mjs",
+    "api:check": "node scripts/api-check.mjs",
+    "api:gen": "node scripts/api-gen.mjs",
+    "api:test": "node --test scripts/api-check.test.mjs scripts/api-gen.test.mjs",
     "check:design": "node scripts/check-design.mjs",
     "doc:design": "node scripts/design-doc.mjs",
     "doc:components": "node scripts/component-doc.mjs",
@@ -25,16 +29,23 @@
     "check:project": "node --experimental-strip-types scripts/check-project-rules.mts",
     "check:admin": "node --experimental-strip-types scripts/check-admin-rules.mts"
   },
+  "overrides": {
+    "openapi-typescript": {
+      "typescript": "$typescript"
+    }
+  },
   "dependencies": {
     "@base-ui/react": "^1.6.0",
     "@fontsource-variable/inter": "^5.3.0",
     "@tailwindcss/vite": "^4.3.3",
+    "@tanstack/react-query": "^5.101.4",
     "@tanstack/react-table": "^8.21.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.4.0",
     "lucide-react": "^1.25.0",
     "next-themes": "^0.4.6",
+    "openapi-fetch": "^0.13.8",
     "react": "^19.2.7",
     "react-day-picker": "^10.0.1",
     "react-dom": "^19.2.7",
@@ -45,13 +56,15 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.3.3",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "zustand": "^5.0.14"
   },
   "devDependencies": {
     "@types/node": "^24.13.2",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.3",
+    "openapi-typescript": "^7.13.0",
     "oxlint": "^1.71.0",
     "prettier": "^3.9.6",
     "typescript": "~6.0.2",

--- a/scripts/api-check.mjs
+++ b/scripts/api-check.mjs
@@ -1,0 +1,336 @@
+#!/usr/bin/env node
+/*
+  받아 둔 OpenAPI 스펙이 **코드 생성을 감당할 품질인가**를 검사한다 — `npm run api:check`
+
+  이 검사들은 추상적인 모범사례가 아니라 **실제로 우리를 물었던 것들**이다.
+  전부 docs/dev/backend-api-requests.md(1차)·backend-api-requests-2.md(2차)에서 왔고,
+  거기서 손으로 세던 것을 그대로 코드로 옮긴 것이다. 목적 둘:
+
+    ① 백엔드가 "고쳤어요" 했을 때 눈으로 99건을 다시 세지 않는다
+    ② 위반 목록이 그대로 다음 요청서가 된다 — 문서를 손으로 다시 쓰지 않는다
+
+  등급
+    error  계약이 깨진다. 이 상태로 생성하면 타입이 거짓말을 한다 → 종료코드 1
+    warn   개선 요청 중이거나 우리가 흡수하는 것 → 종료코드 0 (보이기만 한다)
+
+  사용
+    node scripts/api-check.mjs                    api/openapi.json 검사
+    node scripts/api-check.mjs --spec <경로>       다른 파일 검사(옛 스펙으로 역검증할 때)
+    node scripts/api-check.mjs --verbose          위반 전량 출력(기본은 앞 8건)
+*/
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+const SPEC = 'api/openapi.json'
+const HEAD = 8
+
+/*
+  HTTP 상태를 그대로 옮긴 코드들. 상태코드에 이미 있는 정보라 화면 분기에 쓸 수 없다.
+  "이 코드들만 있는 오퍼레이션"이 2차 요청서의 유일한 요청 항목이다.
+*/
+const GENERIC_CODES = new Set([
+  'BAD_REQUEST',
+  'VALIDATION_FAILED',
+  'CONFLICT',
+  'FORBIDDEN',
+  'NOT_FOUND',
+  'GONE',
+  'UNAUTHORIZED',
+  'UNAUTHENTICATED',
+  'INTERNAL_SERVER_ERROR',
+  'BAD_GATEWAY',
+  'UNPROCESSABLE_ENTITY',
+  'ACCESS_DENIED',
+])
+
+/*
+  required에서 의도적으로 빠진 스키마 — 백엔드가 @JsonInclude(NON_NULL)로 키 자체를 빼는
+  응답이라 정말로 optional이다(1차 요청 회신에서 확인). 프론트 타입도 `?`가 맞다.
+  ⚠️ 새 스키마가 여기 들어오려면 근거가 있어야 한다. 늘어나기 시작하면 규칙이 무력해진다.
+*/
+const REQUIRED_EXEMPT = new Set([
+  'ReportDisclosureResponse',
+  'RoundReportResponse',
+  'ConceptReportResponse',
+  'UpdateModelPricingRequest',
+])
+
+/*
+  일반 코드뿐인 것이 **합의된** 오퍼레이션. 2차 요청 회신에서 근거를 받았다.
+  ⚠️ 여기 없는 것이 새로 뜨면 그건 진짜 누락이다 — 그래서 "전부 통과"가 의미를 갖는다.
+*/
+const GENERIC_ONLY_AGREED = new Map([
+  [
+    'POST /api/v0/auth/password-reset/requests',
+    '계정 존재 여부와 무관하게 항상 202 — 응답이 갈리면 그 자체가 계정 확인 수단',
+  ],
+  ['POST /api/v0/auth/invitations/resend', '위와 같은 이유'],
+  ['GET /api/v0/consents', '단순 조회. 검증 실패 외에 실패할 사유가 없다'],
+])
+
+/** enum을 공유 스키마로 못 뺀 것 — Java enum이 아니라 int + 커스텀 검증이라 $ref가 안 나온다 */
+const ENUM_INLINE_AGREED = new Set(['90|180|365'])
+
+const PAGE_FIELDS = ['page', 'size', 'totalElements', 'totalPages']
+
+/*
+  스키마가 null을 허용하는가 — 표기 방법이 넷이다.
+
+  ⚠️ 이 함수가 이 스크립트에서 가장 틀리기 쉬운 자리다. 처음엔 `nullable`과 `type` 배열만
+  봤다가 **정상인 5건을 위반으로 잡았다.** $ref는 형제 키워드가 무시되므로 3.1에서는
+  `oneOf: [{$ref}, {type:'null'}]`로 쓰는 것이 정석이고, 백엔드는 그렇게 쓰고 있었다.
+  → scripts/api-check.test.mjs가 네 표기를 전부 고정한다.
+*/
+export function isNullable(schema) {
+  if (!schema || typeof schema !== 'object') return false
+  if (schema.nullable === true) return true // 3.0 표기
+  if (Array.isArray(schema.type) && schema.type.includes('null')) return true // 3.1 타입 배열
+  const branches = schema.oneOf ?? schema.anyOf ?? schema.allOf // 3.1 $ref + null 조합
+  return Array.isArray(branches) && branches.some((b) => isNullable(b) || b?.type === 'null')
+}
+
+/*
+  설명문이 "이 값은 null일 수 있다"고 **주장**하는가.
+
+  단순히 'null'이라는 단어를 찾으면 안 된다 — `null은 허용하지 않는다(빈 배열로 보낼 것)`
+  같은 문장이 걸린다. 실제로 걸렸다. 부정문을 먼저 걷어낸다.
+*/
+export function assertsNull(description) {
+  if (typeof description !== 'string' || !/\bnull\b/i.test(description)) return false
+  const denies =
+    /null(을|은|이|가)?\s*(허용하지\s*않|안\s*됨|불가|아니다|아님|보내지\s*(마|말|않))/i
+  return !denies.test(description)
+}
+
+// ── 스펙 훑기 ────────────────────────────────────────────────────────────────
+
+function operations(spec) {
+  const out = []
+  for (const [path, item] of Object.entries(spec.paths ?? {})) {
+    for (const [method, op] of Object.entries(item)) {
+      if (!op || typeof op !== 'object' || !op.responses) continue
+      out.push({ path, method: method.toUpperCase(), op, at: `${method.toUpperCase()} ${path}` })
+    }
+  }
+  return out
+}
+
+/** 4xx·5xx 응답만 */
+function* errorResponses(op) {
+  for (const [code, res] of Object.entries(op.responses)) {
+    if (Number(code) >= 400) yield [code, res]
+  }
+}
+
+/** 이 응답에서 뽑히는 에러 코드들 — examples의 키가 곧 코드명이다(백엔드와 합의한 규약) */
+const codesOf = (res) => Object.keys(res?.content?.['application/json']?.examples ?? {})
+
+// ── 규칙 ─────────────────────────────────────────────────────────────────────
+
+const rules = [
+  {
+    id: 'error-schema',
+    severity: 'error',
+    title: '에러 응답이 성공 응답과 같은 스키마를 가리킨다',
+    why: 'springdoc이 content를 안 적으면 핸들러 반환 타입을 물려준다. 생성 타입이 "409에 성공 DTO가 온다"고 말하게 된다.',
+    run: (spec) =>
+      operations(spec).flatMap(({ op, at }) => {
+        const ok = Object.entries(op.responses)
+          .filter(([c]) => Number(c) < 400)
+          .map(([, r]) => JSON.stringify(r.content))
+        return [...errorResponses(op)]
+          .filter(([, r]) => ok.includes(JSON.stringify(r.content)))
+          .map(([c]) => `${at} ${c}`)
+      }),
+  },
+  {
+    id: 'required',
+    severity: 'error',
+    title: '객체 스키마에 required가 없다',
+    why: '전 필드가 optional이 되어 화면이 ?·!를 남발하고, 요청 DTO는 필수 누락이 컴파일에서 안 걸린다.',
+    run: (spec) =>
+      Object.entries(spec.components?.schemas ?? {})
+        .filter(([name, s]) => s.properties && !s.required?.length && !REQUIRED_EXEMPT.has(name))
+        .map(([name]) => name),
+  },
+  {
+    id: 'nullable',
+    severity: 'error',
+    title: '설명에는 null이라 적혀 있는데 타입이 null을 허용하지 않는다',
+    why: 'optional보다 나쁘다. 컴파일러가 null 검사를 요구하지 않는데 런타임에 null이 온다.',
+    run: (spec) => {
+      const hits = []
+      const walk = (props, trail) => {
+        for (const [key, value] of Object.entries(props ?? {})) {
+          if (!value || typeof value !== 'object') continue
+          if (assertsNull(value.description) && !isNullable(value)) hits.push(`${trail}.${key}`)
+          walk(value.properties, `${trail}.${key}`)
+          walk(value.items?.properties, `${trail}.${key}[]`)
+        }
+      }
+      for (const [name, s] of Object.entries(spec.components?.schemas ?? {}))
+        walk(s.properties, name)
+      return hits
+    },
+  },
+  {
+    id: 'content-type',
+    severity: 'error',
+    title: '응답 content-type이 application/json이 아니다',
+    why: '`*/*`는 produces 미지정 시의 기본값이다. 생성물이 지저분해지고 진짜 다른 타입(CSV·ZIP)과 구분이 안 된다.',
+    run: (spec) =>
+      operations(spec).flatMap(({ op, at }) =>
+        Object.entries(op.responses)
+          .flatMap(([code, res]) => Object.keys(res.content ?? {}).map((ct) => [code, ct]))
+          .filter(([, ct]) => ct !== 'application/json')
+          .map(([code, ct]) => `${at} ${code} → ${ct}`),
+      ),
+  },
+  {
+    id: 'operation-id',
+    severity: 'error',
+    title: 'operationId가 없거나 중복이거나 _N 접미사가 붙었다',
+    why: 'operationId가 우리 함수명·타입명·쿼리 키의 원천이다. _N은 springdoc이 중복을 만나 붙인 것이라 다른 API에 옮겨갈 수 있다.',
+    run: (spec) => {
+      const ops = operations(spec)
+      const seen = new Map()
+      for (const { op, at } of ops)
+        seen.set(op.operationId, [...(seen.get(op.operationId) ?? []), at])
+      return ops.flatMap(({ op, at }) => {
+        if (!op.operationId) return [`${at} — operationId 없음`]
+        if (/_\d+$/.test(op.operationId))
+          return [`${at} — ${op.operationId} (자동 중복 회피 접미사)`]
+        if (seen.get(op.operationId).length > 1) return [`${at} — ${op.operationId} 중복`]
+        return []
+      })
+    },
+  },
+  {
+    id: 'readiness',
+    severity: 'error',
+    title: 'x-readiness가 없다',
+    why: '준비 안 된 API로 함수를 만들면 누군가 쓴다. 코드가 아니라 데이터로 걸러야 배포 환경이 바뀔 때 저절로 풀린다.',
+    run: (spec) =>
+      operations(spec)
+        .filter(({ op }) => !['available', 'hold', 'unavailable'].includes(op['x-readiness']))
+        .map(({ at, op }) => `${at} → ${op['x-readiness'] ?? '(없음)'}`),
+  },
+  {
+    id: 'security',
+    severity: 'error',
+    title: '전역 security 표기가 없다',
+    why: '표기가 없으면 "인증이 필요 없다"와 구분이 안 된다.',
+    run: (spec) => (spec.security?.length ? [] : ['루트에 security가 없다']),
+  },
+  {
+    id: 'error-examples',
+    severity: 'warn',
+    title: '에러 응답에서 코드를 추출할 수 없다 (examples 없음)',
+    why: 'examples의 키가 곧 에러 코드다. 없으면 ApiErrorCode 유니온에서 빠져 화면이 그 분기를 못 만든다.',
+    run: (spec) =>
+      operations(spec).flatMap(({ op, at }) =>
+        [...errorResponses(op)]
+          .filter(([, r]) => codesOf(r).length === 0)
+          .map(([c]) => `${at} ${c}`),
+      ),
+  },
+  {
+    id: 'generic-only',
+    severity: 'warn',
+    title: '에러 코드가 HTTP 상태를 옮긴 일반 코드뿐이다',
+    why: '화면이 케이스를 못 가른다 — 원인이 달라도 같은 코드로 오면 분기할 근거가 없다.',
+    run: (spec) =>
+      operations(spec).flatMap(({ op, at }) => {
+        const codes = [...errorResponses(op)].flatMap(([, r]) => codesOf(r))
+        if (!codes.length || codes.some((c) => !GENERIC_CODES.has(c))) return []
+        if (GENERIC_ONLY_AGREED.has(at)) return [] // 합의된 예외
+        return [`[${op.tags?.[0] ?? '?'}] ${at} → ${[...new Set(codes)].join(',')}`]
+      }),
+  },
+  {
+    id: 'enum-inline',
+    severity: 'warn',
+    title: '같은 enum 값 집합이 여러 곳에 복사돼 있다',
+    why: '같은 개념이 서로 다른 타입이 된다. 한쪽에만 값이 추가되면 아무도 모른다.',
+    run: (spec) => {
+      const counts = new Map()
+      JSON.stringify(spec.components?.schemas ?? {}, (k, v) => {
+        if (v?.enum) counts.set(v.enum.join('|'), (counts.get(v.enum.join('|')) ?? 0) + 1)
+        return v
+      })
+      return [...counts]
+        .filter(([vals, n]) => n > 1 && !ENUM_INLINE_AGREED.has(vals))
+        .map(([vals, n]) => `${n}회 — ${vals}`)
+    },
+  },
+  {
+    id: 'list-envelope',
+    severity: 'warn',
+    title: '목록 응답 봉투 — 생성기가 정규화하는 대상',
+    why: '우리가 흡수한다(D4-2). 다만 페이징 필드가 일부만 있으면 total을 어느 쪽으로 읽을지 정할 수 없다.',
+    run: (spec) =>
+      Object.entries(spec.components?.schemas ?? {})
+        .filter(([, s]) => Object.values(s.properties ?? {}).some((p) => p.type === 'array'))
+        .flatMap(([name, s]) => {
+          const keys = Object.keys(s.properties)
+          const has = PAGE_FIELDS.filter((f) => keys.includes(f))
+          if (has.length === 0 || has.length === PAGE_FIELDS.length) return []
+          return [`${name} — 페이징 필드가 일부만 있다 (${has.join(',')})`]
+        }),
+  },
+]
+
+// ── 실행 ─────────────────────────────────────────────────────────────────────
+
+// 테스트가 isNullable·assertsNull만 import할 수 있게, 직접 실행일 때만 검사를 돌린다
+if (process.argv[1] !== fileURLToPath(import.meta.url)) {
+  // import된 경우 — 아무것도 하지 않는다
+} else main()
+
+function main() {
+  const args = process.argv.slice(2)
+  const specPath = args.includes('--spec') ? args[args.indexOf('--spec') + 1] : SPEC
+  const verbose = args.includes('--verbose')
+
+  let spec
+  try {
+    spec = JSON.parse(readFileSync(specPath, 'utf8'))
+  } catch (e) {
+    console.error(`✗ 스펙을 읽지 못했습니다 (${specPath}) — 먼저 npm run api:pull\n  ${e.message}`)
+    process.exit(1)
+  }
+
+  console.log(`${specPath} — ${spec.info?.title ?? '?'} ${spec.info?.version ?? ''}`)
+  console.log(
+    `오퍼레이션 ${operations(spec).length} · 스키마 ${Object.keys(spec.components?.schemas ?? {}).length}\n`,
+  )
+
+  let errors = 0
+  let warns = 0
+
+  for (const rule of rules) {
+    const hits = rule.run(spec)
+    const mark = hits.length === 0 ? '✅' : rule.severity === 'error' ? '❌' : '⚠️ '
+    console.log(`${mark} [${rule.id}] ${rule.title} — ${hits.length}건`)
+    if (hits.length) {
+      if (rule.severity === 'error') errors += hits.length
+      else warns += hits.length
+      console.log(`     ${rule.why}`)
+      for (const h of verbose ? hits : hits.slice(0, HEAD)) console.log(`     · ${h}`)
+      if (!verbose && hits.length > HEAD)
+        console.log(`     … 그 외 ${hits.length - HEAD}건 (--verbose)`)
+    }
+    console.log()
+  }
+
+  console.log(`error ${errors}건 · warn ${warns}건`)
+  if (errors) {
+    console.log('\nerror가 남아 있으면 생성 타입이 실제와 어긋납니다. 백엔드에 전달하세요.')
+    process.exit(1)
+  }
+  console.log(
+    warns
+      ? '\n생성 가능합니다. warn은 개선 요청 중이거나 우리가 흡수하는 항목입니다.'
+      : '\n전부 통과했습니다.',
+  )
+}

--- a/scripts/api-check.test.mjs
+++ b/scripts/api-check.test.mjs
@@ -1,0 +1,47 @@
+/*
+  api-check의 nullable 판정을 고정한다 — `node --test scripts/`
+
+  왜 이 두 함수만 테스트하나: 나머지 규칙은 스펙을 훑어 세는 단순 집계라 틀리면 눈에 띈다.
+  반면 nullable 판정은 **정상인 것을 위반으로 잡아도 아무도 모른다** — 실제로 처음 돌렸을 때
+  `oneOf: [{$ref}, {type:'null'}]` 5건을 전부 오탐했다. 규칙이 있다는 것과 규칙이 작동한다는
+  것은 다르다(decision-log D15).
+*/
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { isNullable, assertsNull } from './api-check.mjs'
+
+test('isNullable — null을 허용하는 네 가지 표기', () => {
+  assert.ok(isNullable({ type: 'string', nullable: true }), '3.0 nullable 플래그')
+  assert.ok(isNullable({ type: ['string', 'null'] }), '3.1 타입 배열')
+  assert.ok(isNullable({ oneOf: [{ $ref: '#/x' }, { type: 'null' }] }), '3.1 oneOf + null')
+  assert.ok(isNullable({ anyOf: [{ $ref: '#/x' }, { type: 'null' }] }), '3.1 anyOf + null')
+})
+
+test('isNullable — 허용하지 않는 것', () => {
+  assert.ok(!isNullable({ type: 'string' }))
+  assert.ok(!isNullable({ $ref: '#/components/schemas/DisclosureScope' }))
+  assert.ok(!isNullable({ oneOf: [{ $ref: '#/x' }, { type: 'string' }] }), 'null 분기가 없다')
+  assert.ok(!isNullable(undefined))
+})
+
+test('assertsNull — null일 수 있다고 주장하는 문장', () => {
+  assert.ok(assertsNull('지정하지 않은 기관은 null.'))
+  assert.ok(assertsNull('아직 배정 전이면 null'))
+  assert.ok(assertsNull('활성 정책이 없으면 null'))
+})
+
+test('assertsNull — 부정문은 잡지 않는다', () => {
+  // 실제 스펙 문장. 이걸 오탐해서 규칙을 고쳤다
+  assert.ok(
+    !assertsNull(
+      '중복은 서버가 제거하고, 빈 배열을 보내면 전체 해제된다. null은 허용하지 않는다(빈 배열로 보낼 것).',
+    ),
+  )
+  assert.ok(!assertsNull('null이 아니다'))
+  assert.ok(!assertsNull('null을 보내지 마세요'))
+})
+
+test('assertsNull — null 언급이 없으면 대상이 아니다', () => {
+  assert.ok(!assertsNull('기관명'))
+  assert.ok(!assertsNull(undefined))
+})

--- a/scripts/api-gen.mjs
+++ b/scripts/api-gen.mjs
@@ -1,0 +1,489 @@
+#!/usr/bin/env node
+/*
+  스펙에서 코드를 생성한다 — `npm run api:gen`
+
+  ## 이 스크립트의 형태가 곧 설계 결정이다
+  스펙을 한 번 읽어 **중간표현(IR)** 을 만들고, 모든 렌더러가 그 배열 하나만 본다.
+  참고했던 기존 툴킷은 생성한 .ts 파일을 정규식으로 다시 파싱하고(`export const (\w+) = async`),
+  query냐 mutation이냐를 **함수 이름 접두어**로 판정했다 — HTTP 메서드가 스펙에 있는데도.
+  그 구조 때문에 응답 타입이 `any`로 폴백되고 경로가 뭉개졌다(api-codegen.md 1-3).
+  여기서는 `method`를 보면 되고 `$ref`를 따라가면 된다. **텍스트를 다시 읽는 단계가 없다.**
+
+  ## 경로·이름은 전부 api/codegen.config.json에 있다
+  이 파일에 경로 문자열을 박지 않는다. 배치를 바꾸고 싶으면 설정만 고친다.
+
+  ## 만드는 것 (OpenAPI 태그 = 도메인 = 폴더)
+    src/api/schema.d.ts             openapi-typescript 원본 (스펙이 하나라 한 벌)
+    src/api/errorCodes.ts           전역 에러 코드 유니온
+    src/api/PENDING.md              아직 못 쓰는 API
+    src/api/{tag}/{tag}Types.ts     operationId별 별칭 (login_Body · login_Response …)
+    src/api/{tag}/{tag}Api.ts       호출 함수
+    src/api/{tag}/{tag}Keys.ts      쿼리 키
+    src/api/{tag}/use{Tag}Queries.ts    GET 훅
+    src/api/{tag}/use{Tag}Mutations.ts  쓰기 훅 (도메인 무효화 기본 포함)
+
+  ## 화면 폴더에 넣지 않는 이유
+  태그가 화면과 1:1이 아니다 — `Usage Metering`은 SA-02와 OP-06이 같이 쓰고,
+  `Reporting`은 TR-04와 OP-05가 같이 쓴다. 화면 폴더에 넣으면 어느 쪽에 둘지 근거가 없고,
+  다른 역할이 쓸 때 레이어 린트(features/A → features/B 금지)에 막힌다.
+  화면은 어차피 `features/…/api.ts` 어댑터를 통해 쓰므로(D5) 옆에 있을 필요가 없다.
+*/
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const CONFIG = 'api/codegen.config.json'
+const BANNER = `/* 자동 생성 — 손으로 고치지 마세요. 다시 만들려면: npm run api:gen */\n`
+
+// ── 이름 규칙 ────────────────────────────────────────────────────────────────
+
+const pascal = (s) => s.charAt(0).toUpperCase() + s.slice(1)
+/** 'Academic Operations' → 'academicOperations' (설정의 tagAliases가 우선한다) */
+const camelize = (s) =>
+  s
+    .replace(/[^a-zA-Z0-9]+(.)/g, (_, c) => c.toUpperCase())
+    .replace(/^(.)/, (_, c) => c.toLowerCase())
+
+/** 경로·파일명 치환 */
+const fill = (template, vars) => template.replace(/\{(\w+)\}/g, (_, key) => vars[key] ?? `{${key}}`)
+
+// ── IR ───────────────────────────────────────────────────────────────────────
+
+/**
+ * 스펙 → 오퍼레이션 배열. 이 함수 아래로는 스펙 JSON을 다시 열지 않는다.
+ * 렌더러가 필요로 하는 것만 담는다 — 여기 없는 필드가 필요해지면 IR을 넓힌다.
+ */
+export function buildIR(spec, tags = {}) {
+  const ops = []
+  for (const [path, item] of Object.entries(spec.paths ?? {})) {
+    for (const [method, op] of Object.entries(item)) {
+      if (!op || typeof op !== 'object' || !op.responses) continue
+
+      const success = Object.keys(op.responses)
+        .map(Number)
+        .filter((c) => c >= 200 && c < 300)
+        .sort((a, b) => a - b)[0]
+
+      const errorCodes = Object.entries(op.responses)
+        .filter(([c]) => Number(c) >= 400)
+        .flatMap(([, r]) => Object.keys(r.content?.['application/json']?.examples ?? {}))
+
+      const params = op.parameters ?? []
+      const bodyTypes = Object.keys(op.requestBody?.content ?? {})
+      const tag = op.tags?.[0] ?? 'default'
+
+      ops.push({
+        id: op.operationId,
+        method: method.toUpperCase(),
+        path,
+        tag,
+        /** 폴더·파일 이름이 되는 짧은 이름 */
+        tagName: tags[tag] ?? camelize(tag),
+        readiness: op['x-readiness'] ?? 'available',
+        summary: (op.summary ?? '').split('|')[0].trim(),
+        hasPath: params.some((p) => p.in === 'path'),
+        hasQuery: params.some((p) => p.in === 'query'),
+        /** 필수 쿼리 파라미터가 하나라도 있으면 인자를 optional로 만들면 안 된다 */
+        queryRequired: params.some((p) => p.in === 'query' && p.required),
+        /**
+         * 쿠키 파라미터는 브라우저가 싣는다(httpOnly라 JS가 만질 수도 없다).
+         * 그런데 스펙이 required로 선언하면 타입이 값을 요구하므로 생성기가 채워 준다.
+         */
+        hasCookie: params.some((p) => p.in === 'cookie'),
+        hasBody: Boolean(op.requestBody),
+        /** multipart(파일 업로드)는 openapi-fetch 밖에서 손으로 쓴다 — api-codegen.md B1 */
+        isMultipart: bodyTypes.some((t) => t.startsWith('multipart/')),
+        successCode: success,
+        // 204처럼 본문이 없는 응답 — 반환 타입이 void가 된다
+        hasResponseBody: Boolean(op.responses[success]?.content?.['application/json']),
+        /** 목록 응답이면 항목 타입도 별칭으로 뽑는다 — 화면이 스키마 이름을 몰라도 되게 */
+        listProp: listPropertyOf(spec, op.responses[success]),
+        errorCodes: [...new Set(errorCodes)],
+      })
+    }
+  }
+  return ops
+}
+
+/** 성공 응답이 목록 봉투면 배열 속성 이름을 돌려준다 (`content` 등). 아니면 null */
+function listPropertyOf(spec, response) {
+  const ref = response?.content?.['application/json']?.schema?.$ref
+  if (!ref) return null
+  const schema = spec.components?.schemas?.[ref.split('/').pop()]
+  const arrays = Object.entries(schema?.properties ?? {}).filter(([, p]) => p.type === 'array')
+  return arrays.length === 1 ? arrays[0][0] : null
+}
+
+// ── 렌더러 ───────────────────────────────────────────────────────────────────
+
+/*
+  타입 별칭 이름은 `operationId_접미사`다 — 팀 컨벤션이고, 규칙이라 **스키마 이름을 몰라도
+  화면에서 바로 찾을 수 있다**는 것이 목적이다. PascalCase로 이어 붙이면 길어져 읽기 나쁘다.
+*/
+const alias = (op, suffix) => `${op.id}_${suffix}`
+
+export function renderDomainTypes(ops, cfg) {
+  const lines = [
+    BANNER,
+    `import type { operations } from '${cfg.imports.schema}'\n`,
+    `/*`,
+    `  operationId별 타입 별칭. 규칙이 고정이라 스키마 이름을 몰라도 찾을 수 있다:`,
+    `    {operationId}_Body · _Query · _Path · _Response · _Item · _Errors`,
+    `*/\n`,
+  ]
+  for (const op of ops) {
+    const O = `operations['${op.id}']`
+    lines.push(`// ${op.method} ${op.path}${op.summary ? ` — ${op.summary}` : ''}`)
+    if (op.hasPath) lines.push(`export type ${alias(op, 'Path')} = ${O}['parameters']['path']`)
+    if (op.hasQuery)
+      lines.push(`export type ${alias(op, 'Query')} = NonNullable<${O}['parameters']['query']>`)
+    if (op.hasBody)
+      lines.push(
+        `export type ${alias(op, 'Body')} = NonNullable<${O}['requestBody']>['content']['${
+          op.isMultipart ? 'multipart/form-data' : 'application/json'
+        }']`,
+      )
+    const responseType = op.hasResponseBody
+      ? `${O}['responses'][${op.successCode}]['content']['application/json']`
+      : 'void'
+    lines.push(`export type ${alias(op, 'Response')} = ${responseType}`)
+    // 목록이면 항목 타입까지 — 표 컴포넌트가 쓰는 것이 이쪽이다
+    if (op.listProp)
+      lines.push(
+        `export type ${alias(op, 'Item')} = ${alias(op, 'Response')}['${op.listProp}'][number]`,
+      )
+    if (op.errorCodes.length)
+      lines.push(
+        `export type ${alias(op, 'Errors')} = ${op.errorCodes.map((c) => `'${c}'`).join(' | ')}`,
+      )
+    lines.push('')
+  }
+  return lines.join('\n')
+}
+
+export function renderErrorCodes(ops) {
+  const codes = [...new Set(ops.flatMap((o) => o.errorCodes))].sort()
+  return `${BANNER}
+/*
+  서버가 낼 수 있는 에러 코드 전량. 응답의 \`examples\` 키가 곧 코드명이라는 규약에서 뽑았다.
+  오퍼레이션별로 좁힌 유니온은 각 도메인의 \`{tagName}Types.ts\`에 \`{operationId}_Errors\`로 있다 —
+  화면 분기는 그쪽을 쓰는 편이 낫다. switch가 exhaustive해져서 **백엔드가 코드를 추가하면 컴파일이 알려준다.**
+
+  ⚠️ 이 유니온이 전부는 아니다 — 스펙이 늘 최신이라는 보장이 없으므로 \`ApiError.code\`는
+  이 값들로 **자동완성만** 하고 다른 문자열도 받는다.
+*/
+export type ApiErrorCode =
+${codes.map((c) => `  | '${c}'`).join('\n')}
+`
+}
+
+export function renderDomainApi(ops, cfg) {
+  const { tagName } = ops[0]
+  const typeNames = ops
+    .flatMap((op) => [
+      op.hasPath && alias(op, 'Path'),
+      op.hasQuery && alias(op, 'Query'),
+      op.hasBody && alias(op, 'Body'),
+      alias(op, 'Response'),
+    ])
+    .filter(Boolean)
+
+  const fns = ops.map((op) => {
+    const args = [
+      op.hasPath && `path: ${alias(op, 'Path')}`,
+      op.hasQuery && `query${op.queryRequired ? '' : '?'}: ${alias(op, 'Query')}`,
+      op.hasBody && `body: ${alias(op, 'Body')}`,
+    ].filter(Boolean)
+
+    /*
+      인자 순서를 외우지 않게 단일 객체로 받는다(api-codegen.md D3).
+      필수 인자가 없으면 객체 자체에 기본값을 준다 — 안 그러면 빈 객체를 넘겨야 하는 함수가 된다.
+      `signal`은 React Query가 넘겨주는 취소 신호다. 화면을 떠나면 요청이 실제로 끊긴다.
+    */
+    const allOptional = !op.hasPath && !op.hasBody && !op.queryRequired
+    const sig = args.length
+      ? `params: { ${args.join('; ')} } & RequestOptions${allOptional ? ' = {}' : ''}`
+      : 'params: RequestOptions = {}'
+    const paramParts = [
+      op.hasPath && 'path: params.path',
+      op.hasQuery && (op.queryRequired ? 'query: params.query' : 'query: params.query ?? {}'),
+      // 브라우저가 싣는 값이라 호출자에게 묻지 않는다
+      op.hasCookie && 'cookie: undefined as never',
+    ].filter(Boolean)
+    const init = [
+      paramParts.length && `params: { ${paramParts.join(', ')} }`,
+      op.hasBody && 'body: params.body',
+      'signal: params.signal',
+    ].filter(Boolean)
+
+    return `/** ${op.summary || op.id} — \`${op.method} ${op.path}\` */
+export const ${op.id} = (${sig}) =>
+  unwrap<${alias(op, 'Response')}>(izClient.${op.method}('${op.path}', { ${init.join(', ')} }) as never)`
+  })
+
+  return `${BANNER}
+import { izClient, unwrap, type RequestOptions } from '${cfg.imports.contract}'
+import type {
+${typeNames.map((t) => `  ${t},`).join('\n')}
+} from '${fill(cfg.imports.domainTypes, { tagName })}'
+
+${fns.join('\n\n')}
+`
+}
+
+export function renderQueryKeys(ops, cfg) {
+  const { tagName } = ops[0]
+  const reads = ops.filter((op) => op.method === 'GET')
+  const keysName = `${tagName}Keys`
+  const typeNames = reads
+    .flatMap((op) => [op.hasPath && alias(op, 'Path'), op.hasQuery && alias(op, 'Query')])
+    .filter(Boolean)
+
+  const entries = reads.map((op) => {
+    const parts = [op.hasPath && 'path', op.hasQuery && 'query'].filter(Boolean)
+    const args = [
+      op.hasPath && `path: ${alias(op, 'Path')}`,
+      op.hasQuery && `query?: ${alias(op, 'Query')}`,
+    ].filter(Boolean)
+    const sig = args.length ? `(params: { ${args.join('; ')} })` : '()'
+    const value = parts.length
+      ? `[...${keysName}.all, '${op.id}', ${parts.map((p) => `params.${p} ?? null`).join(', ')}]`
+      : `[...${keysName}.all, '${op.id}']`
+    return `  ${op.id}: ${sig} => ${value} as const,`
+  })
+
+  return `${BANNER}
+${typeNames.length ? `import type {\n${typeNames.map((t) => `  ${t},`).join('\n')}\n} from '${fill(cfg.imports.domainTypes, { tagName })}'\n` : ''}
+/*
+  \`all\`이 이 도메인 전체를 가리킨다 — 쓰기 훅이 성공하면 이 접두어로 한 번에 무효화한다.
+  "이 상세가 어느 목록에 속하는가"는 스펙에 없어 생성기가 알 수 없다. **넓게 지우는 것은
+  틀리지 않는다**(과잉 재조회일 뿐). 부분 무효화가 필요해지면 그 도메인만 계층을 넣는다.
+*/
+export const ${keysName} = {
+  all: ['${tagName}'] as const,
+${entries.join('\n')}
+}
+`
+}
+
+export function renderQueries(ops, cfg) {
+  const reads = ops.filter((op) => op.method === 'GET')
+  if (!reads.length) return null
+  const { tagName } = ops[0]
+  const keysName = `${tagName}Keys`
+
+  const typeNames = reads
+    .flatMap((op) => [
+      op.hasPath && alias(op, 'Path'),
+      op.hasQuery && alias(op, 'Query'),
+      alias(op, 'Response'),
+    ])
+    .filter(Boolean)
+
+  const hooks = reads.map((op) => {
+    const args = [
+      op.hasPath && `path: ${alias(op, 'Path')}`,
+      op.hasQuery && `query${op.queryRequired ? '' : '?'}: ${alias(op, 'Query')}`,
+    ].filter(Boolean)
+    const allOptional = !op.hasPath && !op.queryRequired
+    const paramType = args.length ? `{ ${args.join('; ')} }` : 'Record<string, never>'
+    const sig = args.length
+      ? `params: ${paramType}${allOptional ? ' = {}' : ''}, options?: QueryOptions<${alias(op, 'Response')}>`
+      : `options?: QueryOptions<${alias(op, 'Response')}>`
+    const keyArg = args.length ? `${keysName}.${op.id}(params)` : `${keysName}.${op.id}()`
+    const callArg = args.length ? '{ ...params, signal }' : '{ signal }'
+
+    return `/** ${op.summary || op.id} */
+export function use${pascal(op.id)}(${sig}) {
+  return useQuery({
+    queryKey: ${keyArg},
+    queryFn: ({ signal }) => ${op.id}(${callArg}),
+    ...options,
+  })
+}`
+  })
+
+  return `${BANNER}
+import { useQuery } from '${cfg.imports.reactQuery}'
+import type { QueryOptions } from '${cfg.imports.contract}'
+import { ${reads.map((o) => o.id).join(', ')} } from '${fill(cfg.imports.domainApi, { tagName })}'
+import { ${keysName} } from '${fill(cfg.imports.queryKeys, { tagName })}'
+import type {
+${[...new Set(typeNames)].map((t) => `  ${t},`).join('\n')}
+} from '${fill(cfg.imports.domainTypes, { tagName })}'
+
+${hooks.join('\n\n')}
+`
+}
+
+export function renderMutations(ops, cfg) {
+  const writes = ops.filter((op) => op.method !== 'GET')
+  if (!writes.length) return null
+  const { tagName } = ops[0]
+  const keysName = `${tagName}Keys`
+
+  const typeNames = writes
+    .flatMap((op) => [
+      op.hasPath && alias(op, 'Path'),
+      op.hasQuery && alias(op, 'Query'),
+      op.hasBody && alias(op, 'Body'),
+      alias(op, 'Response'),
+    ])
+    .filter(Boolean)
+
+  const hooks = writes.map((op) => {
+    const args = [
+      op.hasPath && `path: ${alias(op, 'Path')}`,
+      op.hasQuery && `query?: ${alias(op, 'Query')}`,
+      op.hasBody && `body: ${alias(op, 'Body')}`,
+    ].filter(Boolean)
+    const varType = args.length ? `{ ${args.join('; ')} }` : 'void'
+    const mutationFn = args.length ? `(vars: ${varType}) => ${op.id}(vars)` : `() => ${op.id}()`
+
+    return `/** ${op.summary || op.id} */
+export function use${pascal(op.id)}(options?: MutationOptions<${alias(op, 'Response')}, ${varType}>) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ${mutationFn},
+    ...options,
+    onSuccess: (...args) => {
+      // 기본 무효화 — 이 도메인의 조회를 전부 다시 읽는다
+      queryClient.invalidateQueries({ queryKey: ${keysName}.all })
+      options?.onSuccess?.(...args)
+    },
+  })
+}`
+  })
+
+  return `${BANNER}
+import { useMutation, useQueryClient } from '${cfg.imports.reactQuery}'
+import type { MutationOptions } from '${cfg.imports.contract}'
+import { ${writes.map((o) => o.id).join(', ')} } from '${fill(cfg.imports.domainApi, { tagName })}'
+import { ${keysName} } from '${fill(cfg.imports.queryKeys, { tagName })}'
+import type {
+${[...new Set(typeNames)].map((t) => `  ${t},`).join('\n')}
+} from '${fill(cfg.imports.domainTypes, { tagName })}'
+
+/*
+  쓰기가 성공하면 **이 도메인의 조회를 전부 무효화한다.** 무엇을 다시 읽어야 하는지는
+  스펙에 없는 도메인 지식이라 생성기가 정확히 알 수 없다 — 넓게 지우면 틀리지 않는다.
+  더 좁히고 싶으면 \`options.onSuccess\`에서 직접 무효화하고, 기본 동작은 그대로 둔다.
+*/
+${hooks.join('\n\n')}
+`
+}
+
+export function renderPending(pending, handwritten) {
+  const rows = pending
+    .map((op) => `| \`${op.readiness}\` | ${op.method} ${op.path} | ${op.summary} |`)
+    .join('\n')
+  const hand = handwritten.length
+    ? `\n## 손으로 쓰는 것 — multipart\n\n\`openapi-fetch\`는 JSON 직렬화를 전제한다. 파일 업로드는 \`FormData\`를 직접 만들어야 하므로\n호출 함수를 생성하지 않는다. **타입(\`{tagName}Types.ts\`)은 생성돼 있으니 그것을 쓴다.**\n\n${handwritten
+        .map((op) => `- \`${op.method} ${op.path}\` — ${op.summary}`)
+        .join('\n')}\n`
+    : ''
+  return `# 아직 생성하지 않은 API
+
+\`x-readiness\`가 \`available\`이 아니어서 **호출 함수를 만들지 않았다.**
+함수가 있으면 누군가 쓰기 때문이다 — 그 화면은 목 데이터로 계속 돈다.
+
+배포 환경 제약(메일 발송 불가 등)으로 막힌 것이 많다. **구현이 없는 게 아니라 환경이 막은
+것**이라, 백엔드가 \`available\`로 바꾸면 \`npm run api:gen\`만 다시 돌리면 된다.
+
+| readiness | 엔드포인트 | |
+|---|---|---|
+${rows}
+${hand}
+> 이 파일은 자동 생성물이다. 손으로 고치지 마세요.
+`
+}
+
+// ── 실행 ─────────────────────────────────────────────────────────────────────
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) main()
+
+function write(path, content) {
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, content)
+}
+
+function main() {
+  const cfg = JSON.parse(readFileSync(CONFIG, 'utf8'))
+  const sharedDir = cfg.paths.shared
+
+  if (!existsSync(cfg.spec.file)) {
+    console.error(`✗ ${cfg.spec.file}이 없습니다 — 먼저 npm run api:pull`)
+    process.exit(1)
+  }
+
+  // 1) 스펙 전체를 타입으로. 런타임 코드가 0이라 우리가 얹는 층이 전부 이 위에 선다.
+  //    도메인이 나뉘어도 이건 한 벌이다 — 스펙 자체가 하나이기 때문.
+  mkdirSync(sharedDir, { recursive: true })
+  execFileSync(
+    'npx',
+    ['openapi-typescript', cfg.spec.file, '-o', `${sharedDir}/${cfg.files.schema}`],
+    { stdio: 'inherit' },
+  )
+
+  const spec = JSON.parse(readFileSync(cfg.spec.file, 'utf8'))
+  const ir = buildIR(spec, cfg.tags)
+
+  const missingId = ir.filter((op) => !op.id)
+  if (missingId.length) {
+    console.error(`✗ operationId가 없는 오퍼레이션 ${missingId.length}건 — npm run api:check`)
+    process.exit(1)
+  }
+
+  const available = ir.filter((op) => op.readiness === 'available')
+  const pending = ir.filter((op) => op.readiness !== 'available')
+  /*
+    multipart는 호출 함수를 만들지 않는다 — openapi-fetch는 JSON 직렬화를 전제하므로
+    파일 업로드는 밖에서 손으로 쓴다. 타입은 남겨 그 손 코드가 쓴다.
+  */
+  const callable = available.filter((op) => !op.isMultipart)
+  const handwritten = available.filter((op) => op.isMultipart)
+
+  write(`${sharedDir}/${cfg.files.errorCodes}`, renderErrorCodes(available))
+  write(`${sharedDir}/${cfg.files.pending}`, renderPending(pending, handwritten))
+
+  // 태그별로 묶어 **그 API를 쓰는 화면 폴더 옆에** 만든다
+  const byTag = new Map()
+  for (const op of callable) byTag.set(op.tagName, [...(byTag.get(op.tagName) ?? []), op])
+
+  const written = []
+  for (const [tagName, ops] of byTag) {
+    const v = { tagName, TagName: pascal(tagName) }
+    const dir = fill(cfg.paths.domain, v)
+    write(`${dir}/${fill(cfg.files.domainTypes, v)}`, renderDomainTypes(ops, cfg))
+    write(`${dir}/${fill(cfg.files.domainApi, v)}`, renderDomainApi(ops, cfg))
+    write(`${dir}/${fill(cfg.files.queryKeys, v)}`, renderQueryKeys(ops, cfg))
+    const queries = renderQueries(ops, cfg)
+    if (queries) write(`${dir}/${fill(cfg.files.queries, v)}`, queries)
+    const mutations = renderMutations(ops, cfg)
+    if (mutations) write(`${dir}/${fill(cfg.files.mutations, v)}`, mutations)
+    written.push({ tagName, dir, count: ops.length })
+  }
+
+  // 생성물은 format:check 대상이지만 사람이 맞출 수는 없으므로 생성 단계에서 포맷한다
+  execFileSync(
+    'npx',
+    [
+      'prettier',
+      '--write',
+      '--log-level',
+      'warn',
+      `${sharedDir}/*.ts`,
+      `${sharedDir}/*.d.ts`,
+      ...written.map((w) => `${w.dir}/*.ts`),
+    ],
+    { stdio: 'inherit' },
+  )
+
+  console.log(`\n생성`)
+  console.log(`  ${sharedDir}/ — schema.d.ts · errorCodes.ts · PENDING.md`)
+  for (const w of written) console.log(`  ${w.dir}/ — ${w.tagName} ${w.count}개`)
+  console.log(
+    `\n  호출 함수 ${callable.length} · 미준비 ${pending.length} · 손으로 쓸 것 ${handwritten.length}`,
+  )
+}

--- a/scripts/api-gen.test.mjs
+++ b/scripts/api-gen.test.mjs
@@ -1,0 +1,203 @@
+/*
+  생성기의 분기를 고정한다 — `node --test scripts/api-gen.test.mjs`
+
+  ## 왜 전체 스펙 스냅샷이 아닌가
+  실제 스펙을 스냅샷으로 잡으면 **백엔드가 뭘 고칠 때마다 깨진다.** 그러면 사람들이
+  내용을 안 보고 갱신하게 되고, 그 순간 테스트가 아니라 의식(儀式)이 된다.
+  고정 입력을 쓰면 깨지는 이유가 하나뿐이다 — **생성기가 바뀐 것.**
+
+  ## 왜 문자열 전량 비교가 아닌가
+  주석 한 줄만 다듬어도 깨진다. 대신 **결정이 걸려 있는 지점**만 확인한다:
+  경로·인자 모양·필수 여부·제외 규칙. 실제로 이 넷에서 전부 버그가 났었다.
+*/
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  buildIR,
+  renderDomainApi,
+  renderQueryKeys,
+  renderDomainTypes,
+  renderErrorCodes,
+} from './api-gen.mjs'
+
+/** 분기를 하나씩 대표하는 최소 스펙 */
+const SPEC = {
+  paths: {
+    '/api/v0/things': {
+      // ① 선택 쿼리만 — 인자 없이 부를 수 있어야 한다
+      get: {
+        operationId: 'findThings',
+        tags: ['Thing Domain'],
+        summary: '목록 | ✅ 사용 가능',
+        'x-readiness': 'available',
+        parameters: [{ name: 'q', in: 'query', required: false, schema: { type: 'string' } }],
+        responses: {
+          200: {
+            content: { 'application/json': { schema: { $ref: '#/components/schemas/ThingList' } } },
+          },
+          409: {
+            content: {
+              'application/json': { schema: {}, examples: { THING_NAME_TAKEN: {}, CONFLICT: {} } },
+            },
+          },
+        },
+      },
+      // ② 바디 — 필수
+      post: {
+        operationId: 'createThing',
+        tags: ['Thing Domain'],
+        'x-readiness': 'available',
+        requestBody: { content: { 'application/json': { schema: {} } } },
+        responses: { 201: { content: { 'application/json': { schema: {} } } } },
+      },
+    },
+    // ③ 경로 파라미터
+    '/api/v0/things/{thingId}': {
+      get: {
+        operationId: 'findThing',
+        tags: ['Thing Domain'],
+        'x-readiness': 'available',
+        parameters: [{ name: 'thingId', in: 'path', required: true, schema: { type: 'string' } }],
+        responses: { 200: { content: { 'application/json': { schema: {} } } } },
+      },
+      // ④ 본문 없는 성공 응답
+      delete: {
+        operationId: 'removeThing',
+        tags: ['Thing Domain'],
+        'x-readiness': 'available',
+        parameters: [{ name: 'thingId', in: 'path', required: true, schema: { type: 'string' } }],
+        responses: { 204: {} },
+      },
+    },
+    // ⑤ 필수 쿼리 — 선택으로 만들면 안 된다
+    '/api/v0/things/availability': {
+      get: {
+        operationId: 'checkThing',
+        tags: ['Thing Domain'],
+        'x-readiness': 'available',
+        parameters: [{ name: 'name', in: 'query', required: true, schema: { type: 'string' } }],
+        responses: { 200: { content: { 'application/json': { schema: {} } } } },
+      },
+    },
+    // ⑥ 준비 안 됨 — 생성 대상에서 빠져야 한다
+    '/api/v0/things/secret': {
+      get: {
+        operationId: 'findSecret',
+        tags: ['Thing Domain'],
+        'x-readiness': 'unavailable',
+        responses: { 200: { content: { 'application/json': { schema: {} } } } },
+      },
+    },
+    // ⑦ 쿠키 파라미터 — 브라우저가 싣는다
+    '/api/v0/auth/refresh': {
+      post: {
+        operationId: 'refreshThing',
+        tags: ['Thing Domain'],
+        'x-readiness': 'available',
+        parameters: [
+          { name: 'refresh_token', in: 'cookie', required: true, schema: { type: 'string' } },
+        ],
+        responses: { 200: { content: { 'application/json': { schema: {} } } } },
+      },
+    },
+    // ⑧ multipart — 손으로 쓴다
+    '/api/v0/things/upload': {
+      post: {
+        operationId: 'uploadThings',
+        tags: ['Thing Domain'],
+        'x-readiness': 'available',
+        requestBody: { content: { 'multipart/form-data': { schema: {} } } },
+        responses: { 200: { content: { 'application/json': { schema: {} } } } },
+      },
+    },
+  },
+  components: { schemas: {} },
+}
+
+/** 실제 설정과 같은 모양. 렌더러가 경로를 하드코딩하지 않는다는 것도 여기서 검증된다 */
+const CFG = {
+  imports: {
+    contract: '@/api/_contract',
+    schema: '@/api/schema',
+    domainTypes: './{tagName}Types',
+    domainApi: './{tagName}Api',
+    queryKeys: './{tagName}Keys',
+    reactQuery: '@tanstack/react-query',
+  },
+}
+const TAGS = { 'Thing Domain': 'thing' }
+
+const ir = buildIR(SPEC, TAGS)
+const byId = Object.fromEntries(ir.map((op) => [op.id, op]))
+const callable = ir.filter((op) => op.readiness === 'available' && !op.isMultipart)
+const code = renderDomainApi(callable, CFG)
+const keys = renderQueryKeys(callable, CFG)
+
+test('IR — 스펙에서 읽어야 하는 것들', () => {
+  assert.equal(ir.length, 8)
+  assert.equal(byId.findThings.method, 'GET')
+  assert.equal(byId.findThings.queryRequired, false)
+  assert.equal(byId.checkThing.queryRequired, true, '필수 쿼리를 인식해야 한다')
+  assert.equal(byId.refreshThing.hasCookie, true)
+  assert.equal(byId.uploadThings.isMultipart, true)
+  assert.equal(byId.removeThing.hasResponseBody, false, '204는 본문이 없다')
+  assert.equal(byId.findSecret.readiness, 'unavailable')
+  assert.equal(byId.findThings.summary, '목록', 'summary에서 준비 상태 표시는 뗀다')
+  assert.equal(byId.findThings.tagName, 'thing', '설정의 짧은 이름을 쓴다')
+})
+
+test('제외 규칙 — 준비 안 된 것과 multipart는 호출 함수를 만들지 않는다', () => {
+  assert.ok(!code.includes('findSecret'), 'unavailable이 새어 나왔다')
+  assert.ok(!code.includes('uploadThings'), 'multipart가 새어 나왔다')
+  assert.ok(code.includes('findThings'), 'available은 있어야 한다')
+})
+
+test('인자 모양 — 필수가 없으면 인자 없이 부를 수 있다', () => {
+  assert.match(
+    code,
+    /findThings = \(params: \{ query\?: findThings_Query \} & RequestOptions = \{\}\)/,
+  )
+  assert.match(code, /checkThing = \(params: \{ query: checkThing_Query \} & RequestOptions\)/)
+  assert.match(code, /findThing = \(params: \{ path: findThing_Path \} & RequestOptions\)/)
+  assert.match(code, /createThing = \(params: \{ body: createThing_Body \} & RequestOptions\)/)
+})
+
+test('경로는 스펙 문자열 그대로 — 뭉개지 않는다', () => {
+  assert.ok(
+    code.includes("izClient.GET('/api/v0/things/{thingId}'"),
+    '{thingId}가 살아 있어야 한다',
+  )
+  assert.ok(code.includes("izClient.DELETE('/api/v0/things/{thingId}'"))
+})
+
+test('쿠키 파라미터는 호출자에게 묻지 않는다', () => {
+  assert.match(
+    code,
+    /refreshThing = \(params: RequestOptions = \{\}\)/,
+    '호출자에게 쿠키를 묻지 않는다',
+  )
+  assert.ok(code.includes('cookie: undefined as never'))
+})
+
+test('쿼리 키 — 읽기(GET)만, 도메인 접두어로 묶인다', () => {
+  assert.ok(keys.includes("all: ['thing'] as const"))
+  assert.ok(keys.includes('findThings:'))
+  assert.ok(!keys.includes('createThing:'), '쓰기는 쿼리 키가 없다')
+})
+
+test('타입 별칭 — operationId_접미사 규칙 · 본문 없는 응답은 void', () => {
+  const types = renderDomainTypes(callable, CFG)
+  assert.ok(types.includes('export type removeThing_Response = void'))
+  assert.ok(
+    types.includes("export type findThing_Path = operations['findThing']['parameters']['path']"),
+  )
+  assert.ok(types.includes('export type findThings_Errors ='), '오퍼레이션별 에러 코드 유니온')
+  assert.ok(types.includes("from '@/api/schema'"), '경로는 설정에서 온다')
+})
+
+test('에러 코드 — examples 키에서 뽑아 정렬한다', () => {
+  const out = renderErrorCodes(callable)
+  assert.ok(out.includes("| 'CONFLICT'"))
+  assert.ok(out.includes("| 'THING_NAME_TAKEN'"))
+  assert.ok(out.indexOf("'CONFLICT'") < out.indexOf("'THING_NAME_TAKEN'"), '정렬되어야 한다')
+})

--- a/scripts/api-pull.mjs
+++ b/scripts/api-pull.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+/*
+  백엔드 OpenAPI 스펙을 레포 파일로 내려받는다 — `npm run api:pull`
+
+  왜 파일로 받아 커밋하나(api-codegen.md A1):
+    ① 스펙 변화가 PR diff로 보인다 — "백엔드가 무엇을 바꿨나"가 리뷰 대상이 된다
+    ② 네트워크 없이 빌드·생성이 된다 (CI가 백엔드 가동에 의존하지 않는다)
+    ③ 무엇을 기준으로 생성했는지가 커밋에 박힌다
+
+  ⚠️ 캐시버스터가 이 스크립트의 존재 이유 절반이다.
+     Railway 엣지가 옛 스펙을 그대로 준다. 실제로 1차 수정 직후 받은 파일이 이전 것과
+     바이트 단위로 같아서 "반영 안 됐다"고 오판했고, `?cb=`를 붙이니 새 파일이 나왔다.
+     그래서 매번 쿼리를 흔들고, 받은 뒤 해시와 개수를 찍어 "정말 바뀌었는지"를 보여준다.
+*/
+import { createHash } from 'node:crypto'
+import { readFileSync } from 'node:fs'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname } from 'node:path'
+
+/*
+  주소·저장 위치는 **생성기와 같은 설정 파일**에서 읽는다. 두 곳에 적어 두면 한쪽만 바꿨을 때
+  "받은 스펙"과 "코드를 만든 스펙"이 갈린다 — 실제로 백엔드를 옮기며 그럴 뻔했다.
+*/
+const CONFIG = 'api/codegen.config.json'
+
+function parseArgs(argv) {
+  const cfg = JSON.parse(readFileSync(CONFIG, 'utf8'))
+  const args = { url: process.env.IZ_API_DOCS_URL || cfg.spec.url, out: cfg.spec.file }
+  for (let i = 2; i < argv.length; i++) {
+    if (argv[i] === '--url') args.url = argv[++i]
+    else if (argv[i] === '--out') args.out = argv[++i]
+  }
+  return args
+}
+
+const sha = (s) => createHash('sha256').update(s).digest('hex').slice(0, 12)
+
+/** 사람이 "무엇이 달라졌나"를 한 줄로 볼 수 있는 최소 지표. 전체 diff는 git이 보여준다 */
+function summarize(spec) {
+  const ops = Object.values(spec.paths ?? {}).flatMap((item) =>
+    Object.entries(item).filter(([, op]) => op?.responses),
+  )
+  return {
+    version: spec.info?.version ?? '?',
+    paths: Object.keys(spec.paths ?? {}).length,
+    operations: ops.length,
+    schemas: Object.keys(spec.components?.schemas ?? {}).length,
+  }
+}
+
+const main = async () => {
+  const { url, out } = parseArgs(process.argv)
+
+  // 캐시버스터 두 겹 — 쿼리스트링(엣지 키를 바꾼다) + 헤더(중간 프록시용)
+  const bust = `${url}${url.includes('?') ? '&' : '?'}cb=${Date.now()}`
+  const res = await fetch(bust, { headers: { 'Cache-Control': 'no-cache', Pragma: 'no-cache' } })
+  if (!res.ok) throw new Error(`스펙을 받지 못했습니다 — HTTP ${res.status} ${url}`)
+
+  const raw = await res.text()
+  let spec
+  try {
+    spec = JSON.parse(raw)
+  } catch {
+    throw new Error(
+      '받은 응답이 JSON이 아닙니다. URL이 Swagger UI 페이지를 가리키고 있지 않은지 확인하세요.',
+    )
+  }
+
+  const before = await readFile(out, 'utf8').catch(() => null)
+  // 저장은 정규화(2칸 들여쓰기 + 끝 개행)해서 한다 — 서버가 한 줄로 주면 diff가 통째로 한 줄이 된다
+  const next = JSON.stringify(spec, null, 2) + '\n'
+
+  await mkdir(dirname(out), { recursive: true })
+  await writeFile(out, next)
+
+  const s = summarize(spec)
+  console.log(`↓ ${url}`)
+  console.log(
+    `  ${out}  ${s.version} · 경로 ${s.paths} · 오퍼레이션 ${s.operations} · 스키마 ${s.schemas}`,
+  )
+  console.log(`  sha256 ${sha(next)}${before ? ` (이전 ${sha(before)})` : ''}`)
+
+  if (before === next) {
+    console.log('\n= 이전과 동일합니다. 백엔드가 아직 재배포하지 않았을 수 있습니다.')
+  } else if (before) {
+    const b = summarize(JSON.parse(before))
+    const d = (a, z) => (a === z ? `${z}` : `${a} → ${z}`)
+    console.log(
+      `\n★ 바뀌었습니다 — 오퍼레이션 ${d(b.operations, s.operations)} · 스키마 ${d(b.schemas, s.schemas)}`,
+    )
+    console.log('  다음: npm run api:check')
+  } else {
+    console.log('\n★ 처음 받았습니다. 다음: npm run api:check')
+  }
+}
+
+main().catch((e) => {
+  console.error(`✗ ${e.message}`)
+  process.exit(1)
+})


### PR DESCRIPTION
## 작업 내용

백엔드 OpenAPI 스펙을 **받아오고 · 검사하고 · 코드를 생성하는** 파이프라인. 이 PR은 **도구와 설정까지**이고, 생성된 API 코드(`src/api/`)는 다음 PR에 들어온다.

```bash
npm run api:pull    # 스펙을 받아 api/openapi.json 에 저장
npm run api:check   # 규칙 11종 검사 (error는 실패, warn은 통과)
npm run api:gen     # 스펙 → IR → 코드
npm run api:test    # 검사기·생성기 자체 테스트 13개
```

## 리뷰 포인트

**① 명령을 셋으로 나눈 축은 "파이프라인 단계"가 아니다**

내부 단계는 7개(렌더러 6 + 타입 생성 1)인데 명령은 3개다. **실패했을 때 대응 주체가 다른 지점**에서 잘랐다.

| 명령 | 실패하면 | 누가 |
| --- | --- | --- |
| `api:pull` | 네트워크·서버 다운 | 기다린다 |
| `api:check` | 스펙 품질 | **백엔드에 요청서를 보낸다** |
| `api:gen` | 생성기 버그 | **내가 생성기를 고친다** |

`gen` 내부를 더 쪼개지 않은 이유는 대응이 전부 같고("생성기를 고친다"), **부분 생성이 위험하며**(타입만 만들고 훅을 안 만들면 어긋난 상태가 커밋된다), 1초면 끝나기 때문이다.

**② 드리프트 검사를 일부러 뺐다**

원래 이 PR에 넣으려던 것이다.

```yaml
npm run api:gen
git diff --exit-code -- src/api      # ← 넣지 않았다
```

**`git diff`는 추적되지 않는 새 파일을 못 본다.** 생성물이 아직 없는 이 PR에서는 `api:gen`이 전부 새 파일로 만들어내고, 검사는 **아무것도 못 본 채 통과**한다. 거짓 통과하는 검사는 없는 것보다 나쁘다.

**검사는 검사 대상과 같은 PR에 넣는다** — 생성물이 들어오는 다음 PR에서 추가한다.

**③ 스펙 원본을 커밋한다**

`api/openapi.json`(8,973줄)이 diff에 잡힌다. 의도한 것이다.

- 스펙 변화가 **PR diff로 보인다** — "백엔드가 무엇을 바꿨나"가 리뷰 대상이 된다
- 네트워크 없이 빌드·생성이 된다 (CI가 백엔드 가동에 의존하지 않는다)
- 무엇을 기준으로 생성했는지가 커밋에 박힌다

받을 때 2칸 들여쓰기로 **정규화**해서 저장한다. 서버가 한 줄로 주는데 그대로 두면 diff가 통째로 한 줄이 된다.

**④ 캐시버스터가 `api:pull`의 존재 이유 절반이다**

```js
const bust = `${url}${url.includes('?') ? '&' : '?'}cb=${Date.now()}`
fetch(bust, { headers: { 'Cache-Control': 'no-cache', Pragma: 'no-cache' } })
```

백엔드가 스펙을 고쳤다는데 받아보니 **이전 파일과 바이트 단위로 같았다.** 배포 플랫폼 엣지가 옛 스펙을 캐시하고 있었고, "아직 배포를 안 했구나"로 잘못 판단했다. 받은 뒤 **해시와 개수를 찍어** 정말 바뀌었는지 눈으로 보게 했다.

**⑤ 기성 스펙 린터 대신 직접 만들었다**

Spectral·Redocly는 규칙이 방대하지만 **우리 문제를 거의 못 잡는다** — 1차 진단에서 나온 99건은 전부 **문법적으로 올바른 문서**였다. "OpenAPI를 잘못 썼다"가 아니라 "우리가 쓰려는 방식과 안 맞는다"라서 일반 규칙집에 있을 수 없다.

그리고 **위반 목록이 그대로 백엔드에 보낼 요청서**가 된다. 기성 린터는 그쪽 규칙 이름으로 나와서 다시 사람 말로 옮겨야 한다.

**⑥ `.oxlintrc.json`에서 `schema.d.ts`만 제외한다**

`openapi-typescript`가 뱉는 스펙 전량 타입이라 사람이 안 읽고 안 고친다. **나머지 생성물(호출 함수·훅)은 린트한다** — 우리 생성기가 만들고 우리 규칙을 지켜야 하기 때문이다.

> 처음엔 `src/api/**`를 통째로 제외했다가 되돌렸다. 손으로 쓰는 `_contract`까지 검사에서 빠져서, `console.log`를 심어 확인하고 범위를 좁혔다.

## 확인

- [x] 로컬에서 동작 확인
- [x] 하나의 PR = 하나의 기능

**`npm ci`부터 CI와 같은 조건으로** 별도 워크트리에서 재현해 통과를 확인했다.

```
npm ci ✅  lint ✅  format:check ✅  api:test ✅  api:check ✅
check:design ✅  design-doc --check ✅  component-doc --check ✅  build ✅
```

> `api:check`는 현재 스펙에서 **error 0 · warn 0**이다. 1차 진단 당시 99건이던 것을 백엔드가 전부 반영했다.

closes #130
