### PR TITLE
[Feat] Add Role Guard to Operator Console Routes

### DIFF
--- a/src/features/operator/admin/AdminScreen.route.tsx
+++ b/src/features/operator/admin/AdminScreen.route.tsx
@@ -1,4 +1,5 @@
 import type { RouteObject } from 'react-router'
+import RequireRole from '@/shells/RequireRole'
 import AdminScreen from './AdminScreen'
 
 /*
@@ -21,4 +22,11 @@ import AdminScreen from './AdminScreen'
   세그먼트가 더 많아** React Router 랭킹에서 `:tab?`보다 먼저 잡힌다 — 순서를 손으로
   맞출 필요가 없다(app/routes.tsx가 glob으로 모으므로 순서를 정할 수도 없다).
 */
-export const route: RouteObject = { path: '/operator/admin/:tab?', element: <AdminScreen /> }
+export const route: RouteObject = {
+  path: '/operator/admin/:tab?',
+  element: (
+    <RequireRole allow={['OPERATOR']}>
+      <AdminScreen />
+    </RequireRole>
+  ),
+}

--- a/src/features/operator/admin/assign/AssignModeScreen.route.tsx
+++ b/src/features/operator/admin/assign/AssignModeScreen.route.tsx
@@ -1,4 +1,5 @@
 import type { RouteObject } from 'react-router'
+import RequireRole from '@/shells/RequireRole'
 import AssignModeScreen from './AssignModeScreen'
 
 /*
@@ -14,5 +15,9 @@ import AssignModeScreen from './AssignModeScreen'
 */
 export const route: RouteObject = {
   path: '/operator/admin/assign',
-  element: <AssignModeScreen />,
+  element: (
+    <RequireRole allow={['OPERATOR']}>
+      <AssignModeScreen />
+    </RequireRole>
+  ),
 }

--- a/src/features/operator/admin/curricula/CurriculumDetailScreen.route.tsx
+++ b/src/features/operator/admin/curricula/CurriculumDetailScreen.route.tsx
@@ -1,4 +1,5 @@
 import type { RouteObject } from 'react-router'
+import RequireRole from '@/shells/RequireRole'
 import CurriculumDetailScreen from './CurriculumDetailScreen'
 
 /*
@@ -13,5 +14,9 @@ import CurriculumDetailScreen from './CurriculumDetailScreen'
 */
 export const route: RouteObject = {
   path: '/operator/admin/curricula/:id',
-  element: <CurriculumDetailScreen />,
+  element: (
+    <RequireRole allow={['OPERATOR']}>
+      <CurriculumDetailScreen />
+    </RequireRole>
+  ),
 }

--- a/src/features/operator/analysis/AnalysisScreen.route.tsx
+++ b/src/features/operator/analysis/AnalysisScreen.route.tsx
@@ -1,4 +1,5 @@
 import type { RouteObject } from 'react-router'
+import RequireRole from '@/shells/RequireRole'
 import AnalysisScreen from './AnalysisScreen'
 
 /*
@@ -12,4 +13,11 @@ import AnalysisScreen from './AnalysisScreen'
   `*.route.tsx`를 훑어 route만 모은다(import.meta.glob) — 새 화면을
   추가해도 그 파일은 안 바뀐다.
 */
-export const route: RouteObject = { path: '/operator/analysis', element: <AnalysisScreen /> }
+export const route: RouteObject = {
+  path: '/operator/analysis',
+  element: (
+    <RequireRole allow={['OPERATOR']}>
+      <AnalysisScreen />
+    </RequireRole>
+  ),
+}

--- a/src/features/operator/dashboard/DashboardScreen.route.tsx
+++ b/src/features/operator/dashboard/DashboardScreen.route.tsx
@@ -1,4 +1,5 @@
 import type { RouteObject } from 'react-router'
+import RequireRole from '@/shells/RequireRole'
 import DashboardScreen from './DashboardScreen'
 
 /*
@@ -12,4 +13,11 @@ import DashboardScreen from './DashboardScreen'
   `*.route.tsx`를 훑어 route만 모은다(import.meta.glob) — 새 화면을
   추가해도 그 파일은 안 바뀐다.
 */
-export const route: RouteObject = { path: '/operator/dashboard', element: <DashboardScreen /> }
+export const route: RouteObject = {
+  path: '/operator/dashboard',
+  element: (
+    <RequireRole allow={['OPERATOR']}>
+      <DashboardScreen />
+    </RequireRole>
+  ),
+}

--- a/src/features/operator/projects/detail/ProjectDetailScreen.route.tsx
+++ b/src/features/operator/projects/detail/ProjectDetailScreen.route.tsx
@@ -1,4 +1,5 @@
 import type { RouteObject } from 'react-router'
+import RequireRole from '@/shells/RequireRole'
 import ProjectDetailScreen from './ProjectDetailScreen'
 
 /*
@@ -19,5 +20,9 @@ import ProjectDetailScreen from './ProjectDetailScreen'
 */
 export const route: RouteObject = {
   path: '/operator/projects/:id/:tab?',
-  element: <ProjectDetailScreen />,
+  element: (
+    <RequireRole allow={['OPERATOR']}>
+      <ProjectDetailScreen />
+    </RequireRole>
+  ),
 }

--- a/src/features/operator/projects/list/ProjectListScreen.route.tsx
+++ b/src/features/operator/projects/list/ProjectListScreen.route.tsx
@@ -1,4 +1,5 @@
 import type { RouteObject } from 'react-router'
+import RequireRole from '@/shells/RequireRole'
 import ProjectListScreen from './ProjectListScreen'
 
 /*
@@ -12,4 +13,11 @@ import ProjectListScreen from './ProjectListScreen'
   `*.route.tsx`를 훑어 route만 모은다(import.meta.glob) — 새 화면을
   추가해도 그 파일은 안 바뀐다.
 */
-export const route: RouteObject = { path: '/operator/projects', element: <ProjectListScreen /> }
+export const route: RouteObject = {
+  path: '/operator/projects',
+  element: (
+    <RequireRole allow={['OPERATOR']}>
+      <ProjectListScreen />
+    </RequireRole>
+  ),
+}

--- a/src/features/operator/report/ReportScreen.route.tsx
+++ b/src/features/operator/report/ReportScreen.route.tsx
@@ -1,4 +1,5 @@
 import type { RouteObject } from 'react-router'
+import RequireRole from '@/shells/RequireRole'
 import ReportScreen from './ReportScreen'
 
 /*
@@ -12,4 +13,11 @@ import ReportScreen from './ReportScreen'
   `*.route.tsx`를 훑어 route만 모은다(import.meta.glob) — 새 화면을
   추가해도 그 파일은 안 바뀐다.
 */
-export const route: RouteObject = { path: '/operator/report', element: <ReportScreen /> }
+export const route: RouteObject = {
+  path: '/operator/report',
+  element: (
+    <RequireRole allow={['OPERATOR']}>
+      <ReportScreen />
+    </RequireRole>
+  ),
+}


### PR DESCRIPTION
## 작업 요약
슈퍼어드민 파일럿(#144)에서 검증한 RequireRole 라우트 가드를 operator 콘솔 8개 라우트에 적용.

## 리뷰 포인트
- 패턴은 #144와 동일(RequireRole 컴포넌트 변경 없음, 라우트 element만 래핑)
- allow=['OPERATOR']로 8개 라우트 전부 통일

closes #146