### PR TITLE
[Feat] Connect Password Reset to Real Backend API

### DIFF
--- a/docs/dev/api/integration-status.md
+++ b/docs/dev/api/integration-status.md
@@ -1,0 +1,105 @@
+# API 연동 현황 — 역할·화면별 스냅샷
+
+> 기준: `origin/develop` 05fd785(PR #177 머지, 2026-08-11 02:13)까지, 코드 직접 확인(각 화면의 `_/api`·`mockData.ts`·`mockDb.ts` 존재 여부와 실제 import 대상).
+> "연동 완료"는 화면이 mock 파일 대신 `src/api/{domain}` 생성 훅(`useFind*`/`use*Mutation` 등)을 직접 호출하는 상태를 뜻한다. 자동 갱신 문서가 아니라 이 시점의 수동 스냅샷 — 다음에 다시 확인하려면 각 화면 폴더에 `mockData.ts`/`mockDb.ts`가 남아 있는지부터 보면 된다.
+
+---
+
+## 요약
+
+| 역할 | 화면 수 | 연동 완료 | 상태 |
+|---|---|---|---|
+| 슈퍼어드민 | 3 | 3 | 전체 완료 |
+| 오퍼레이터 | 8 | 8 | 전체 완료 |
+| 매니저 | 10 | 0 | 전체 미착수(전부 mock) |
+| 교육생 | 4 | 0 | 전체 미착수(전부 mock) |
+| 공통(인증) | 4 | 2 | 로그인·세션만 완료, 초대·비번재설정 미착수 |
+
+---
+
+## 슈퍼어드민 — 전체 완료
+
+| 화면 | 경로 | 상태 | 비고 |
+|---|---|---|---|
+| 기관 목록(SA-01) | `/superadmin/orgs` | 완료 | `useFindOrganizations`, `useFindPlatformSummary` |
+| 기관 상세 | `/superadmin/orgs/:id` | 완료 | `useFindOrganization` + 운영자/설정/사용량 탭 전부 실호출 |
+| 플랫폼 설정 | `/superadmin/settings` | 완료 | `useFindModelSettings`, 모델·티어·가격 다이얼로그 포함 |
+
+---
+
+## 오퍼레이터 — 전체 완료
+
+| 화면 | 경로 | 상태 | 비고 |
+|---|---|---|---|
+| 대시보드(OP-01) | `/operator/dashboard` | 완료 | PR #176(오늘 새벽 머지) |
+| 분석 | `/operator/analysis` | 완료 | PR #177(오늘 새벽 머지) |
+| 운영관리(OP-06, 반·기수·비용·교안·매니저·명부 6탭) | `/operator/admin/:tab?` | 완료 | PR #161·#174. 자체 기수 스위처(`admin/_/cohortScope.ts`)로 `'7'` 자리표시자 제거 |
+| 교안 상세 | `/operator/admin/curricula/:id` | 완료 | `useFindCurriculum`·`useFindSections`·`useFindUsedProjects` |
+| 회차 배정 모드 | `/operator/admin/assign` | 완료 | `useAssignTrainees`·`useRollbackAssignment` |
+| 프로젝트 목록(OP-03) | `/operator/projects` | 완료 | PR #164, `projects/queries.ts`가 생성 훅을 감싸는 구조 |
+| 프로젝트 상세(OP-04) | `/operator/projects/:id/:tab?` | 완료 | 목록과 같은 `queries.ts` 공유 |
+| 리포트(OP-05) | `/operator/report` | 완료 | 이슈 #170, `GET /reports/class-diagnosis` 단일 엔드포인트 |
+
+⚠ admin은 로컬 `cohortScope.ts`, 나머지(대시보드·분석·프로젝트)는 전역 `stores/cohortScope.ts`를 따로 씀 — 둘 다 실서버 연동이라 기능엔 문제없지만 아직 하나로 안 합쳐진 상태(주석에 "상단 기수 스위처가 붙으면 합친다"고 기록돼 있음).
+
+---
+
+## 매니저 — 전체 미착수(전부 mock)
+
+| 화면 | 경로 | 상태 | 비고 |
+|---|---|---|---|
+| 대시보드(MG-01) | `/manager/dashboard` | mock | `mockData.ts` |
+| 히트맵(MG-02) | `/manager/heatmap` | mock | `mockData.ts` |
+| 면담 목록(MG-03) | `/manager/interviews` | mock | `mockData.ts` |
+| 면담 브리프(MG-04) | `/manager/interviews/:id/brief` | mock | `mockData.ts` |
+| 교육생 목록(MG-05) | `/manager/trainees` | mock | `mockData.ts` |
+| 교육생 상세(MG-06) | `/manager/trainees/:id` | mock | `mockData.ts` |
+| 프로젝트 목록(MG-07) | `/manager/projects` | mock | `mockData.ts` |
+| 프로젝트 상세(MG-08) | `/manager/projects/:id` | mock | `mockData.ts` |
+| 교안 목록 | `/manager/curriculum` | mock | `mockData.ts` |
+| 교안 상세 | `/manager/curriculum/:id` | mock | `mockData.ts` |
+
+`src/features/manager/` 어디에도 `_/api` 디렉토리가 없다. 매니저 도메인용 백엔드 API(코호트/교육생/면담/프로젝트/히트맵) 자체가 아직 스펙에 안 보임.
+
+---
+
+## 교육생 — 전체 미착수(전부 mock)
+
+| 화면 | 경로 | 상태 | 비고 |
+|---|---|---|---|
+| 홈(TR-01) | `/trainee/home` | mock | `mockDb.ts`(`buildHomeFixture`) |
+| 내 리포트 | `/trainee/report` | mock | `mockDb.ts`(`buildReportsFixture`) |
+| 세션(문제 풀이) | `/trainee/session` | mock | 스크립트 픽스처(`script.ts`), 인위적 지연(250ms)까지 흉내 |
+| 제출 | `/trainee/submission` | mock | `mockDb.ts`(`buildSubmissionFixture`) |
+
+---
+
+## 공통(인증) — 로그인만 완료
+
+| 기능 | 경로 | 상태 | 비고 |
+|---|---|---|---|
+| 로그인·퀵로그인 | `/shared/login` | 완료 | `login()`(`@/api/auth/authApi`) |
+| 세션 조회·로그아웃·리프레시 | (전역) | 완료 | `useSession`(`GET /members/me`), `logout`, `/auth/refresh` |
+| 초대·가입(회원가입) | `/invite/:token` | mock | `inviteApi.ts`가 여전히 `mockDb.ts` 사용 |
+| 비밀번호 재설정 | `/shared/password-reset` | mock | `passwordResetApi.ts`가 여전히 `mockDb.ts` 사용 |
+| 개인정보 처리방침 | `/shared/privacy-policy` | N/A | 정적 콘텐츠 페이지, API 없음 |
+
+⚠ **초대·비번재설정은 다른 미착수 항목과 성격이 다르다.** `api/openapi.json` 기준 Auth 태그 10개 엔드포인트가 **전부 `available`**이고(초대 재발송·초대 토큰 해석·매니저 가입·교육생 활성화·비밀번호 재설정 3종 포함), 생성 함수(`resolveInvitation`·`signupManager`·`activateTrainee`·`requestPasswordReset`·`confirmPasswordReset`·`validatePasswordResetToken`)도 `src/api/auth/authApi.ts`에 이미 있다. 백엔드가 막고 있는 게 아니라 **아직 손을 안 댄 것** — 우선순위에 올리면 바로 연동 가능.
+
+**진행 순서(2026-08-11 확정):** 비밀번호 재설정부터(이슈 초안 작성, 매핑이 거의 1:1이라 리스크 낮음) → 초대·가입은 뒤로.
+초대·가입을 미룬 이유: `resolveInvitation`(초대 토큰 검증) 실패가 스펙상 `INVITATION_INVALID` 코드 하나로만 오고 만료/이미가입/무효/명단외 4가지를 구분할 필드가 없어서(화면은 지금 4가지를 각각 다른 카드로 보여줌 — §"매니저" 화면 참고), 그대로 연동하면 UX가 퇴화한다. **백엔드 팀원이 이 4가지를 구분되는 코드로 분리하겠다고 확답함(2026-08-11)** — 스펙이 갱신되면 `npm run api:pull && npm run api:gen`으로 반영 여부 확인 후 착수.
+
+---
+
+## 백엔드가 막고 있는 나머지(`src/api/PENDING.md` 기준)
+
+| readiness | 엔드포인트 | 비고 |
+|---|---|---|
+| unavailable | `GET /reports/{reportId}/disclosure` | 내 리포트 공개 상태 조회 |
+| unavailable | `PUT /reports/{reportId}/disclosure` | 리포트 공개 범위 설정 |
+| unavailable | `POST /organizations/{organizationId}/purge` | 기관 파기 요청 |
+| unavailable | `GET /reports` | 내 리포트 전량 조회(교육생) |
+| unavailable | `GET /reports/{reportId}` | 리포트 단건 조회 |
+| unavailable | `GET /reports/managed` | 담당 반 리포트 목록 조회(매니저) |
+
+이 6건은 operator 화면엔 안 걸린다(operator는 `class-diagnosis` 단일 엔드포인트만 씀) — 교육생·매니저의 리포트 조회 화면이 나중에 연동될 때 걸릴 항목들.

--- a/src/features/auth/LoginScreen.tsx
+++ b/src/features/auth/LoginScreen.tsx
@@ -240,9 +240,11 @@ export default function LoginScreen() {
           {/*
             개발용 안내 — 실제 배포 시 제거.
 
-            로그인은 **실서버에 붙어 있다.** 계정은 위 「발표용 · 역할별 바로 입장」 버튼이
-            들고 있으므로 여기 다시 적지 않는다 — 두 곳에 적으면 한쪽이 반드시 낡는다.
-            아래에 남긴 것은 **아직 목으로 도는 흐름**(AU-02 초대 · AU-03 재설정)뿐이다.
+            로그인·비밀번호 재설정은 **실서버에 붙어 있다.** 계정은 위 「발표용 · 역할별
+            바로 입장」 버튼이 들고 있으므로 여기 다시 적지 않는다 — 두 곳에 적으면 한쪽이
+            반드시 낡는다. 재설정은 토큰이 실제 메일로만 오므로(이슈 178로 mock 토큰
+            제거) 여기서 케이스별 딥링크를 못 남긴다 — 요청 단계만 아래에서 바로 시도할 수
+            있다. 아래에 남긴 것은 **아직 목으로 도는 흐름**(AU-02 초대)뿐이다.
           */}
           <div className="mt-8 rounded-md bg-canvas px-3 py-2.5 text-[11px] leading-relaxed text-fg-subtle">
             <b className="text-fg-muted">로그인</b> · 실서버 연동됨. 위 버튼으로 역할별 입장
@@ -258,51 +260,11 @@ export default function LoginScreen() {
               교육생 활성화
             </Link>
             <br />
-            <b className="text-fg-muted">비밀번호 재설정(AU-03)</b> · <span>아직 목</span> ·{' '}
-            <Link
-              to="/shared/password-reset?token=reset-valid"
-              className="text-primary hover:underline"
-            >
-              정상
+            <b className="text-fg-muted">비밀번호 재설정(AU-03)</b> · 실서버 연동됨 ·{' '}
+            <Link to="/shared/password-reset" className="text-primary hover:underline">
+              요청 화면 열기
             </Link>{' '}
-            ·{' '}
-            <Link
-              to="/shared/password-reset?token=reset-expired"
-              className="text-primary hover:underline"
-            >
-              만료
-            </Link>{' '}
-            ·{' '}
-            <Link
-              to="/shared/password-reset?token=reset-used"
-              className="text-primary hover:underline"
-            >
-              사용됨
-            </Link>{' '}
-            ·{' '}
-            <Link
-              to="/shared/password-reset?token=reset-tampered"
-              className="text-primary hover:underline"
-            >
-              위변조
-            </Link>{' '}
-            ·{' '}
-            <Link
-              to="/shared/password-reset?token=reset-revokefail"
-              className="text-primary hover:underline"
-            >
-              세션폐기실패
-            </Link>{' '}
-            ·{' '}
-            <Link
-              to="/shared/password-reset?token=reset-failing"
-              className="text-primary hover:underline"
-            >
-              저장실패
-            </Link>
-            <br />
-            <span className="text-fg-muted">정상</span> 링크에서 현재 비밀번호(<code>pass1234</code>
-            )를 그대로 넣으면 &quot;이전과 같은 비밀번호&quot; 케이스가 나온다
+            — 토큰은 실제 메일로만 오므로 케이스별 딥링크는 없다
           </div>
         </AuthForm>
       </div>

--- a/src/features/auth/PasswordResetScreen.tsx
+++ b/src/features/auth/PasswordResetScreen.tsx
@@ -6,7 +6,7 @@ import { requestPasswordReset, verifyResetToken, confirmPasswordReset } from './
 import { resolvePasswordResetState } from './passwordResetStates'
 import type { PasswordResetState } from './passwordResetStates'
 import { checkPasswordPolicy } from './passwordPolicy'
-import type { PasswordResetApiError } from './passwordResetTypes'
+import { ApiError } from '@/api/_contract'
 import { useCapsLockWarning } from './useCapsLockWarning'
 import BrandPanel from './components/BrandPanel'
 import AuthForm from './components/AuthForm'
@@ -128,7 +128,7 @@ function SetPasswordStage({ token }: { token: string }) {
   const [verifying, setVerifying] = useState(true)
   const [tokenAlert, setTokenAlert] = useState<PasswordResetState | null>(null)
   const [submitAlert, setSubmitAlert] = useState<string | null>(null)
-  const [done, setDone] = useState<'full' | 'partial' | null>(null)
+  const [done, setDone] = useState(false)
 
   const [showPassword, setShowPassword] = useState(false)
   const [showPasswordConfirm, setShowPasswordConfirm] = useState(false)
@@ -166,22 +166,25 @@ function SetPasswordStage({ token }: { token: string }) {
   // 진입 시 토큰 검증 — 만료·사용됨·위변조면 폼을 렌더하지 않는다. 계정 활성 상태는 보지 않는다
   useEffect(() => {
     verifyResetToken(token)
-      .catch((err: PasswordResetApiError) => setTokenAlert(resolvePasswordResetState(err.code)))
+      .catch((err: unknown) => setTokenAlert(resolvePasswordResetState(err)))
       .finally(() => setVerifying(false))
   }, [token])
 
   async function onSubmit(values: SetPasswordFormValues) {
     setSubmitAlert(null)
     try {
-      const res = await confirmPasswordReset({ token, password: values.password })
-      setDone(res.revokeFailed ? 'partial' : 'full')
+      await confirmPasswordReset({
+        token,
+        password: values.password,
+        passwordConfirm: values.passwordConfirm,
+      })
+      setDone(true)
     } catch (err) {
-      const { code } = err as PasswordResetApiError
-      if (code === 'SAME_AS_CURRENT') {
+      if (err instanceof ApiError && err.code === 'SAME_AS_CURRENT') {
         setError('password', { type: 'manual', message: '지금 쓰는 비밀번호와 달라야 합니다' })
         return
       }
-      setSubmitAlert(resolvePasswordResetState(code).message)
+      setSubmitAlert(resolvePasswordResetState(err).message)
     }
   }
 
@@ -231,15 +234,11 @@ function SetPasswordStage({ token }: { token: string }) {
   if (done) {
     return (
       <AuthStatusCard
-        variant={done === 'full' ? 'success' : 'warning'}
-        icon={done === 'full' ? '✓' : '!'}
+        variant="success"
+        icon="✓"
         title="비밀번호가 바뀌었습니다"
         description="새 비밀번호로 다시 로그인해 주세요."
-        aux={
-          done === 'full'
-            ? '보안을 위해 다른 기기에서는 모두 로그아웃되었어요.'
-            : '다른 기기는 아직 로그아웃되지 않았을 수 있어요. 계속 시도하고 있습니다 — 공용 기기를 쓰셨다면 직접 로그아웃해 주세요.'
-        }
+        aux="보안을 위해 다른 기기에서는 모두 로그아웃되었어요."
         actions={
           <Button onClick={() => navigate('/shared/login', { replace: true })}>로그인</Button>
         }

--- a/src/features/auth/mockDb.ts
+++ b/src/features/auth/mockDb.ts
@@ -1,6 +1,7 @@
 // ─────────────────────────────────────────────────────────────
-// ⚠️ Mock 전용 계정 저장소 — 백엔드 연동 시 이 파일을 통째로 삭제하세요.
-// 로그인(authApi)과 가입·활성화(inviteApi)가 같은 데이터를 보도록 하는 임시 DB입니다.
+// ⚠️ Mock 전용 계정 저장소 — 초대·가입(inviteApi)이 아직 이 파일을 본다.
+// 로그인(authApi)·비밀번호 재설정(passwordResetApi)은 실서버로 옮겨서 더 이상 안 쓴다
+// (이슈 178). 초대·가입까지 연동되면 이 파일을 통째로 삭제한다.
 // 실제로는 서버 DB의 accounts 테이블이 이 역할을 합니다.
 // ─────────────────────────────────────────────────────────────
 import type { Role } from './authTypes'
@@ -67,11 +68,4 @@ export function activateTraineeAccount(email: string, password: string) {
   if (!account) return
   account.password = password
   account.active = true
-}
-
-/** 비밀번호 재설정 → 비밀번호만 교체 (AU-03) */
-export function resetAccountPassword(email: string, password: string) {
-  const account = accounts[email]
-  if (!account) return
-  account.password = password
 }

--- a/src/features/auth/passwordResetApi.ts
+++ b/src/features/auth/passwordResetApi.ts
@@ -1,105 +1,33 @@
 // ─────────────────────────────────────────────────────────────
-// 비밀번호 재설정 API 격리 모듈 (password-reset.html#cases · mockup c6911c0)
-// 백엔드 준비 시 각 함수의 Mock 블록만 지우고 아래 fetch를 켜면 됩니다.
+// 비밀번호 재설정 API 격리 모듈 — 실서버 연동 완료(이슈 178)
+// 화면 어휘(password/passwordConfirm)를 서버 어휘(newPassword/newPasswordConfirmation)로
+// 여기서만 바꾼다 — report 도메인(`operator/report/_/api/api.ts`)과 같은 경계 원칙.
 // ─────────────────────────────────────────────────────────────
-import type {
-  ConfirmResetRequest,
-  ConfirmResetResponse,
-  PasswordResetApiError,
-  ResetTokenInfo,
-} from './passwordResetTypes'
-import { accounts, resetAccountPassword } from './mockDb'
+import type { ConfirmResetRequest, ResetTokenInfo } from './passwordResetTypes'
+import {
+  requestPasswordReset as requestPasswordResetApi,
+  validatePasswordResetToken,
+  confirmPasswordReset as confirmPasswordResetApi,
+} from '@/api/auth/authApi'
 
-// ───────── Mock 재설정 토큰 (백엔드 연동 시 이 블록 전체 삭제) ─────────
-/** 정상 토큰 — 어느 계정의 비밀번호를 바꿀지 결정 */
-const MOCK_RESET_TOKENS: Record<string, string> = {
-  'reset-valid': 'manager@org.com',
-  'reset-revokefail': 'manager@org.com', // 성공하지만 세션 폐기가 실패하는 case8 시연용
-  'reset-failing': 'manager@org.com', // 제출 단계에서 항상 실패하는 case7 시연용
+/** `POST /auth/password-reset/requests` — 항상 202. 정상·없는 이메일·미활성 계정 셋 다 같은 응답(계정 열거 방지) */
+export async function requestPasswordReset(email: string): Promise<void> {
+  await requestPasswordResetApi({ body: { email } })
 }
 
-/** 토큰 검증 단계에서 바로 실패하는 시연용 토큰 */
-const MOCK_RESET_TOKEN_ERRORS: Record<string, PasswordResetApiError> = {
-  'reset-expired': { code: 'RESET_TOKEN_EXPIRED' },
-  'reset-used': { code: 'RESET_TOKEN_USED' },
-  'reset-tampered': { code: 'RESET_TOKEN_INVALID' },
+/** `POST /auth/password-reset/validations` — 토큰 검증(만료·사용됨·위변조만 판정, 계정 활성 상태는 보지 않는다) */
+export async function verifyResetToken(token: string): Promise<ResetTokenInfo> {
+  const res = await validatePasswordResetToken({ body: { token } })
+  return { email: res.email }
 }
 
-function delay<T>(value: T, ms = 500): Promise<T> {
-  return new Promise((resolve) => setTimeout(() => resolve(value), ms))
-}
-// ──────────────────────────────────────────────────────────────
-
-/** POST /auth/password-reset/request — 항상 202. 정상·없는 이메일·미활성 계정 셋 다 같은 응답(계정 열거 방지) */
-export function requestPasswordReset(_email: string): Promise<void> {
-  // ===== Mock 버전 =====
-  return delay(undefined)
-
-  // ===== 실제 백엔드 버전 =====
-  // await fetch('/auth/password-reset/request', {
-  //   method: 'POST',
-  //   headers: { 'Content-Type': 'application/json' },
-  //   body: JSON.stringify({ email }),
-  // })
-}
-
-/** GET /auth/password-reset/{token} — 토큰 검증(만료·사용됨·위변조만 판정, 계정 활성 상태는 보지 않는다) */
-export function verifyResetToken(token: string): Promise<ResetTokenInfo> {
-  // ===== Mock 버전 =====
-  return new Promise((resolve, reject) => {
-    setTimeout(() => {
-      const failure = MOCK_RESET_TOKEN_ERRORS[token]
-      if (failure) {
-        reject(failure)
-        return
-      }
-      const email = MOCK_RESET_TOKENS[token]
-      if (!email) {
-        reject({ code: 'RESET_TOKEN_INVALID' } satisfies PasswordResetApiError)
-        return
-      }
-      resolve({ email })
-    }, 400)
+/** `POST /auth/password-reset/confirmations` — 새 비밀번호 저장, 성공 시 서버가 기존 세션 전부 폐기 시도 */
+export async function confirmPasswordReset(req: ConfirmResetRequest): Promise<void> {
+  await confirmPasswordResetApi({
+    body: {
+      token: req.token,
+      newPassword: req.password,
+      newPasswordConfirmation: req.passwordConfirm,
+    },
   })
-
-  // ===== 실제 백엔드 버전 =====
-  // const res = await fetch(`/auth/password-reset/${token}`)
-  // if (!res.ok) return Promise.reject(await res.json())
-  // return res.json() // { email }
-}
-
-/** POST /auth/password-reset/confirm — 새 비밀번호 저장, 성공 시 서버가 기존 세션 전부 폐기 시도 */
-export function confirmPasswordReset(req: ConfirmResetRequest): Promise<ConfirmResetResponse> {
-  // ===== Mock 버전 =====
-  return new Promise((resolve, reject) => {
-    setTimeout(() => {
-      // case7 시연용 — 항상 저장 실패(롤백, 비밀번호 아직 안 바뀜)
-      if (req.token === 'reset-failing') {
-        reject({ code: 'RESET_FAILED' } satisfies PasswordResetApiError)
-        return
-      }
-      const email = MOCK_RESET_TOKENS[req.token]
-      if (!email) {
-        reject({ code: 'RESET_TOKEN_INVALID' } satisfies PasswordResetApiError)
-        return
-      }
-      const account = accounts[email]
-      // case6 — 지금 쓰는 비밀번호와 같음(클라이언트는 현재 비밀번호를 모르므로 서버가 판정)
-      if (account?.password === req.password) {
-        reject({ code: 'SAME_AS_CURRENT' } satisfies PasswordResetApiError)
-        return
-      }
-      resetAccountPassword(email, req.password)
-      resolve({ revokeFailed: req.token === 'reset-revokefail' })
-    }, 600)
-  })
-
-  // ===== 실제 백엔드 버전 =====
-  // const res = await fetch('/auth/password-reset/confirm', {
-  //   method: 'POST',
-  //   headers: { 'Content-Type': 'application/json' },
-  //   body: JSON.stringify(req), // { token, password }
-  // })
-  // if (!res.ok) return Promise.reject(await res.json())
-  // return res.json() // { revokeFailed }
 }

--- a/src/features/auth/passwordResetStates.ts
+++ b/src/features/auth/passwordResetStates.ts
@@ -1,14 +1,24 @@
+import { ApiError } from '@/api/_contract'
 import type { PasswordResetErrorCode } from './passwordResetTypes'
 
-/** password-reset.html#cases (mockup c6911c0) · 토큰 검증 단계 상태별 UI */
+/** password-reset.html#cases · 토큰 검증·확정 단계 상태별 UI */
 export interface PasswordResetState {
   message: string
   /** 알림 안에 노출할 후속 행동 */
   action?: 'REQUEST_AGAIN' | 'CONTACT'
 }
 
-export function resolvePasswordResetState(code: PasswordResetErrorCode): PasswordResetState {
-  switch (code) {
+const SYSTEM_MESSAGE =
+  '잠시 문제가 있었어요. 다시 시도해 주세요. 비밀번호는 아직 바뀌지 않았습니다.'
+
+/**
+ * **분기는 2단이다** — `code`로 먼저, 모르는 코드(네트워크·5xx·스펙에 없는 값)면 폴백으로.
+ * `resolveAuthState`(로그인)와 같은 구조 — authStates.tsx 참고.
+ */
+export function resolvePasswordResetState(error: unknown): PasswordResetState {
+  const e = error instanceof ApiError ? error : null
+
+  switch (e?.code as PasswordResetErrorCode | undefined) {
     // 2·3 — 만료·이미 사용됨 (할 일이 재요청으로 같아 한 화면)
     case 'RESET_TOKEN_EXPIRED':
     case 'RESET_TOKEN_USED':
@@ -18,15 +28,24 @@ export function resolvePasswordResetState(code: PasswordResetErrorCode): Passwor
     case 'RESET_TOKEN_INVALID':
       return { message: '유효하지 않은 링크입니다', action: 'CONTACT' }
 
-    // 6 — 지금 쓰는 비밀번호와 같음. 필드 하단에 붙이므로 여기서는 도달하지 않지만
-    // confirmPasswordReset 실패 분기가 이 타입을 공유한다
+    // 6 — 지금 쓰는 비밀번호와 같음. 화면이 필드 하단에 직접 붙이므로 보통 여기까지 안 오지만
+    // (PasswordResetScreen.tsx가 먼저 가로챈다), 폴백 경로로 들어오면 같은 문구를 쓴다
     case 'SAME_AS_CURRENT':
       return { message: '지금 쓰는 비밀번호와 달라야 합니다' }
 
     // 7 — 저장 실패·롤백. 비밀번호는 아직 안 바뀜
     case 'RESET_FAILED':
-      return {
-        message: '잠시 문제가 있었어요. 다시 시도해 주세요. 비밀번호는 아직 바뀌지 않았습니다.',
-      }
+      return { message: SYSTEM_MESSAGE }
+
+    // 클라이언트가 이미 정책·일치 여부를 검사해서 거의 안 오지만, 경쟁 상태 대비 폴백
+    case 'WEAK_PASSWORD':
+      return { message: '비밀번호 정책을 다시 확인해 주세요.' }
+    case 'VALIDATION_FAILED':
+      return { message: '입력값을 다시 확인해 주세요.' }
+
+    // 모르는 코드·네트워크 — 화면이 흰 채로 남는 것이 가장 나쁘므로 원인은 감추고 행동만 남긴다
+    default:
+      if (e?.isNetwork) return { message: '서버에 연결하지 못했습니다. 연결을 확인해 주세요.' }
+      return { message: SYSTEM_MESSAGE }
   }
 }

--- a/src/features/auth/passwordResetTypes.ts
+++ b/src/features/auth/passwordResetTypes.ts
@@ -1,41 +1,48 @@
 // ─────────────────────────────────────────────────────────────
-// 비밀번호 재설정 API 계약 · 출처: docs/plan/v2/wireframe/shared/password-reset.html#cases (mockup c6911c0)
+// 비밀번호 재설정 API 계약
+// 출처: 배포 스펙 `POST /api/v0/auth/password-reset/*` (api/openapi.json) — **여기가 단일 원천**
+// 이전 판은 목업 케이스 표(password-reset.html#cases)를 옮긴 것이었다. 이슈 178로 실서버
+// 연동하며 실제 스펙(`src/api/auth/authTypes.ts`)에 맞춰 정리했다 — authTypes.ts(로그인)와
+// 같은 근거·구조.
 // ─────────────────────────────────────────────────────────────
 
-/** POST /auth/password-reset/request — 항상 202, 계정 유무·활성 상태와 무관하게 동일 응답 */
+/** POST /auth/password-reset/requests — 항상 202, 계정 유무·활성 상태와 무관하게 동일 응답 */
 export interface RequestResetRequest {
   email: string
 }
 
-/** GET /auth/password-reset/{token} 응답 */
+/** POST /auth/password-reset/validations 응답 — `expiresAt`은 화면이 아직 안 써서 안 옮긴다 */
 export interface ResetTokenInfo {
   email: string
 }
 
-/** POST /auth/password-reset/confirm */
+/** POST /auth/password-reset/confirmations — 확인란 값도 서버로 같이 보낸다(서버가 재검증) */
 export interface ConfirmResetRequest {
   token: string
   password: string
+  passwordConfirm: string
 }
 
-/** POST /auth/password-reset/confirm 성공 응답 — 세션 폐기가 실패해도 비밀번호 변경 자체는 성공이다 */
-export interface ConfirmResetResponse {
-  /** true면 다른 기기 세션 폐기가 실패 — #donepartial 렌더, 서버는 계속 재시도 */
-  revokeFailed: boolean
-}
+/*
+  ⚠️ 없어진 것 — `revokeFailed`("다른 기기 세션 폐기 실패" 부분성공, #donepartial).
+  실제 확정 응답(`PasswordResetConfirmationResponse`)엔 `status`·`message`만 있고 세션 폐기
+  결과를 알려주는 필드가 없다 — 서버가 그 정보를 안 주므로 화면에서 도달 불가능한 상태였다.
+  백엔드가 필드를 추가하면 그때 복원한다. 성공 응답은 지금 화면이 값을 안 써서 void로 둔다.
+*/
 
 /**
- * 케이스 계약 · AUTH-05 전량 (구현 근거)
- * PR_INACTIVE_ACCOUNT(v1 라운드)는 삭제됐다 — 미활성 계정은 ①요청 단계에서 이미
- * 항상 202로 균일 처리되고, 토큰 검증 단계에서는 애초에 발생하지 않는 케이스다.
+ * 케이스 계약 · AUTH-05 (구현 근거)
+ * `RESET_TOKEN_EXPIRED`~`RESET_FAILED`는 목업 케이스 표와 그대로 대응. `WEAK_PASSWORD`·
+ * `VALIDATION_FAILED`는 실제 스펙에만 있던 것 — 클라이언트가 이미 정책·일치 여부를 검사해서
+ * 거의 안 오지만, 경쟁 상태(정책이 그 사이 바뀌는 등)를 대비해 폴백 문구를 둔다.
+ *
+ * 여기 없는 코드(네트워크·5xx·미지의 값)는 `resolvePasswordResetState`가 폴백으로 처리한다.
  */
 export type PasswordResetErrorCode =
   | 'RESET_TOKEN_EXPIRED' // 2 — 링크 만료
   | 'RESET_TOKEN_USED' // 3 — 이미 사용됨 (2와 같은 화면)
-  | 'RESET_TOKEN_INVALID' // 4(신규) — 위변조·목적 불일치, 보안 로그
-  | 'SAME_AS_CURRENT' // 6(신규) — 지금 쓰는 비밀번호와 같음
+  | 'RESET_TOKEN_INVALID' // 4 — 위변조·목적 불일치, 보안 로그
+  | 'SAME_AS_CURRENT' // 6 — 지금 쓰는 비밀번호와 같음
   | 'RESET_FAILED' // 7 — 저장 실패·롤백 (비밀번호 아직 안 바뀜)
-
-export interface PasswordResetApiError {
-  code: PasswordResetErrorCode
-}
+  | 'WEAK_PASSWORD' // 스펙에만 있음 — 클라이언트 정책 검사가 보통 먼저 막는다
+  | 'VALIDATION_FAILED' // 스펙에만 있음 — 형식 오류 일반


### PR DESCRIPTION
## 작업 내용
- 비밀번호 재설정 3단계(요청/토큰검증/확정)를 mock에서 `@/api/auth/authApi` 실호출로 교체
- 에러 코드 처리를 로그인(`resolveAuthState`)과 같은 패턴으로 통일 — `ApiError` narrowing + 폴백
- 서버가 안 주는 "다른 기기 세션 폐기 실패" 부분성공 상태(#donepartial) 제거

## 리뷰 포인트
- `passwordResetApi.ts`의 필드명 변환(`password`→`newPassword` 등)이 스펙과 맞는지
- `SAME_AS_CURRENT`를 필드 에러로, 나머지를 인라인 알림으로 가르는 분기(`PasswordResetScreen.tsx`)

closes #178