### PR TITLE
[Feat] Add Role Guard to Trainee Console Routes

### DIFF
--- a/src/features/trainee/home/HomeScreen.route.tsx
+++ b/src/features/trainee/home/HomeScreen.route.tsx
@@ -1,4 +1,5 @@
 import type { RouteObject } from 'react-router'
+import RequireRole from '@/shells/RequireRole'
 import HomeScreen from './HomeScreen'
 
 /*
@@ -12,4 +13,11 @@ import HomeScreen from './HomeScreen'
   `*.route.tsx`를 훑어 route만 모은다(import.meta.glob) — 새 화면을
   추가해도 그 파일은 안 바뀐다.
 */
-export const route: RouteObject = { path: '/trainee/home', element: <HomeScreen /> }
+export const route: RouteObject = {
+  path: '/trainee/home',
+  element: (
+    <RequireRole allow={['TRAINEE']}>
+      <HomeScreen />
+    </RequireRole>
+  ),
+}

--- a/src/features/trainee/report/MyReportScreen.route.tsx
+++ b/src/features/trainee/report/MyReportScreen.route.tsx
@@ -1,4 +1,5 @@
 import type { RouteObject } from 'react-router'
+import RequireRole from '@/shells/RequireRole'
 import MyReportScreen from './MyReportScreen'
 
 /*
@@ -12,4 +13,11 @@ import MyReportScreen from './MyReportScreen'
   `*.route.tsx`를 훑어 route만 모은다(import.meta.glob) — 새 화면을
   추가해도 그 파일은 안 바뀐다.
 */
-export const route: RouteObject = { path: '/trainee/report', element: <MyReportScreen /> }
+export const route: RouteObject = {
+  path: '/trainee/report',
+  element: (
+    <RequireRole allow={['TRAINEE']}>
+      <MyReportScreen />
+    </RequireRole>
+  ),
+}

--- a/src/features/trainee/session/SessionScreen.route.tsx
+++ b/src/features/trainee/session/SessionScreen.route.tsx
@@ -1,4 +1,5 @@
 import type { RouteObject } from 'react-router'
+import RequireRole from '@/shells/RequireRole'
 import SessionScreen from './SessionScreen'
 
 /*
@@ -12,4 +13,11 @@ import SessionScreen from './SessionScreen'
   `*.route.tsx`를 훑어 route만 모은다(import.meta.glob) — 새 화면을
   추가해도 그 파일은 안 바뀐다.
 */
-export const route: RouteObject = { path: '/trainee/session', element: <SessionScreen /> }
+export const route: RouteObject = {
+  path: '/trainee/session',
+  element: (
+    <RequireRole allow={['TRAINEE']}>
+      <SessionScreen />
+    </RequireRole>
+  ),
+}

--- a/src/features/trainee/submission/SubmissionScreen.route.tsx
+++ b/src/features/trainee/submission/SubmissionScreen.route.tsx
@@ -1,4 +1,5 @@
 import type { RouteObject } from 'react-router'
+import RequireRole from '@/shells/RequireRole'
 import SubmissionScreen from './SubmissionScreen'
 
 /*
@@ -12,4 +13,11 @@ import SubmissionScreen from './SubmissionScreen'
   `*.route.tsx`를 훑어 route만 모은다(import.meta.glob) — 새 화면을
   추가해도 그 파일은 안 바뀐다.
 */
-export const route: RouteObject = { path: '/trainee/submission', element: <SubmissionScreen /> }
+export const route: RouteObject = {
+  path: '/trainee/submission',
+  element: (
+    <RequireRole allow={['TRAINEE']}>
+      <SubmissionScreen />
+    </RequireRole>
+  ),
+}


### PR DESCRIPTION
## 작업 요약
슈퍼어드민(#144)·operator(#146)·manager(#148) 파일럿에서 검증한 RequireRole 라우트 가드를 trainee 콘솔 4개 라우트에 적용. 이걸로 관리자 권한 접속 가드 롤아웃(#144 후속)이 전부 끝난다.

## 리뷰 포인트
- 패턴은 #144/#146/#148과 동일(RequireRole 컴포넌트 변경 없음, 라우트 element만 래핑)
- allow=['TRAINEE']로 4개 라우트 전부 통일
- 전체 `.route.tsx` 중 RequireRole 없는 건 auth 3개(로그인·초대·비번재설정, 비로그인 화면이라 정상)뿐임을 확인

closes #150