### PR TITLE
[Fix] Harden Roster and Curriculum Registration Dialogs

### DIFF
--- a/src/features/operator/admin/_/rules.ts
+++ b/src/features/operator/admin/_/rules.ts
@@ -120,6 +120,14 @@ export function checkEmail(value: string, domain: string): RosterIssueReason | n
 }
 
 // ── CSV ────────────────────────────────────────────────────
+/**
+ * 한 번에 등록할 수 있는 최대 인원 — **서버도 같은 값을 검증한다**
+ * (`CSV_FORMAT_INVALID · "한 번에 최대 1000명의 교육생을 초대할 수 있습니다"`,
+ * 8/13 실측 — 5000명 업로드가 이 코드로 거절됨). 넘으면 서버에 물어볼 것도 없이
+ * 화면에서 먼저 막는다 — 어차피 실패할 요청은 아예 보내지 않는다.
+ */
+export const MAX_TRAINEE_INVITE = 1000
+
 export type ParsedRoster = {
   /** 등록 후보. 서버가 여기서 **이미 등록된 이메일**을 다시 걸러낸다 */
   entries: RosterEntry[]

--- a/src/features/operator/admin/curricula/components/RegisterCurriculumDialog.tsx
+++ b/src/features/operator/admin/curricula/components/RegisterCurriculumDialog.tsx
@@ -59,6 +59,18 @@ export default function RegisterCurriculumDialog({ open, onOpenChange }: Props) 
 
   const submittable = !!file && name.trim().length > 0 && !submitting
 
+  /** 닫을 때 비운다 — 실패 문구·고른 파일·이름이 다음에 열었을 때 남아있으면 안 된다 */
+  const reset = () => {
+    setFile(null)
+    setName('')
+    setFailed(null)
+  }
+
+  const close = (next: boolean) => {
+    onOpenChange(next)
+    if (!next) reset()
+  }
+
   const submit = async () => {
     if (!file) return
     setSubmitting(true)
@@ -74,9 +86,7 @@ export default function RegisterCurriculumDialog({ open, onOpenChange }: Props) 
         return
       }
       await queryClient.invalidateQueries({ queryKey: curriculumKeys.all })
-      onOpenChange(false)
-      setFile(null)
-      setName('')
+      close(false)
     } catch {
       setFailed('등록하지 못했습니다. PDF 파일인지 확인해 주세요.')
     } finally {
@@ -85,7 +95,7 @@ export default function RegisterCurriculumDialog({ open, onOpenChange }: Props) 
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={close}>
       <DialogContent className="sm:max-w-[460px]">
         <DialogHeader>
           <DialogTitle>교안 등록</DialogTitle>
@@ -146,7 +156,7 @@ export default function RegisterCurriculumDialog({ open, onOpenChange }: Props) 
         </div>
 
         <DialogFooter>
-          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={submitting}>
+          <Button variant="ghost" onClick={() => close(false)} disabled={submitting}>
             취소
           </Button>
           <Button disabled={!submittable} onClick={submit}>

--- a/src/features/operator/admin/roster/components/AddRosterDialog.tsx
+++ b/src/features/operator/admin/roster/components/AddRosterDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useRef } from 'react'
 import { XIcon } from 'lucide-react'
 import {
   Dialog,
@@ -68,7 +68,10 @@ export default function AddRosterDialog({ open, onOpenChange, onAdded }: Props) 
   const [preview, setPreview] = useState<registerTrainees_Response | null>(null)
   const [rows, setRows] = useState<RosterEntry[]>([emptyRow()])
   const [submitting, setSubmitting] = useState(false)
-  const [failed, setFailed] = useState(false)
+  /** 서버가 준 원본 에러 — previewFailure와 같은 방식으로 `errorCopy`가 문구를 정한다 */
+  const [submitFailure, setSubmitFailure] = useState<unknown>(null)
+  /** 진행 중인 CSV 등록 요청 — 닫으면서 취소할 수 있게 들고 있는다 */
+  const submitAbortRef = useRef<AbortController | null>(null)
 
   /** 기관 도메인은 세션이 준다(9차 Q3-④) — `null`이면 도메인 제한을 걸지 않는다 */
   const { data: me } = useGetCurrentMember()
@@ -131,18 +134,23 @@ export default function AddRosterDialog({ open, onOpenChange, onAdded }: Props) 
   const submit = async () => {
     if (!cohortId) return
     setSubmitting(true)
-    setFailed(false)
+    setSubmitFailure(null)
+    const controller = new AbortController()
+    submitAbortRef.current = controller
     try {
       const result =
         mode === 'csv' && file
-          ? await registerTraineesFromCsv({ path: { cohortId }, file })
+          ? await registerTraineesFromCsv({ path: { cohortId }, file, signal: controller.signal })
           : await registerTyped.mutateAsync({ path: { cohortId }, body: { trainees: entries } })
       onAdded(result)
       close(false) // 닫기가 비우는 일까지 한다 — 성공·취소가 같은 길로 나간다
-    } catch {
-      setFailed(true)
+    } catch (e) {
+      // 닫으면서 우리가 취소한 것 — 이미 닫힌 다이얼로그에 실패를 띄울 필요는 없다
+      if (controller.signal.aborted) return
+      setSubmitFailure(e)
     } finally {
       setSubmitting(false)
+      submitAbortRef.current = null
     }
   }
 
@@ -151,7 +159,9 @@ export default function AddRosterDialog({ open, onOpenChange, onAdded }: Props) 
     setFile(null)
     setPreview(null)
     setRows([emptyRow()])
-    setFailed(false)
+    setSubmitFailure(null)
+    // pending 상태에서 닫혔을 수 있다 — 닫혔다 다시 열었을 때 스피너가 안 남게 같이 지운다
+    setSubmitting(false)
   }
 
   /*
@@ -160,6 +170,7 @@ export default function AddRosterDialog({ open, onOpenChange, onAdded }: Props) 
     센 수**라 그 사이 명단이 바뀌면 틀린 수를 보여준다. 등록은 이어 하는 작업이 아니다.
   */
   const close = (next: boolean) => {
+    if (!next) submitAbortRef.current?.abort()
     onOpenChange(next)
     if (!next) reset()
   }
@@ -175,11 +186,24 @@ export default function AddRosterDialog({ open, onOpenChange, onAdded }: Props) 
         </DialogHeader>
 
         <div className="-mx-1 flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-1">
-          {failed && (
-            <Alert variant="danger">
-              <AlertTitle>등록하지 못했습니다. 잠시 후 다시 시도해 주세요.</AlertTitle>
-            </Alert>
-          )}
+          {/*
+            **submit 실패를 previewFailure와 같은 방식으로 다룬다.** 예전엔
+            `catch { setFailed(true) }`로 뭉뚱그려 이유가 무엇이든(예: `CSV_FORMAT_INVALID`
+            "한 번에 최대 1000명" 같은 구체적 사유도) 같은 범용 문구만 보여줬다 — 서버가
+            이미 행 번호·사유가 담긴 message를 주는데 버리고 있었다.
+          */}
+          {submitFailure !== null &&
+            (() => {
+              const copy = errorCopy(submitFailure, { subject: '교육생', action: '등록' })
+              return (
+                <Alert variant="danger">
+                  <AlertTitle>{copy.title}</AlertTitle>
+                  <AlertDescription>
+                    {(submitFailure as { message?: string }).message ?? copy.description}
+                  </AlertDescription>
+                </Alert>
+              )
+            })()}
 
           {/*
             **미리보기가 거절당하면 그 말을 그대로 보여준다.** 서버는 행 번호까지 준다

--- a/src/features/operator/admin/roster/components/AddRosterDialog.tsx
+++ b/src/features/operator/admin/roster/components/AddRosterDialog.tsx
@@ -17,7 +17,7 @@ import { useGetCurrentMember } from '@/api/member/useMemberQueries'
 import { useRegisterTrainees, usePreviewTrainees } from '@/api/member/useMemberMutations'
 import { registerTraineesFromCsv, previewTraineesFromCsv } from '@/api/uploads'
 import type { registerTrainees_Response } from '@/api/member/memberTypes'
-import { checkRosterRows, type ParsedRoster } from '../../_/rules'
+import { checkRosterRows, MAX_TRAINEE_INVITE, type ParsedRoster } from '../../_/rules'
 import { ROSTER_ISSUE_LABEL } from '../../_/labels'
 import { useCohortScope } from '../../_/cohortScope'
 import type { RosterEntry, RosterIssue } from '../../_/api/types'
@@ -94,7 +94,10 @@ export default function AddRosterDialog({ open, onOpenChange, onAdded }: Props) 
 
   const entries = mode === 'csv' ? (parsed?.entries ?? []) : typedValid
   const issues = mode === 'csv' ? (parsed?.invalid ?? []) : typedIssues
-  const submittable = entries.length > 0 && issues.length === 0 && !submitting && !!cohortId
+  /** 1000명 초과 — 서버가 파일 전체를 거절하는 규칙(`MAX_TRAINEE_INVITE`)을 화면에서 먼저 막는다 */
+  const tooMany = entries.length > MAX_TRAINEE_INVITE
+  const submittable =
+    entries.length > 0 && !tooMany && issues.length === 0 && !submitting && !!cohortId
 
   /** 서버가 센 중복 수 — 응답이 실패 행을 이유별 코드로 준다(3 = 이미 있는 이메일) */
   const duplicates = preview?.failures.filter((f) => f.status === 3).length ?? 0
@@ -245,6 +248,16 @@ export default function AddRosterDialog({ open, onOpenChange, onAdded }: Props) 
                 onChange={(next, _name, picked) => {
                   setParsed(next)
                   setFile(picked)
+                  /*
+                    **1000명을 넘으면 미리보기를 안 부른다.** 어차피 서버가 같은 이유로
+                    거절할 게 확실한 요청이다 — 물어보고 실패 문구를 또 하나 띄우는 대신
+                    화면이 이미 아는 사실(`tooMany`)만 보여준다.
+                  */
+                  if ((next?.entries.length ?? 0) > MAX_TRAINEE_INVITE) {
+                    setPreview(null)
+                    setPreviewFailure(null)
+                    return
+                  }
                   void askPreviewCsv(picked)
                 }}
               />
@@ -308,13 +321,21 @@ export default function AddRosterDialog({ open, onOpenChange, onAdded }: Props) 
           {/* 판정 결과 — **누르기 전에** 무엇이 등록되고 무엇이 걸리는지 보여준다 */}
           {(entries.length > 0 || issues.length > 0) && (
             <div className="border-border bg-surface-2 rounded-md border p-3">
-              {/* 유효가 0이면 이 줄을 쓰지 않는다 — `✓ 유효 0명`은 체크 표시가 거짓말을 한다 */}
-              {entries.length > 0 && (
-                <p className="text-success text-xs">
-                  ✓ 유효{' '}
-                  <b className="font-semibold">{preview?.registeredCount ?? entries.length}명</b> —
-                  등록하면 활성화 초대가 나갑니다
+              {tooMany ? (
+                <p className="text-danger text-xs">
+                  ✗ <b className="font-semibold">{entries.length.toLocaleString()}명</b> — 한 번에
+                  최대 {MAX_TRAINEE_INVITE.toLocaleString()}명까지 등록할 수 있습니다. 파일을 나눠서
+                  다시 올려 주세요.
                 </p>
+              ) : (
+                // 유효가 0이면 이 줄을 쓰지 않는다 — `✓ 유효 0명`은 체크 표시가 거짓말을 한다
+                entries.length > 0 && (
+                  <p className="text-success text-xs">
+                    ✓ 유효{' '}
+                    <b className="font-semibold">{preview?.registeredCount ?? entries.length}명</b>{' '}
+                    — 등록하면 활성화 초대가 나갑니다
+                  </p>
+                )
               )}
               {duplicates > 0 && (
                 <p className="text-warning mt-0.5 text-xs">

--- a/src/lib/errorCopy.ts
+++ b/src/lib/errorCopy.ts
@@ -189,6 +189,19 @@ const BY_CODE: Record<string, (ctx: Ctx) => ErrorCopy> = {
     retry: false,
     tone: 'pending',
   }),
+
+  /*
+    CSV 파일 자체가 스펙에 안 맞는다 — 한 번에 최대 1000명 제한(8/13 실측, 5000명 업로드가
+    이 코드로 거절됨) 초과나 행 형식·인코딩 문제. **서버가 어느 행이 왜 틀렸는지를
+    `message`에 담아 준다**(스펙 명시) — `AddRosterDialog`가 `error.message`를 그대로
+    보여주고, 여기 `description`은 message가 없을 때만 쓰는 fallback이다.
+  */
+  CSV_FORMAT_INVALID: () => ({
+    title: 'CSV 파일 형식이 올바르지 않습니다',
+    description: '한 번에 최대 1000명까지 등록할 수 있습니다 — 파일 형식을 확인해 주세요.',
+    retry: false,
+    tone: 'failed',
+  }),
 }
 
 export function errorCopy(error: unknown, ctx: Ctx): ErrorCopy {


### PR DESCRIPTION
## 작업 내용 요약

명단·교안 등록 다이얼로그 두 개를 하드닝했다(#222).

1. `AddRosterDialog.tsx` — submit 실패를 `catch { setFailed(true) }`로 뭉뚱그리던 걸
   걷어내고, previewFailure와 같은 방식(`errorCopy`)으로 서버 에러 코드별 문구를
   보여준다. `AbortController`를 붙여 CSV 등록 요청 중 닫으면 실제로 취소되고,
   `reset()`이 `submitting`도 같이 초기화해 pending 상태에서 닫았다 다시 열어도
   스피너가 안 남는다.
2. `RegisterCurriculumDialog.tsx` — `reset()` 자체가 없던 걸 추가하고 `onOpenChange`를
   직접 부르던 자리를 전부 `close()` 래퍼로 통일. 실패 후 닫았다 다시 열어도 이전
   문구·파일·이름이 안 남는다.
3. `errorCopy.ts` — `CSV_FORMAT_INVALID` 코드 문구 추가.
4. (수동 테스트 중 발견) 5000명 CSV를 올리면 로컬 판정은 전부 "유효"로 세는데
   서버(1000명 상한)가 미리보기·등록 양쪽에서 같은 이유로 거절해 같은 실패 알럿이
   두 번 뜨는 버그를 발견 — `rules.ts`에 `MAX_TRAINEE_INVITE`(1000) 상수를 추가하고,
   `AddRosterDialog`가 1000명 넘으면 미리보기를 아예 안 부르고 등록도 막는다.
   어차피 실패할 요청을 안 보내니 중복 알럿도 자연히 없어진다.

## 리뷰 포인트

- `AddRosterDialog.tsx`의 `submitAbortRef`가 CSV 경로(`registerTraineesFromCsv`)만
  실제로 취소되고, 직접 입력 경로(`registerTyped.mutateAsync`)는 mutation 훅이
  `signal`을 안 받아서 취소는 안 되고 스피너 정리만 됩니다 — 의도한 범위인지 확인
  부탁드립니다.
- `MAX_TRAINEE_INVITE = 1000`은 8/13 실측(`CSV_FORMAT_INVALID` 메시지)에서 가져온
  값입니다 — 서버 쪽 실제 상한과 계속 같은 값인지는 별도로 맞춰야 합니다.
- 폴링 UI(대량 등록 진행률 표시)는 이번 범위에서 뺐습니다 — 백엔드 PR이 아직
  API 계약을 안 정해서 후속으로 미룹니다.

closes #222