### PR TITLE
[Fix] Auth and Roster Dialog Copy

### DIFF
--- a/src/components/common/Loading.tsx
+++ b/src/components/common/Loading.tsx
@@ -27,8 +27,11 @@ export function SlowNotice({ afterMs = 12000 }: { afterMs?: number }) {
   if (!slow) return null
   return (
     <p className="text-fg-subtle mt-4 text-center text-xs">
-      예상보다 오래 걸립니다. 서버가 깨어나는 중일 수 있습니다 — 조금 더 기다리거나 주소가 맞는지
-      확인해 주세요.
+      응답이 늦어지고 있어요.
+      <br />
+      서버가 잠들어 있다가 깨어나는 중일 수 있으니
+      <br />
+      조금만 더 기다리거나, 주소가 맞는지 확인해 주세요.
     </p>
   )
 }
@@ -75,9 +78,11 @@ export default function Loading({
       <Spinner className="size-6" aria-label={label} />
       {slow && (
         <p className="text-fg-subtle max-w-xs text-center text-xs">
-          예상보다 오래 걸립니다. 서버가 깨어나는 중일 수 있습니다 — 조금 더 기다리거나
+          응답이 늦어지고 있어요.
           <br />
-          주소가 맞는지 확인해 주세요.
+          서버가 잠들어 있다가 깨어나는 중일 수 있으니
+          <br />
+          조금만 더 기다리거나, 주소가 맞는지 확인해 주세요.
         </p>
       )}
     </div>

--- a/src/features/auth/components/BrandPanel.tsx
+++ b/src/features/auth/components/BrandPanel.tsx
@@ -4,7 +4,7 @@ import Wordmark from '@/components/common/Wordmark'
 interface Props {
   /** 마케팅 리드 — 화면마다 다름 */
   title?: ReactNode
-  description?: string
+  description?: ReactNode
   meta?: string
 }
 
@@ -24,7 +24,12 @@ export default function BrandPanel({
       검증합니다
     </>
   ),
-  description = '제출한 코드의 특정 지점을 두고 왜 그렇게 했는지 묻습니다. 그 자리에서 설명할 수 있는지가 이해도입니다.',
+  description = (
+    <>
+      제출한 코드에서 한 지점을 짚어 왜 그렇게 작성했는지 묻습니다.
+      <br />그 자리에서 바로 설명할 수 있는 능력이 이해도입니다.
+    </>
+  ),
   meta = '교육 운영기관 전용 · 초대 기반 계정',
 }: Props) {
   return (

--- a/src/features/operator/admin/roster/components/DeactivateTraineeDialog.tsx
+++ b/src/features/operator/admin/roster/components/DeactivateTraineeDialog.tsx
@@ -104,15 +104,19 @@ export default function DeactivateTraineeDialog({ target, cohortId, onOpenChange
 
         {/* **무엇이 일어나는지 쓴다**(G4) — `정말 하시겠습니까?`는 판단 근거를 안 준다 */}
         <p className="text-fg-muted text-xs">
-          계정이 막혀 더는 로그인할 수 없습니다. 교육생 목록과 소속 반에는 그대로 남고, 이미 응시한
-          기록과 리포트도 남습니다.{' '}
+          비활성화 할 시 교육생은 계정이 막혀 더는 로그인할 수 없습니다.
+          <br />
+          교육생 목록과 소속 반에는 그대로 남고,
+          <br />
+          이미 응시한 기록과 리포트도 남습니다.
+          <br />
           <b className="text-danger font-semibold">다시 활성으로 되돌릴 수 없습니다.</b>
         </p>
 
         <div className="mt-1">
           <label htmlFor="deactivate-reason" className="mb-1 block text-xs font-semibold">
-            사유
-            <RequiredMark />
+            사유(
+            <RequiredMark />)
           </label>
           <Input
             id="deactivate-reason"
@@ -122,7 +126,9 @@ export default function DeactivateTraineeDialog({ target, cohortId, onOpenChange
           />
           {/* 일자는 서버가 찍는다 — 매니저 화면이 `중도 이탈 2026-08-04`로 읽는다 */}
           <p className="text-fg-subtle mt-1 text-2xs">
-            사유와 오늘 날짜가 교육생 목록에 남고, 담당 매니저 화면에도 그대로 보입니다.
+            비활성화 사유와 날짜가 교육생 목록에 남고,
+            <br />
+            담당 매니저가 확인할 수 있습니다.
           </p>
         </div>
 


### PR DESCRIPTION
## 요약

- 응답 지연 시 뜨는 로딩 안내 문구를 자연스럽게 수정 (Loading.tsx)
- 로그인 화면 브랜드 패널의 설명 문구를 세련되게 재작성 (BrandPanel.tsx)
- 교육생 비활성화 다이얼로그의 경고 문구·사유 라벨·안내 텍스트 정리 (DeactivateTraineeDialog.tsx)

## 리뷰 포인트

- BrandPanel.tsx의 `description` prop 타입을 `string` → `ReactNode`로 변경했습니다. 줄바꿈(`<br />`)을 넣기 위함이며, 기존 호출부(InviteScreen.tsx 등 문자열 전달)는 `ReactNode`가 `string`을 포함하므로 그대로 호환됩니다.
- DeactivateTraineeDialog.tsx는 jxxnixx님 소유 파일이라 문구만 바꿨고 로직 변경은 없습니다.
- 기능 변경 없이 텍스트/포맷만 수정한 PR입니다.

## 완료 조건

- [x] 세 화면 모두 브라우저에서 실제 렌더링 확인
- [x] 기존 기능(로딩 표시, 비활성화 처리)에 문제 없음 확인

closes #246