### PR TITLE
[Refactor] Move Platform Settings from the Header to the Sidebar

### DIFF
--- a/src/shells/ConsoleShell.tsx
+++ b/src/shells/ConsoleShell.tsx
@@ -78,7 +78,7 @@ export default function ConsoleShell({
         본문으로 건너뛰기
       </a>
 
-      <Header user={user} scope={scope} role={role} />
+      <Header user={user} scope={scope} />
 
       <div className="flex min-h-0 min-w-0 flex-1 print:block">
         <Sidebar sidebar={sidebar} />

--- a/src/shells/Header.tsx
+++ b/src/shells/Header.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
-import { Link, useLocation, useNavigate } from 'react-router'
-import { SettingsIcon, UserCogIcon } from 'lucide-react'
+import { useNavigate } from 'react-router'
+import { UserCogIcon } from 'lucide-react'
 import { Avatar, AvatarFallback } from '@/components/ui/Avatar'
 import { Button } from '@/components/ui/Button'
 import {
@@ -19,12 +19,10 @@ import {
   SelectValue,
 } from '@/components/ui/Select'
 import Wordmark from '@/components/common/Wordmark'
-import { cn } from '@/lib/utils/cn'
 import { initialScreenFor } from '@/features/auth/authStore'
 import { useSignIn } from '@/features/auth/useSession'
 import { login } from '@/api/auth/authApi'
 import { QUICK_LOGIN_ACCOUNTS } from '@/features/auth/quickLoginAccounts'
-import type { Role } from './sidebarConfig'
 
 // dev 전용 역할 전환(헤더) — import.meta.env.DEV는 프로덕션 빌드(vite build)에서
 // 항상 false라 develop Vercel 프리뷰 배포도 걸러진다. __GIT_BRANCH__(vite.config.ts
@@ -86,22 +84,17 @@ function DevRoleSwitcher() {
   기수 · 교육생은 자기 자신) 없으면 자리 자체를 렌더하지 않는다. 지금은 옵션이
   현재 값 하나뿐이다 — 실제 기수 목록은 화면 이식 때 API에서 받는다.
 
-  우상단 톱니(⚙) — SA-03(플랫폼 설정) 진입점. 정의서 "네비 자리를 주지 않는다 —
-  화면이라기보다 설정 항목이다"(SA-03-platform-settings.md §2)를 그대로 따라 네비가
-  아니라 여기 둔다. superadmin 역할일 때만 렌더하고(다른 역할엔 이 설정 자체가
-  없다), 현재 경로가 /superadmin/settings 아래면 활성 색(primary)을 준다 — 와이어
-  `.gear.on`과 같은 신호다.
+  우상단 톱니(⚙)는 없앴다 — SA-03이 사이드바 `플랫폼 관리`로 내려갔다. 정의서는
+  "네비 자리를 주지 않는다"고 했지만 만들고 보니 탭 두 개짜리 화면이라, 오퍼레이터의
+  `운영 관리`와 같은 자리(구분선 아래 별도 그룹)로 옮겼다(sidebarConfig.ts 참고).
 */
 type Props = {
   user: { name: string; role: string }
   scope?: { label: string; value: string }
-  role: Role
 }
 
-export default function Header({ user, scope, role }: Props) {
+export default function Header({ user, scope }: Props) {
   const [value, setValue] = useState(scope?.value)
-  const location = useLocation()
-  const isSettingsActive = location.pathname.startsWith('/superadmin/settings')
 
   return (
     <header className="bg-surface border-border flex h-[54px] w-full shrink-0 items-center justify-between overflow-x-auto border-b px-6">
@@ -126,18 +119,6 @@ export default function Header({ user, scope, role }: Props) {
 
       <div className="text-fg-muted flex shrink-0 items-center gap-3 text-sm">
         {SHOW_DEV_ROLE_SWITCHER && <DevRoleSwitcher />}
-        {role === 'superadmin' && (
-          <Link
-            to="/superadmin/settings"
-            aria-label="플랫폼 설정"
-            className={cn(
-              'rounded-md p-1.5 text-fg-subtle transition-colors hover:bg-surface-2 hover:text-fg',
-              isSettingsActive && 'text-primary hover:text-primary',
-            )}
-          >
-            <SettingsIcon className="size-4" aria-hidden="true" />
-          </Link>
-        )}
         <span className="hidden sm:inline">
           {user.name} · {user.role}
         </span>

--- a/src/shells/sidebarConfig.ts
+++ b/src/shells/sidebarConfig.ts
@@ -37,9 +37,19 @@ export type SidebarItem = {
 
 export type SidebarGroup = SidebarItem[]
 
-/** 슈퍼어드민 — 1. 실질 화면이 기관 하나뿐이다(플랫폼 설정은 우상단 ⚙, 자리 없음) */
+/*
+  슈퍼어드민 — 2. 기관 / 플랫폼 관리.
+
+  플랫폼 관리는 원래 우상단 톱니(⚙)에 있었다. 정의서가 *"네비 자리를 주지 않는다 —
+  화면이라기보다 설정 항목이다"* 라고 해서 그렇게 뒀는데, **실제로 만들고 보니 화면이었다** —
+  모델 정책·티어·단가·보정 버전·계정 관리까지 탭 두 개짜리다.
+
+  오퍼레이터의 `운영 관리`와 성격이 같아 배치도 같게 간다 — **구분선 아래 별도 그룹.**
+  "매일 보는 것"과 "설정하러 들어가는 것"이 갈리는 자리다.
+*/
 export const SUPERADMIN_SIDEBAR: SidebarGroup[] = [
   [{ icon: Building2Icon, label: '기관', to: '/superadmin/orgs' }],
+  [{ icon: SettingsIcon, label: '플랫폼 관리', to: '/superadmin/settings' }],
 ]
 
 /** 오퍼레이터 — 5. 면담·교육생 없음(담당 반이 없다, 17번 3-2) */


### PR DESCRIPTION
## 작업 내용

슈퍼어드민의 **플랫폼 관리(SA-03)** 진입점을 우상단 톱니(⚙)에서 사이드바로 내렸다.

```
🏢 기관
─────────────      ← 구분선
⚙ 플랫폼 관리
```

오퍼레이터의 `운영 관리`와 **같은 형태**다 — 별도 그룹이라 구분선이 자동으로 그어진다.

## 리뷰 포인트

**① 정의서를 뒤집는 변경이라 이유를 코드에 남겼다**

SA-03 정의서 §2가 이렇게 적고 있다.

> 네비 자리를 주지 않는다 — **화면이라기보다 설정 항목이다**

그래서 톱니에 뒀었다. **그런데 만들고 보니 화면이었다** — 모델 정책 · 티어 · 단가 · 보정 버전 · 계정 관리까지 **탭 두 개짜리**다.

톱니는 "설정 한 줄"을 위한 자리이지 탭 두 개짜리 화면의 입구가 아니다. 오퍼레이터의 `운영 관리`와 성격이 같으니 **같은 자리**에 둔다.

> 정의서와 어긋나는 선택이라, 나중에 "왜 정의서랑 다르지?"가 나오지 않게 `sidebarConfig.ts` 주석에 경위를 적었다.

**② 딸려 나온 정리 — `Header`의 `role` prop**

톱니를 빼니 `Header`가 `role`을 더 쓰지 않게 됐다. **안 쓰는 인자를 남기면 다음 사람이 "왜 있지" 하고 찾게 되므로** 호출부(`ConsoleShell`)까지 지웠다.

같이 정리한 것: `Link` · `useLocation` · `SettingsIcon` · `cn` · `Role` 타입.

`useNavigate`·`UserCogIcon`은 **다른 곳에서 쓰여서 남겼다** — 파일 안 등장 횟수를 세어 확인했다.

**③ 구분선은 자동이다**

`SidebarGroup[]`(배열의 배열) 구조라 **그룹을 하나 더하면 구분선이 그어진다.** 스타일을 따로 넣지 않았다.

```ts
export const SUPERADMIN_SIDEBAR: SidebarGroup[] = [
  [{ icon: Building2Icon, label: '기관', to: '/superadmin/orgs' }],
  [{ icon: SettingsIcon, label: '플랫폼 관리', to: '/superadmin/settings' }],
]
```

## 확인

- [x] 로컬에서 동작 확인
- [x] 하나의 PR = 하나의 기능

**`npm ci`부터 CI와 같은 조건으로** 별도 워크트리에서 재현했다.

```
npm ci ✅  Format ✅  Design tokens ✅  Design doc ✅  Component doc ✅
Lint ✅  API spec ✅  API codegen up to date ✅  Domain rules ✅  Build ✅
```

> 진행 중인 SA-02 연동 작업이 같은 작업 폴더에 있지만 **이 PR에는 안 들어갔다.** 격리 워크트리 검증이 그것을 확인해 준다(*"커밋되지 않은 변경 36건은 검사 대상이 아니다"*).

closes #154
