### PR TITLE
[Fix] Harden SA-01 Org Summary Card Loading/Error States

### DIFF
--- a/docs/dev/decision-log.md
+++ b/docs/dev/decision-log.md
@@ -505,3 +505,11 @@ git에는 `pre-stash`·`pre-reset` 훅이 없다. 그래서 Claude Code의 `PreT
   5. 프로젝트는 애초에 회차(round) 개념이 목록 필터에 없어(각 행 자체가 회차) 이 항목은 해당 없음.
 - **검산:** `/tmp` 격리 재검증 — `tsc --noEmit`(app·node) 통과, `prettier --check`에서 `TraineeListScreen.tsx` 포맷 어긋남 1건 발견 → `--write`로 고쳐 원본에 반영 후 재검증 전부 통과, `check-design.mjs` 통과(디자인 토큰 41개·대비 21쌍 그대로).
 - **목적·효과:** 세 목록 화면(면담·교육생·프로젝트) 모두 상세→목록 왕복 시 필터가 안 사라지는 동작으로 통일. 회차 전환 시 필터 초기화 여부만 화면 성격에 따라 갈린다(면담: 초기화 / 교육생: 유지 / 프로젝트: 해당 없음).
+
+## D28 · SA-01 summary 카드 B3(실패)·B1(로딩) 하드닝 — 컴팩트 Alert + Card 스켈레톤
+
+- **배경:** 이슈 #185 3차 라운드. `sa-01-org-list-situations.md` 축 B — `OrgListScreen.tsx`(208행)가 `summary.data &&` 조건만 보고 `isPending`·`isError`를 안 읽어 로딩 중엔 카드 자리가 없고(레이아웃 시프트, 4단계 CLS 실측 0.0550), 실패 시엔 재시도 수단 없이 그냥 안 뜬다. 지시서가 B3는 필수, B1은 "같이 처리 권장"(같은 조건문의 나머지 분기라 어차피 손댈 자리이고 CLS의 직접 원인)으로 못 박아 둬서 둘 다 처리.
+- **판단(전문가 제안, 반대하면 되돌림) — 실패 UI 모양:** 4칸짜리 dashed `Empty`(목록 자체의 isError가 쓰는 것과 같은 모양)는 쓰지 않았다. 카드 행 높이(약 90~130px)에 비해 `Empty`는 아이콘·헤더·설명까지 들어가 세로로 너무 길어 이 자리에서 어색하다. 대신 `manager/dashboard/DashboardScreen.tsx`가 밴드별 실패 줄에 이미 쓰고 있는 `Alert variant="danger"` + `AlertAction`(다시 시도 버튼) 조합을 그대로 재현했다(레이어 린트가 features 간 import를 막아 패턴만 따르고 새로 작성 — `OrgMetrics.tsx`에 `OrgMetricsFailed`로 추가). 한 줄짜리 인라인 배너라 4칸 그리드 높이와 자연스럽게 어울린다.
+- **판단 — 로딩 스켈레톤 높이:** 처음엔 `MetricCard`의 label·value·sub 3줄만 반영한 스켈레톤(94px)을 만들었는데, Playwright `PerformanceObserver`로 실측하니 실제 로드 완료 높이(124.66px)와 30px 넘게 차이 나 CLS가 남았다. 원인: 4장 중 "이번 달 AI 비용" 카드만 예산 진행바(Progress)가 있는데, CSS Grid `align-items: stretch` 기본값 때문에 나머지 3장도 그 카드 높이에 맞춰 함께 늘어난다. 스켈레톤에도 진행바 자리(4번째 줄)를 4장 전부에 추가해 130px로 보정 → 재측정 결과 **CLS 0.0550 → 0.0021(96% 감소)**. 남은 0.0021은 sub 텍스트가 콘텐츠 길이에 따라 1~2줄을 오가는 잔차로, 콘텐츠별로 스켈레톤을 다르게 그려야 없앨 수 있는데 임계(0.1)의 2% 수준이라 이번 범위에서는 멈췄다.
+- **검산:** `typecheck`·`build`·`lint`·`format:check`·`check:design`·`check:admin` 전부 로컬 실행 통과. 렌더은 Playwright(`page.route()` 가로채기 — 2차 라운드와 같은 이유로 claude-in-chrome 대신 사용, 사용자 로그인 없이 `.env.local`의 dev 전용 슈퍼어드민 quick-login 계정으로 진행)로 B2(회귀, 안 깨짐)·B3(500 강제 → 실패 배너 → 다시 시도 클릭 → 정상 회복)·B1(2.5초 지연 → 스켈레톤 → CLS 수치) 전부 스크린샷·수치로 확인.
+- **목적·효과:** SA-01 축 B(summary 조회 상태) 3종(B1/B2/B3) 전부 명시적으로 처리됨 — 이슈 #185의 마지막 남은 범위 종료. summary 실패가 더 이상 "무대응"이 아니고, 로딩 중 레이아웃 시프트가 실질적으로 사라짐.

--- a/docs/dev/screens/sa-01-org-list-situations.md
+++ b/docs/dev/screens/sa-01-org-list-situations.md
@@ -43,9 +43,9 @@ A3·A4는 같은 "0건"인데 문구·액션이 다르다(`hasFilter`로 분기)
 
 | | |
 |---|---|
-| B1 | pending — `summary.data &&` 조건이라 **카드 자리 자체가 없다**(스켈레톤 없음) |
+| B1 | pending — `summary.data &&` 조건이라 **카드 자리 자체가 없다**(스켈레톤 없음) *(3차 라운드에서 고침 → 5단계)* |
 | B2 | success |
-| B3 | isError — `isError`를 아예 안 읽는다. 실패해도 그냥 안 뜬다, 재시도 버튼도 없다 |
+| B3 | isError — `isError`를 아예 안 읽는다. 실패해도 그냥 안 뜬다, 재시도 버튼도 없다 *(3차 라운드에서 고침 → 5단계)* |
 
 조합 후보: 목록은 이미 떴는데(A5) 요약은 아직(B1) → **표가 먼저 자리 잡고 카드 4개가 위에서
 불쑥 나타나며 표를 밀어낸다**(레이아웃 시프트 후보, 4단계에서 CLS로 확인). 반대로 요약이
@@ -436,3 +436,55 @@ Playwright `page.route(url, r => r.abort('internetdisconnected'))`로 **진짜 �
 백엔드를 실제로 건드릴 이유가 없다 — `GET /organizations` 응답을 라우트 가로채기로
 부풀려(`totalPages` > 1이 되도록 `rows`·`total` 조작) E2–E5를 재현한다. G8·DELETION_PENDING과
 같은 방식이라 도구 하나로 묶어 처리 가능.
+
+## 5단계 · 3차 라운드 — B3·B1 하드닝 (2026-08-12, 이슈 #185)
+
+이슈 #185의 마지막 남은 범위. 대상: `OrgListScreen.tsx`(208행)·`OrgMetrics.tsx`.
+
+### B3 · summary 실패 시 무대응 — 🔴 확정된 결함 · ✅ 고침·렌더 확인 완료
+
+`summary.isError`를 읽어 `OrgMetricsFailed`(`Alert variant="danger"` + `AlertAction`의
+"다시 시도" 버튼)를 카드 자리에 그린다. 4칸 dashed `Empty`는 이 좁은 높이에서 어색해
+쓰지 않고, `manager/dashboard/DashboardScreen.tsx`가 밴드 실패 줄에 쓰는 것과 같은
+Alert+AlertAction 조합을 그대로 따랐다(레이어 린트 때문에 import는 못 하고 패턴만 재현).
+
+Playwright `page.route('**/organizations/summary', ...)`로 500을 강제해 렌더 확인:
+실패 배너 노출 → "다시 시도" 클릭 → 라우트 가로채기 해제 후 정상 카드로 회복하는 것까지
+스크린샷으로 확인함(성공 상태 B2도 함께 회귀 확인, 깨지지 않음).
+
+### B1 · pending 시 카드 자리 없음(CLS) — ✅ 같이 고침·렌더 확인 완료
+
+`summary.isPending`일 때 `OrgMetricsSkeleton`(카드 4장과 같은 `grid-cols-4 gap-4 mb-5`,
+`MetricCard`와 같은 `Card size="sm" gap-1.5 px-4` 래퍼)을 그린다. B3와 같은 조건문의
+나머지 분기라 어차피 손대는 자리였고, 4단계에서 실측한 CLS 0.0550(B1+A5 조합, 위 "실제
+렌더에서만 잡힌 것" 참고)의 직접 원인이라 함께 처리.
+
+Playwright `PerformanceObserver`(`layout-shift`)로 재측정 — summary 응답을 2.5초
+지연시켜 pending→success 전환을 강제로 관찰:
+
+| | 카드 그리드 높이 | 비고 |
+|---|---|---|
+| 스켈레톤(초안) | 94px | label+value+sub 3줄만 |
+| 스켈레톤(보정) | 130px | AI 비용 카드의 진행바(Progress) 자리까지 4번째 줄로 반영 |
+| 실제 로드 완료 | 124.66px | AI 비용 카드의 2줄 sub + 진행바 때문에 grid stretch로 4장 다 이만큼 늘어남 |
+
+첫 스켈레톤은 sub 한 줄만 반영해 94px — 실제(124.66px)와 30px 넘게 차이 나 CLS가
+여전히 남았다(측정 안 함, 시각적으로 부족해 보정 먼저 함). `sub` 자리를 2줄 높이로,
+진행바 자리를 4번째 줄로 추가해 130px로 보정한 뒤 재측정: **CLS 0.0550 → 0.0021**
+(96% 감소). 4장 중 AI 비용 카드 하나만 진행바가 있지만 CSS Grid의 `align-items: stretch`
+기본값 때문에 4장이 항상 같은 높이로 늘어난다 — 그래서 스켈레톤도 4장 전부에 진행바
+자리를 넣어야 실제 높이에 맞는다(카드별로 다르게 그리면 오히려 더 어긋난다).
+
+남은 0.0021은 실제 카드 텍스트 줄바꿈(통화 포맷·퍼센트 문자열 길이가 기관마다 달라
+sub 텍스트가 1~2줄 사이를 오간다)에서 오는 잔차라 완전히 0으로 맞추려면 콘텐츠별로
+스켈레톤을 다르게 그려야 하는데, 그 정밀도는 이번 범위에서 과함 — 임계 0.1의 2% 수준이라
+여기서 멈춤.
+
+### 검증
+
+`typecheck`·`build`·`lint`·`format:check`·`check:design`·`check:admin` 전부 통과(로컬
+실행 결과 직접 확인). 렌더 확인은 Playwright(`page.route()` 가로채기, 2차 라운드와 같은
+이유로 claude-in-chrome 대신 사용)로 B2(회귀)·B3(실패→재시도 회복)·B1(스켈레톤, CLS
+실측)까지 전부 스크린샷·수치로 확인.
+
+**이슈 #185, 이걸로 축 B 잔여 범위 전부 종료.**

--- a/src/features/superadmin/orgs/OrgListScreen.tsx
+++ b/src/features/superadmin/orgs/OrgListScreen.tsx
@@ -58,7 +58,7 @@ import {
   type OrgSortDirection,
   type OrgSortKey,
 } from './labels'
-import OrgMetrics from './components/OrgMetrics'
+import OrgMetrics, { OrgMetricsSkeleton, OrgMetricsFailed } from './components/OrgMetrics'
 import OrgCreateDialog from './components/OrgCreateDialog'
 import { useDebounced } from '@/lib/useDebounced'
 import { cn } from '@/lib/utils/cn'
@@ -205,7 +205,13 @@ export default function OrgListScreen() {
         }
       />
 
-      {summary.data && <OrgMetrics summary={summary.data} />}
+      {summary.isError ? (
+        <OrgMetricsFailed onRetry={() => summary.refetch()} />
+      ) : summary.isPending ? (
+        <OrgMetricsSkeleton />
+      ) : summary.data ? (
+        <OrgMetrics summary={summary.data} />
+      ) : null}
 
       {isError ? (
         <Empty>

--- a/src/features/superadmin/orgs/components/OrgMetrics.tsx
+++ b/src/features/superadmin/orgs/components/OrgMetrics.tsx
@@ -1,6 +1,9 @@
 import type { ReactNode } from 'react'
 import { Card } from '@/components/ui/Card'
 import { Progress } from '@/components/ui/Progress'
+import { Skeleton } from '@/components/ui/Skeleton'
+import { Alert, AlertTitle, AlertAction } from '@/components/ui/Alert'
+import { Button } from '@/components/ui/Button'
 import type { findPlatformSummary_Response } from '@/api/organization/organizationTypes'
 import { formatBytes, formatChangeRate, formatCost } from '../labels'
 
@@ -35,6 +38,42 @@ function MetricCard({
       {sub && <p className="text-fg-subtle text-xs">{sub}</p>}
       {children}
     </Card>
+  )
+}
+
+/*
+  로딩·실패 — 카드 4장과 같은 `grid-cols-4`·`mb-5`, MetricCard와 같은 `Card size="sm"
+  gap-1.5 px-4` 래퍼를 그대로 써서 자리 높이를 맞춘다(CLS, 정의서 축 B1 근거: 2026-08-12
+  실측 CLS 0.0550). 실패는 카드 자리 대신 한 줄 Alert로 — 4칸짜리 dashed Empty는
+  이 좁은 높이에서 어색하다(manager/dashboard DashboardScreen.tsx의 밴드 실패 줄과 같은
+  Alert+AlertAction 조합을 따른다).
+*/
+export function OrgMetricsSkeleton() {
+  return (
+    <div className="mb-5 grid grid-cols-4 gap-4">
+      {Array.from({ length: 4 }, (_, i) => (
+        <Card key={i} size="sm" className="gap-1.5 px-4">
+          <Skeleton className="h-3 w-16" />
+          <Skeleton className="h-8 w-20" />
+          <Skeleton className="h-7 w-28" />
+          {/* AI 비용 카드에만 있는 예산 진행바(Progress) 자리 — 4장이 같은 높이로 늘어나므로(grid stretch) 전부에 둔다 */}
+          <Skeleton className="mt-2 h-1.5 w-full" />
+        </Card>
+      ))}
+    </div>
+  )
+}
+
+export function OrgMetricsFailed({ onRetry }: { onRetry: () => void }) {
+  return (
+    <Alert variant="danger" className="mb-5">
+      <AlertTitle>요약 정보를 불러오지 못했습니다</AlertTitle>
+      <AlertAction>
+        <Button variant="ghost" size="sm" onClick={onRetry}>
+          다시 시도
+        </Button>
+      </AlertAction>
+    </Alert>
   )
 }
 


### PR DESCRIPTION
## 작업 내용
- `OrgListScreen.tsx`의 요약 카드 렌더 조건이 `summary.data &&` 하나뿐이라, 조회 실패 시
  카드 자리 없이 그냥 사라지고 재시도 수단이 없었다(B3). 로딩 중에도 카드 자리가 없어
  목록이 먼저 뜨고 요약 카드가 나중에 밀고 들어오며 레이아웃 시프트를 유발했다(B1, 실측
  CLS 0.0550).
- `isError` 시 `OrgMetricsFailed`(Alert + 다시 시도 버튼), `isPending` 시
  `OrgMetricsSkeleton`(카드 4장과 같은 그리드 높이)을 추가해 두 상태 모두 처리했다.
- 스켈레톤 높이를 Playwright `PerformanceObserver`로 실측·보정해 CLS를 0.0550 → 0.0021로
  줄였다(96% 감소).

## 리뷰 포인트
- 실패 UI를 4칸 dashed Empty 대신 `manager/dashboard/DashboardScreen.tsx`가 이미 쓰는
  Alert+AlertAction 패턴으로 재현했다(레이어 린트로 import는 못 함) — 이 판단이
  적절한지 확인 부탁.
- 스켈레톤에 진행바 자리를 카드 4장 전부에 넣은 이유(CSS Grid `align-items: stretch`)가
  `OrgMetrics.tsx` 주석에 있다.

## 테스트 플랜
- [x] typecheck / build / lint / format:check / check:design / check:admin
- [x] Playwright 렌더 확인 — B2(회귀) / B3(실패 → 재시도 → 회복) / B1(스켈레톤, CLS 실측)

closes #185