### PR TITLE
[Fix] Curriculum PDF Upload Fails With 413 Over ~6MB

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,11 @@
 # envoy가 404를 즉답해 "죽은 것처럼" 보인다. 프록시(Lambda)에는 깨우기 로직이 있다.
 VITE_API_BASE=https://xvdanr6m362b2ge232vdmfbrny0kwakz.lambda-url.ap-northeast-1.on.aws
 
+# 대용량 업로드(교안 PDF)가 Lambda 6MB 상한을 우회해 직접 쏘는 App Runner origin 도메인.
+# PAUSED 상태는 못 깨우므로(Lambda 프록시만 깨움) registerCurriculum이 먼저 VITE_API_BASE로
+# 웜업 GET을 보낸 뒤에만 이 도메인을 쓴다. 코드에 하드코딩 기본값이 있어 필수는 아니다.
+VITE_API_ORIGIN_BASE=https://mmbvymzj5k.ap-northeast-1.awsapprunner.com
+
 # dev 전용 역할 전환 버튼(로그인 화면 하단 · 헤더 드롭다운)이 쓸 계정.
 # 없으면 그 버튼이 아예 안 나온다 — 기능이 없는 것이지 고장 난 것이 아니다.
 #

--- a/src/api/_contract/client.ts
+++ b/src/api/_contract/client.ts
@@ -117,10 +117,10 @@ const authMiddleware: Middleware = {
  * 테스트·스토리북이 자기 인스턴스를 만들 수 있게 팩토리를 연다.
  * 서버가 하나뿐이라 앱은 아래 `izClient` 하나만 쓴다 — 팩토리는 "문"이지 사용 패턴이 아니다.
  */
-export function createIzClient(options: { baseUrl: string }) {
+export function createIzClient(options: { baseUrl: string; credentials?: RequestCredentials }) {
   const client = createClient<paths>({
     baseUrl: options.baseUrl,
-    credentials: 'include', // 리프레시 쿠키
+    credentials: options.credentials ?? 'include', // 기본은 리프레시 쿠키 포함
   })
   client.use(authMiddleware)
   return client
@@ -141,10 +141,16 @@ export const izClient = createIzClient({
   PAUSED 상태는 origin 직접 호출로 못 깨운다 — `resume_service()`는 Lambda 프록시를 거친
   요청만 트리거한다(프록시 소스 확인). 그래서 이 클라이언트를 쓰는 호출 앞에는 반드시
   `izClient`로 가벼운 웜업 GET이 선행돼야 한다(예: `uploads.ts`의 `registerCurriculum`).
+
+  `credentials: 'omit'`이다 — 리프레시 쿠키는 로그인이 실제로 일어나는 `izClient`의 호스트에만
+  scope된 host-only 쿠키라(Domain 속성 미지정) 브라우저가 애초에 이 도메인으론 실어 보내지
+  않지만, 이 클라이언트가 쿠키를 쓸 일이 없다는 걸 최소 권한으로 명시해 둔다 — Bearer 헤더만으로
+  인증이 끝나는 호출이라서다.
 */
 export const izOriginClient = createIzClient({
   baseUrl:
     import.meta.env?.VITE_API_ORIGIN_BASE ?? 'https://mmbvymzj5k.ap-northeast-1.awsapprunner.com',
+  credentials: 'omit',
 })
 
 /**

--- a/src/api/_contract/client.ts
+++ b/src/api/_contract/client.ts
@@ -130,6 +130,23 @@ export const izClient = createIzClient({
   baseUrl: import.meta.env?.VITE_API_BASE ?? '',
 })
 
+/*
+  **대용량 업로드 전용 — App Runner origin 도메인으로 직접.**
+
+  Lambda Function URL(=`izClient`)은 AWS 플랫폼 자체의 동기 페이로드 상한이 6MB다(실측,
+  Backend 코드 도달 전에 413). Backend가 자기 쪽(→AI 서비스) 같은 문제를 이미 이 패턴으로
+  풀었다(`AiCurriculumClient`/`AiProxyWarmUp`, Backend PR #87) — 가벼운 GET을 프록시로 먼저
+  보내 깨우고, 실제 대용량 바디는 origin으로 직접. 여기서는 그 패턴을 프론트 쪽에 미러링한다.
+
+  PAUSED 상태는 origin 직접 호출로 못 깨운다 — `resume_service()`는 Lambda 프록시를 거친
+  요청만 트리거한다(프록시 소스 확인). 그래서 이 클라이언트를 쓰는 호출 앞에는 반드시
+  `izClient`로 가벼운 웜업 GET이 선행돼야 한다(예: `uploads.ts`의 `registerCurriculum`).
+*/
+export const izOriginClient = createIzClient({
+  baseUrl:
+    import.meta.env?.VITE_API_ORIGIN_BASE ?? 'https://mmbvymzj5k.ap-northeast-1.awsapprunner.com',
+})
+
 /**
  * openapi-fetch의 `{ data, error, response }`를 **성공값 또는 throw**로 바꾼다.
  *

--- a/src/api/_contract/index.ts
+++ b/src/api/_contract/index.ts
@@ -5,7 +5,7 @@
   여기 있는 시그니처는 백엔드가 바뀌어도 그대로 남는다. 반대로 생성물은 스펙이 바뀌면
   통째로 다시 만들어진다. **그 경계가 이 폴더다.**
 */
-export { izClient, createIzClient, unwrap } from './client'
+export { izClient, izOriginClient, createIzClient, unwrap } from './client'
 export { ApiError, isApiError, isGenericCode, NETWORK_ERROR_CODE } from './errors'
 export type { FieldError, ErrorCode } from './errors'
 export { authBridge, connectAuth } from './authBridge'

--- a/src/api/uploads.ts
+++ b/src/api/uploads.ts
@@ -1,4 +1,4 @@
-import { izClient, unwrap, type RequestOptions } from '@/api/_contract'
+import { izClient, izOriginClient, unwrap, type RequestOptions } from '@/api/_contract'
 import type { operations } from '@/api/schema'
 
 /*
@@ -71,14 +71,21 @@ export const previewTraineesFromCsv = (params: CsvUpload) =>
  *
  * ⚠ **등록 직후에는 분석이 안 된 상태다.** 섹션·검증개념을 쓰려면 별도로
  * `POST /curricula/{materialId}/analyses`를 불러야 한다(스펙 명시).
+ *
+ * **본문은 `izClient`가 아니라 `izOriginClient`로 보낸다.** Lambda Function URL(`izClient`)엔
+ * AWS 자체 6MB 동기 페이로드 상한이 있어 그 이상은 413(실측) — App Runner origin 도메인으로
+ * 직접 보내 우회한다(Backend PR #87의 `AiCurriculumClient` 패턴 미러링). origin은 PAUSED
+ * 상태를 스스로 못 깨우므로, 실제 업로드 전에 `izClient`로 가벼운 GET을 먼저 보내 깨운다.
  */
-export const registerCurriculum = (
+export const registerCurriculum = async (
   params: { query: { title: string; topic?: string }; file: File } & RequestOptions,
-) =>
-  unwrap<RegisterCurriculumResponse>(
-    izClient.POST('/api/v0/curricula', {
+) => {
+  await izClient.GET('/api/v0/members/me', { signal: params.signal }).catch(() => {})
+  return unwrap<RegisterCurriculumResponse>(
+    izOriginClient.POST('/api/v0/curricula', {
       params: { query: params.query },
       body: csvBody(params.file) as never,
       signal: params.signal,
     }) as never,
   )
+}


### PR DESCRIPTION
## 작업 내용

교안 PDF 업로드가 ~6MB를 넘으면 413으로 실패하던 문제 수정.

원인: Frontend가 Backend를 부르는 유일한 경로(`VITE_API_BASE`)가 AWS Lambda Function URL인데,
이 URL 자체가 AWS 플랫폼 레벨 동기 페이로드 상한 6MB를 갖고 있어 Backend 코드에 닿기도 전에
막힘(실측: 동일 8MB 바디가 Lambda URL엔 413, App Runner origin 도메인엔 401).

Backend가 이미 같은 문제를 자기 쪽(→AI 서비스)에서 #87로 고쳐서 merge한 패턴을 그대로
미러링함(`AiCurriculumClient`/`AiProxyWarmUp`): 가벼운 GET으로 Lambda 프록시를 먼저 깨우고
(origin 도메인 직접 호출로는 PAUSED 상태를 못 깨움 — 프록시 Lambda 소스로 확인), 실제 PDF는
App Runner origin 도메인으로 직접 전송.

- `src/api/_contract/client.ts`: `izOriginClient` 추가(기존 `createIzClient` 팩토리 재사용).
  이 업로드는 Authorization 헤더만으로 인증되므로 `credentials: 'omit'`으로 명시(팩토리에
  `credentials` 옵션 추가).
- `src/api/uploads.ts`: `registerCurriculum`이 웜업 GET(`/api/v0/members/me`) 후
  `izOriginClient`로 PDF 전송하도록 변경.
- `.env.example`: `VITE_API_ORIGIN_BASE` 문서화(코드에 하드코딩 기본값 있어 필수는 아님).

## 리뷰 포인트

- **CORS는 Backend 변경이 필요 없음** — 실측: CORS는 브라우저 Origin 헤더 기준으로 판정되지
  호출 대상 URL과 무관. Lambda든 origin이든 같은 Spring 앱(`SecurityConfig`)이 응답하므로
  정책이 동일하게 적용됨(origin 도메인에 실제 preflight 날려서 프로덕션 Vercel 도메인에 대해
  `Access-Control-Allow-Origin`이 정상 매치되는 것까지 확인).
- **알려진 대안**: `CurriculumController`/`application.yaml` 주석에 "진짜 답은 presigned S3"라는
  코멘트가 있음 — 현재 S3 자격증명이 깨져 있고 Storage 연동 자체가 없어 그 경로는 막혀 있는
  상태라, 이번 PR은 Backend가 이미 검증한 패턴을 재사용하는 실용적 우회로 진행. presigned S3가
  나중에 구현되면 이 우회는 대체 가능.
- **아직 실제 계정으로 UI에서 대용량 PDF 업로드 성공까지는 확인 못 함** — curl로 "413이 안 난다"는
  확인했지만 인증된 전체 플로우 성공은 리뷰/머지 전에 실제 계정으로 확인 필요.
- CSV 대량 등록의 502 이슈는 별개 — 이 PR 스코프 아님.

## 확인

- [x] `npm run verify:ci` 전체 통과
- [ ] 로컬에서 동작 확인 — 실제 계정으로 대용량 PDF 업로드 성공까지 확인 필요(머지 전)
- [x] 하나의 PR = 하나의 기능

closes #206