### PR TITLE
[Feat] Add Role Guard to Manager Console Routes

### DIFF
--- a/src/features/manager/curriculum/CurriculumDetailScreen.route.tsx
+++ b/src/features/manager/curriculum/CurriculumDetailScreen.route.tsx
@@ -1,4 +1,5 @@
 import type { RouteObject } from 'react-router'
+import RequireRole from '@/shells/RequireRole'
 import CurriculumDetailScreen from './CurriculumDetailScreen'
 
 /*
@@ -13,5 +14,9 @@ import CurriculumDetailScreen from './CurriculumDetailScreen'
 */
 export const route: RouteObject = {
   path: '/manager/curriculum/:id',
-  element: <CurriculumDetailScreen />,
+  element: (
+    <RequireRole allow={['MANAGER']}>
+      <CurriculumDetailScreen />
+    </RequireRole>
+  ),
 }

--- a/src/features/manager/curriculum/CurriculumScreen.route.tsx
+++ b/src/features/manager/curriculum/CurriculumScreen.route.tsx
@@ -1,4 +1,5 @@
 import type { RouteObject } from 'react-router'
+import RequireRole from '@/shells/RequireRole'
 import CurriculumScreen from './CurriculumScreen'
 
 /*
@@ -12,4 +13,11 @@ import CurriculumScreen from './CurriculumScreen'
   `*.route.tsx`를 훑어 route만 모은다(import.meta.glob) — 새 화면을
   추가해도 그 파일은 안 바뀐다.
 */
-export const route: RouteObject = { path: '/manager/curriculum', element: <CurriculumScreen /> }
+export const route: RouteObject = {
+  path: '/manager/curriculum',
+  element: (
+    <RequireRole allow={['MANAGER']}>
+      <CurriculumScreen />
+    </RequireRole>
+  ),
+}

--- a/src/features/manager/dashboard/DashboardScreen.route.tsx
+++ b/src/features/manager/dashboard/DashboardScreen.route.tsx
@@ -1,4 +1,5 @@
 import type { RouteObject } from 'react-router'
+import RequireRole from '@/shells/RequireRole'
 import DashboardScreen from './DashboardScreen'
 
 /*
@@ -12,4 +13,11 @@ import DashboardScreen from './DashboardScreen'
   `*.route.tsx`를 훑어 route만 모은다(import.meta.glob) — 새 화면을
   추가해도 그 파일은 안 바뀐다.
 */
-export const route: RouteObject = { path: '/manager/dashboard', element: <DashboardScreen /> }
+export const route: RouteObject = {
+  path: '/manager/dashboard',
+  element: (
+    <RequireRole allow={['MANAGER']}>
+      <DashboardScreen />
+    </RequireRole>
+  ),
+}

--- a/src/features/manager/heatmap/HeatmapScreen.route.tsx
+++ b/src/features/manager/heatmap/HeatmapScreen.route.tsx
@@ -1,4 +1,5 @@
 import type { RouteObject } from 'react-router'
+import RequireRole from '@/shells/RequireRole'
 import HeatmapScreen from './HeatmapScreen'
 
 /*
@@ -12,4 +13,11 @@ import HeatmapScreen from './HeatmapScreen'
   `*.route.tsx`를 훑어 route만 모은다(import.meta.glob) — 새 화면을
   추가해도 그 파일은 안 바뀐다.
 */
-export const route: RouteObject = { path: '/manager/heatmap', element: <HeatmapScreen /> }
+export const route: RouteObject = {
+  path: '/manager/heatmap',
+  element: (
+    <RequireRole allow={['MANAGER']}>
+      <HeatmapScreen />
+    </RequireRole>
+  ),
+}

--- a/src/features/manager/interviews/InterviewBriefScreen.route.tsx
+++ b/src/features/manager/interviews/InterviewBriefScreen.route.tsx
@@ -1,4 +1,5 @@
 import type { RouteObject } from 'react-router'
+import RequireRole from '@/shells/RequireRole'
 import InterviewBriefScreen from './InterviewBriefScreen'
 
 /*
@@ -14,5 +15,9 @@ import InterviewBriefScreen from './InterviewBriefScreen'
 */
 export const route: RouteObject = {
   path: '/manager/interviews/:id/brief',
-  element: <InterviewBriefScreen />,
+  element: (
+    <RequireRole allow={['MANAGER']}>
+      <InterviewBriefScreen />
+    </RequireRole>
+  ),
 }

--- a/src/features/manager/interviews/InterviewListScreen.route.tsx
+++ b/src/features/manager/interviews/InterviewListScreen.route.tsx
@@ -1,4 +1,5 @@
 import type { RouteObject } from 'react-router'
+import RequireRole from '@/shells/RequireRole'
 import InterviewListScreen from './InterviewListScreen'
 
 /*
@@ -12,4 +13,11 @@ import InterviewListScreen from './InterviewListScreen'
   `*.route.tsx`를 훑어 route만 모은다(import.meta.glob) — 새 화면을
   추가해도 그 파일은 안 바뀐다.
 */
-export const route: RouteObject = { path: '/manager/interviews', element: <InterviewListScreen /> }
+export const route: RouteObject = {
+  path: '/manager/interviews',
+  element: (
+    <RequireRole allow={['MANAGER']}>
+      <InterviewListScreen />
+    </RequireRole>
+  ),
+}

--- a/src/features/manager/projects/ProjectDetailScreen.route.tsx
+++ b/src/features/manager/projects/ProjectDetailScreen.route.tsx
@@ -1,4 +1,5 @@
 import type { RouteObject } from 'react-router'
+import RequireRole from '@/shells/RequireRole'
 import ProjectDetailScreen from './ProjectDetailScreen'
 
 /*
@@ -14,5 +15,9 @@ import ProjectDetailScreen from './ProjectDetailScreen'
 */
 export const route: RouteObject = {
   path: '/manager/projects/:id',
-  element: <ProjectDetailScreen />,
+  element: (
+    <RequireRole allow={['MANAGER']}>
+      <ProjectDetailScreen />
+    </RequireRole>
+  ),
 }

--- a/src/features/manager/projects/ProjectListScreen.route.tsx
+++ b/src/features/manager/projects/ProjectListScreen.route.tsx
@@ -1,4 +1,5 @@
 import type { RouteObject } from 'react-router'
+import RequireRole from '@/shells/RequireRole'
 import ProjectListScreen from './ProjectListScreen'
 
 /*
@@ -12,4 +13,11 @@ import ProjectListScreen from './ProjectListScreen'
   `*.route.tsx`를 훑어 route만 모은다(import.meta.glob) — 새 화면을
   추가해도 그 파일은 안 바뀐다.
 */
-export const route: RouteObject = { path: '/manager/projects', element: <ProjectListScreen /> }
+export const route: RouteObject = {
+  path: '/manager/projects',
+  element: (
+    <RequireRole allow={['MANAGER']}>
+      <ProjectListScreen />
+    </RequireRole>
+  ),
+}

--- a/src/features/manager/trainees/TraineeDetailScreen.route.tsx
+++ b/src/features/manager/trainees/TraineeDetailScreen.route.tsx
@@ -1,4 +1,5 @@
 import type { RouteObject } from 'react-router'
+import RequireRole from '@/shells/RequireRole'
 import TraineeDetailScreen from './TraineeDetailScreen'
 
 /*
@@ -14,5 +15,9 @@ import TraineeDetailScreen from './TraineeDetailScreen'
 */
 export const route: RouteObject = {
   path: '/manager/trainees/:id',
-  element: <TraineeDetailScreen />,
+  element: (
+    <RequireRole allow={['MANAGER']}>
+      <TraineeDetailScreen />
+    </RequireRole>
+  ),
 }

--- a/src/features/manager/trainees/TraineeListScreen.route.tsx
+++ b/src/features/manager/trainees/TraineeListScreen.route.tsx
@@ -1,4 +1,5 @@
 import type { RouteObject } from 'react-router'
+import RequireRole from '@/shells/RequireRole'
 import TraineeListScreen from './TraineeListScreen'
 
 /*
@@ -12,4 +13,11 @@ import TraineeListScreen from './TraineeListScreen'
   `*.route.tsx`를 훑어 route만 모은다(import.meta.glob) — 새 화면을
   추가해도 그 파일은 안 바뀐다.
 */
-export const route: RouteObject = { path: '/manager/trainees', element: <TraineeListScreen /> }
+export const route: RouteObject = {
+  path: '/manager/trainees',
+  element: (
+    <RequireRole allow={['MANAGER']}>
+      <TraineeListScreen />
+    </RequireRole>
+  ),
+}


### PR DESCRIPTION
## 작업 요약
슈퍼어드민(#144)·operator(#146) 파일럿에서 검증한 RequireRole 라우트 가드를 manager 콘솔 10개 라우트에 적용.

## 리뷰 포인트
- 패턴은 #144/#146과 동일(RequireRole 컴포넌트 변경 없음, 라우트 element만 래핑)
- allow=['MANAGER']로 10개 라우트 전부 통일

closes #148