### PR TITLE
[Remove] Org Email Domain Restriction and Mock Invite Links

### DIFF
--- a/scripts/check-admin-rules.mts
+++ b/scripts/check-admin-rules.mts
@@ -4,11 +4,12 @@
  * 화면 렌더는 검사하지 않는다. 여기 있는 것은 **입력을 넣으면 답이 정해지는 규칙**뿐이다
  * (검사 방식은 check-project-rules.mts와 같다 — 러너를 따로 들이지 않는다).
  *
- * 이 넷이 깨지면 조용히 틀린다:
+ * 이 셋이 깨지면 조용히 틀린다:
  *   · CSV 파싱   한 줄 때문에 전체가 막히거나, 오류 행 번호가 어긋난다
- *   · 도메인     기관 밖 주소가 등록되고 초대가 나간다
  *   · 정원       `22 → 24 / 25` 미리보기가 실제와 다르다
  *   · 최근 접속  `오늘`이 어제 것을 가리킨다
+ *
+ * 기관 도메인 제한은 8/18로 없앴다(백엔드도 동일하게 열었다) — 이메일은 형식만 본다.
  */
 import assert from 'node:assert'
 import { MAX_UPLOAD_BYTES, MAX_UPLOAD_LABEL } from '../src/api/uploadLimits.ts'
@@ -27,16 +28,12 @@ import {
   toIsoDate,
 } from '../src/features/operator/admin/_/rules.ts'
 
-const DOMAIN = 'green.com'
-
 // ── 이메일 ──────────────────────────────────────────────────
-// 두 실패를 갈라야 한다 — 형식은 그 줄을, 도메인은 주소 자체를 고쳐야 한다
-assert.strictEqual(checkEmail('dohyun@green.com', DOMAIN), null)
-assert.strictEqual(checkEmail('DoHyun@GREEN.COM', DOMAIN), null, '대소문자를 가리지 않는다')
-assert.strictEqual(checkEmail('이름만', DOMAIN), 'INVALID_FORMAT')
-assert.strictEqual(checkEmail('someone@gmail.com', DOMAIN), 'DOMAIN_NOT_ALLOWED')
-// 도메인이 뒤에 붙기만 하면 되는 게 아니다 — `@`까지 맞아야 한다
-assert.strictEqual(checkEmail('a@evilgreen.com', DOMAIN), 'DOMAIN_NOT_ALLOWED')
+// 형식만 본다 — 기관 도메인 제한은 없다
+assert.strictEqual(checkEmail('dohyun@green.com'), null)
+assert.strictEqual(checkEmail('DoHyun@GREEN.COM'), null, '대소문자를 가리지 않는다')
+assert.strictEqual(checkEmail('이름만'), 'INVALID_FORMAT')
+assert.strictEqual(checkEmail('someone@gmail.com'), null, '도메인 제한 없음 — 형식만 맞으면 통과')
 
 // ── CSV ────────────────────────────────────────────────────
 {
@@ -46,23 +43,22 @@ assert.strictEqual(checkEmail('a@evilgreen.com', DOMAIN), 'DOMAIN_NOT_ALLOWED')
     '정하늘,haneul@green.com',
     '', // 빈 줄은 오류가 아니다 — 파일 끝 개행이 늘 붙는다
     '오류행,not-an-email',
-    '외부인,someone@gmail.com',
+    '외부인,someone@gmail.com', // 도메인 제한 없음 — 형식만 맞으면 유효 행이다
     '중복,dohyun@green.com',
   ].join('\n')
 
-  const { entries, invalid } = parseRosterCsv(csv, DOMAIN)
+  const { entries, invalid } = parseRosterCsv(csv)
 
   // **한 줄 때문에 전체를 막지 않는다** — 유효 행은 그대로 등록 후보다
-  assert.strictEqual(entries.length, 2, '유효 행만 남는다')
+  assert.strictEqual(entries.length, 3, '유효 행만 남는다')
   assert.deepStrictEqual(
     entries.map((e) => e.name),
-    ['한도현', '정하늘'],
+    ['한도현', '정하늘', '외부인'],
   )
 
   // **행 번호는 파일의 줄 번호다** — 편집기에서 그 줄을 찾을 수 있어야 한다
   assert.deepStrictEqual(invalid, [
     { line: 5, reason: 'INVALID_FORMAT' },
-    { line: 6, reason: 'DOMAIN_NOT_ALLOWED' },
     { line: 7, reason: 'DUPLICATE_IN_FILE' },
   ])
 }
@@ -82,7 +78,6 @@ assert.strictEqual(checkEmail('a@evilgreen.com', DOMAIN), 'DOMAIN_NOT_ALLOWED')
   */
   const { entries, invalid } = parseRosterCsv(
     '번호,이메일,소속,이름\n1,dohyun@green.com,백엔드,한도현',
-    DOMAIN,
   )
   assert.deepStrictEqual(
     entries,
@@ -94,34 +89,34 @@ assert.strictEqual(checkEmail('a@evilgreen.com', DOMAIN), 'DOMAIN_NOT_ALLOWED')
 
 {
   // 엑셀이 쉼표 뒤에 공백을 남기는 파일이 흔하다 — 머리글 칸도 trim 한다
-  const { entries, invalid } = parseRosterCsv('이름, 이메일\n한도현, dohyun@green.com', DOMAIN)
+  const { entries, invalid } = parseRosterCsv('이름, 이메일\n한도현, dohyun@green.com')
   assert.deepStrictEqual(entries, [{ name: '한도현', email: 'dohyun@green.com' }], '머리글 공백')
   assert.deepStrictEqual(invalid, [])
 }
 
 {
   // 두 열 중 하나라도 없으면 그 파일로는 아무것도 못 한다 — 서버도 400이다
-  const { entries, invalid } = parseRosterCsv('이메일\ndohyun@green.com', DOMAIN)
+  const { entries, invalid } = parseRosterCsv('이메일\ndohyun@green.com')
   assert.strictEqual(entries.length, 0, '이름 열이 없으면 파일 오류')
   assert.deepStrictEqual(invalid, [{ line: 1, reason: 'HEADER_NOT_FOUND' }])
 }
 
 {
   // 머리글이 없으면 **파일을 못 읽는다** — 행 오류가 아니라 파일 오류다
-  const { entries, invalid } = parseRosterCsv('한도현,dohyun@green.com', DOMAIN)
+  const { entries, invalid } = parseRosterCsv('한도현,dohyun@green.com')
   assert.strictEqual(entries.length, 0)
   assert.deepStrictEqual(invalid, [{ line: 1, reason: 'HEADER_NOT_FOUND' }])
 }
 
 {
   // BOM 은 첫 열 이름을 가린다 — 떼고 읽는다(서버도 BOM 파일은 받는다)
-  const { entries } = parseRosterCsv('\uFEFF이름,이메일\n한도현,dohyun@green.com', DOMAIN)
+  const { entries } = parseRosterCsv('\uFEFF이름,이메일\n한도현,dohyun@green.com')
   assert.deepStrictEqual(entries, [{ name: '한도현', email: 'dohyun@green.com' }], 'BOM')
 }
 
 {
   // 따옴표 안의 쉼표를 안 자른다 — 엑셀이 이름에 쉼표를 넣으면 그렇게 내보낸다
-  const { entries } = parseRosterCsv('이름,이메일\n"한, 도현",dohyun@green.com', DOMAIN)
+  const { entries } = parseRosterCsv('이름,이메일\n"한, 도현",dohyun@green.com')
   assert.deepStrictEqual(
     entries,
     [{ name: '한, 도현', email: 'dohyun@green.com' }],
@@ -138,17 +133,14 @@ assert.strictEqual(checkEmail('a@evilgreen.com', DOMAIN), 'DOMAIN_NOT_ALLOWED')
     (`400 TRAINEE_NAME_INVALID · "5행의 이름을 입력해야 합니다"` — 실측).
     화면만 관대하면 `✓ 유효 2명`이라 해 놓고 아무도 안 들어간다.
   */
-  const { entries, invalid } = parseRosterCsv(
-    '이름,이메일\n한도현,a@green.com\n,dohyun@green.com',
-    DOMAIN,
-  )
+  const { entries, invalid } = parseRosterCsv('이름,이메일\n한도현,a@green.com\n,dohyun@green.com')
   assert.strictEqual(entries.length, 1, '이름 있는 행만 유효')
   assert.deepStrictEqual(invalid, [{ line: 3, reason: 'NAME_REQUIRED' }])
 }
 
 {
   // 따옴표로 감싼 값도 읽는다(엑셀이 그렇게 내보낸다)
-  const { entries } = parseRosterCsv('"이름","이메일"\n"한도현","dohyun@green.com"', DOMAIN)
+  const { entries } = parseRosterCsv('"이름","이메일"\n"한도현","dohyun@green.com"')
   assert.deepStrictEqual(entries, [{ name: '한도현', email: 'dohyun@green.com' }])
 }
 
@@ -156,31 +148,25 @@ assert.strictEqual(checkEmail('a@evilgreen.com', DOMAIN), 'DOMAIN_NOT_ALLOWED')
 // **줄 번호가 입력칸 번호와 같아야 한다.** 빈 행을 걸러낸 뒤의 인덱스를 쓰면
 // 1행을 비우고 2행을 틀렸을 때 `1번째 줄 오류`라고 말한다 — 그 칸은 멀쩡한 빈 칸이다
 assert.deepStrictEqual(
-  checkRosterRows(
-    [
-      { name: '', email: '' },
-      { name: '박', email: '나쁜주소' },
-    ],
-    DOMAIN,
-  ),
+  checkRosterRows([
+    { name: '', email: '' },
+    { name: '박', email: '나쁜주소' },
+  ]),
   [{ line: 2, reason: 'INVALID_FORMAT' }],
 )
 
 // 입력칸 사이 중복 — 안 잡으면 `유효 2명`이라 해 놓고 서버가 1명만 등록한다
 assert.deepStrictEqual(
-  checkRosterRows(
-    [
-      { name: 'a', email: 'x@green.com' },
-      { name: 'b', email: 'X@GREEN.COM' },
-    ],
-    DOMAIN,
-  ),
+  checkRosterRows([
+    { name: 'a', email: 'x@green.com' },
+    { name: 'b', email: 'X@GREEN.COM' },
+  ]),
   [{ line: 2, reason: 'DUPLICATE_IN_FILE' }],
   '대소문자를 가리지 않는다',
 )
 
 // 안 친 칸은 오류가 아니다 — 마지막 빈 줄은 늘 있다
-assert.deepStrictEqual(checkRosterRows([{ name: '', email: '  ' }], DOMAIN), [])
+assert.deepStrictEqual(checkRosterRows([{ name: '', email: '  ' }]), [])
 
 // ── 반 편집 잠금(D30-②) ────────────────────────────────────
 // **개강일 하루 전까지만** 열린다. 시작일 당일은 이미 시작한 것이라 잠긴다

--- a/src/features/auth/LoginScreen.tsx
+++ b/src/features/auth/LoginScreen.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
-import { useNavigate, Navigate, Link } from 'react-router'
+import { useNavigate, Navigate } from 'react-router'
 import { EyeIcon, EyeOffIcon } from 'lucide-react'
 import { initialScreenFor } from './authStore'
 import { useSession, useSignIn } from './useSession'
@@ -267,31 +267,19 @@ export default function LoginScreen() {
             </div>
           </form>
 
-          {/* 폼의 일부로 읽히게 붙여 둔다 — 아래 dev 블록과 같은 무게로 보이면 안 된다 */}
+          {/* 폼의 일부로 읽히게 붙여 둔다 — 위 dev 블록(발표용 바로 입장)과 같은 무게로 보이면 안 된다 */}
           <div className="mt-5 text-center">
             <TextLink to="/shared/password-reset">비밀번호를 잊으셨나요?</TextLink>
           </div>
 
           {/*
-            **dev 안내를 지웠다.** 실서버 연동 여부·차단 정책·재설정 토큰 같은 설명이
-            넉 줄 쌓여 있었는데, 그 내용은 화면이 실제로 알려 주거나(차단되면 서버가 남은
-            시간을 말한다) 이미 다른 곳에 적혀 있다. 두 곳에 적으면 한쪽이 반드시 낡는다.
-
-            남긴 것은 **아직 목으로 도는 초대 흐름** 링크 둘뿐이다 — 그건 눌러 봐야만
-            갈 수 있고 다른 진입 경로가 없다.
+            **한때 여기 아래에 목으로 도는 초대 흐름 링크(매니저 가입·교육생 활성화)와
+            dev 안내 넉 줄이 더 있었다.** 안내 문구는 화면이 실제로 알려 주거나 이미
+            다른 곳에 적혀 있어 먼저 지웠고(두 곳에 적으면 한쪽이 반드시 낡는다), 남겨
+            뒀던 목 링크 둘도 8/19 실제 초대 메일로 두 흐름 다 엔드투엔드 검증
+            완료(가입·활성화·로그인까지 확인)했으므로 마저 지웠다 — 이제 진입 경로는
+            실제 초대 메일뿐이고, 그게 맞는 경로다.
           */}
-          {SHOW_DEV_UI && (
-            <div className="mt-8 flex items-center justify-center gap-2 border-t border-border pt-4 text-[11px] text-fg-subtle">
-              <span>초대 링크(목)</span>
-              <Link to="/invite/mgr-8f3a" className="text-primary hover:underline">
-                매니저 가입
-              </Link>
-              <span aria-hidden="true">·</span>
-              <Link to="/invite/stu-4c19" className="text-primary hover:underline">
-                교육생 활성화
-              </Link>
-            </div>
-          )}
         </AuthForm>
       </div>
     </div>

--- a/src/features/operator/admin/_/api/types.ts
+++ b/src/features/operator/admin/_/api/types.ts
@@ -55,9 +55,9 @@ export type CurriculumStatus = NonNullable<findOrganizationCurricula_Item['analy
 
 // ── CSV 판정 ── **서버 계약이 아니다** ─────────────────────────
 /*
-  명단을 보내기 전에 화면이 그 자리에서 거른다(`rules.ts`). 형식·기관 도메인·파일 안
-  중복은 서버를 안 거쳐도 알 수 있고, 등록을 누른 뒤에 알려주면 수백 명짜리 파일을
-  다시 만들게 된다.
+  명단을 보내기 전에 화면이 그 자리에서 거른다(`rules.ts`). 형식·파일 안 중복은 서버를
+  안 거쳐도 알 수 있고, 등록을 누른 뒤에 알려주면 수백 명짜리 파일을 다시 만들게 된다.
+  (기관 도메인 제한은 8/18에 없앴다 — 매니저 초대와 같은 결정.)
 
   *이미 등록된 이메일*은 여기 없다 — 명단 전량을 받아야 셀 수 있어 서버가 판정하고
   (드라이런 · 9차 Q3-③) 그 결과는 `Failure.status`로 온다.
@@ -77,7 +77,6 @@ export type RosterIssue = {
 
 export type RosterIssueReason =
   | 'INVALID_FORMAT'
-  | 'DOMAIN_NOT_ALLOWED'
   | 'DUPLICATE_IN_FILE'
   /** 이름 칸이 비었다 — **서버가 파일 전체를 거절한다**(`TRAINEE_NAME_INVALID`) */
   | 'NAME_REQUIRED'

--- a/src/features/operator/admin/_/components/RosterCsvField.tsx
+++ b/src/features/operator/admin/_/components/RosterCsvField.tsx
@@ -6,7 +6,7 @@ import { parseRosterCsv, type ParsedRoster } from '../rules'
 /*
   명단 CSV 고르기 — **열은 둘, 이름과 이메일**(목업 `#roster-add`).
 
-  파일을 고르는 즉시 **그 자리에서 판정한다.** 형식·도메인·파일 안 중복은 서버를 안 거쳐도
+  파일을 고르는 즉시 **그 자리에서 판정한다.** 형식·파일 안 중복은 서버를 안 거쳐도
   알 수 있고, 등록을 누른 뒤에 알려주면 수백 명짜리 파일을 다시 만들게 된다.
   서버만 아는 것(`이미 등록된 이메일`)은 부르는 쪽이 따로 물어본다.
 
@@ -27,9 +27,10 @@ type Props = {
 }
 
 /**
- * 내려받는 양식. **도메인은 그 기관 것을 쓴다** — `example.com`을 예시로 두면 그대로
- * 채워 올리고 「기관 도메인 밖 주소」로 전부 튕긴다. 이름 칸은 **비우면 서버가 파일
- * 전체를 거절**하므로(`TRAINEE_NAME_INVALID`) 예시 줄이 그것을 보여 준다.
+ * 내려받는 양식. **도메인은 그 기관 것을 쓴다** — 실제로 등록할 주소와 같은 모양을
+ * 보여주려는 것뿐이고, 다른 도메인을 채워 넣어도 더는 걸리지 않는다(8/18 결정). 이름
+ * 칸은 **비우면 서버가 파일 전체를 거절**하므로(`TRAINEE_NAME_INVALID`) 예시 줄이
+ * 그것을 보여 준다.
  */
 const template = (domain: string) => `이름,이메일\n홍길동,gildong@${domain || 'example.com'}\n`
 
@@ -88,7 +89,7 @@ export default function RosterCsvField({ domain, onChange }: Props) {
       return
     }
     setFileName(file.name)
-    onChange(parseRosterCsv(text, domain), file.name, file)
+    onChange(parseRosterCsv(text), file.name, file)
   }
 
   return (

--- a/src/features/operator/admin/_/components/RosterIssueList.tsx
+++ b/src/features/operator/admin/_/components/RosterIssueList.tsx
@@ -7,8 +7,8 @@ import type { RosterIssue } from '../api/types'
   이유별로 묶는다. `3행 · 17행 · 42행`처럼 번호만 늘어놓으면 무엇이 잘못됐는지 모르고,
   줄마다 한 문장씩 쓰면 오류 30건짜리 파일에서 모달이 스크롤로 가득 찬다.
 
-  **이유마다 고칠 곳이 다르다** — 형식은 그 줄을, 도메인은 주소 자체를, 파일 안 중복은
-  둘 중 하나를 지워야 한다(labels.ts).
+  **이유마다 고칠 곳이 다르다** — 형식은 그 줄을, 파일 안 중복은 둘 중 하나를 지워야
+  한다(labels.ts).
 */
 export default function RosterIssueList({ issues }: { issues: RosterIssue[] }) {
   if (issues.length === 0) return null

--- a/src/features/operator/admin/_/labels.ts
+++ b/src/features/operator/admin/_/labels.ts
@@ -69,12 +69,11 @@ export const CURRICULUM_STATUS_LABEL: Record<CurriculumStatus, string> = {
 /**
  * 명단 오류 행 문구.
  *
- * **이유마다 고칠 곳이 다르다.** 형식은 그 줄을, 도메인은 주소 자체를, 파일 안 중복은
- * 둘 중 하나를 지워야 한다 — 하나로 합치면 화면이 무엇을 하라고 할지 정할 수 없다.
+ * **이유마다 고칠 곳이 다르다.** 형식은 그 줄을, 파일 안 중복은 둘 중 하나를 지워야
+ * 한다 — 하나로 합치면 화면이 무엇을 하라고 할지 정할 수 없다.
  */
 export const ROSTER_ISSUE_LABEL: Record<RosterIssueReason, string> = {
   INVALID_FORMAT: '이메일 형식 오류',
-  DOMAIN_NOT_ALLOWED: '기관 도메인 밖 주소',
   /*
     **`파일 안에서 중복`이 아니다.** 같은 판정을 직접 입력에서도 쓰는데 거기엔 파일이
     없어서, 두 줄에 같은 주소를 치면 `파일 안에서 중복`이라는 말이 나왔다 —

--- a/src/features/operator/admin/_/rules.ts
+++ b/src/features/operator/admin/_/rules.ts
@@ -100,22 +100,17 @@ export function assignPolicy(
 
 // ── 이메일 ──────────────────────────────────────────────────
 /*
-  기관 도메인 밖 주소는 등록되지 않는다(OP-06 §3 · 케이스 `DOMAIN_NOT_ALLOWED`).
+  **기관 도메인 제한은 없앴다(8/18 결정, 매니저 초대와 같은 판단).** 예전엔 기관 도메인
+  밖 주소가 등록되지 않았다(OP-06 §3 · 케이스 `DOMAIN_NOT_ALLOWED`) — 그 판정을 지웠다.
 
   형식 검사는 **최소한만** 한다. RFC를 흉내 낸 정규식은 실제로 유효한 주소를 떨어뜨리고,
   진짜 판정은 초대 메일이 도착하는지로 갈린다 — 여기서 막을 것은 `이름만 적힌 칸`처럼
   명백히 주소가 아닌 것이다.
 */
 
-/** 기관 도메인 주소인가. 대소문자를 가리지 않는다 — 사용자는 섞어 친다 */
-export function isOrgEmail(value: string, domain: string): boolean {
-  return value.toLowerCase().endsWith(`@${domain.toLowerCase()}`)
-}
-
 /** 화면이 쓰는 판정 하나 — 이 주소를 등록할 수 있나. 못 하면 이유가 곧 문구가 된다 */
-export function checkEmail(value: string, domain: string): RosterIssueReason | null {
+export function checkEmail(value: string): RosterIssueReason | null {
   if (!isEmailShape(value)) return 'INVALID_FORMAT'
-  if (!isOrgEmail(value, domain)) return 'DOMAIN_NOT_ALLOWED'
   return null
 }
 
@@ -206,7 +201,7 @@ export function splitCsvLine(line: string): string[] {
  *
  * 서버 검증을 대신하지 않는다 — 같은 규칙이 서버에도 있어야 한다(우회 가능).
  */
-export function parseRosterCsv(text: string, domain: string): ParsedRoster {
+export function parseRosterCsv(text: string): ParsedRoster {
   const entries: RosterEntry[] = []
   const invalid: RosterIssue[] = []
   const seen = new Set<string>()
@@ -241,7 +236,7 @@ export function parseRosterCsv(text: string, domain: string): ParsedRoster {
     const email = (cells[cols.email] ?? '').trim()
     if (!name && !email) continue // 다른 열만 채워진 줄은 우리 것이 아니다
 
-    const reason = checkEmail(email, domain)
+    const reason = checkEmail(email)
     if (reason) {
       invalid.push({ line, reason })
       continue
@@ -280,7 +275,7 @@ export function parseRosterCsv(text: string, domain: string): ParsedRoster {
  *
  * @param rows 빈 행을 **포함한** 입력칸 전체. 번호가 칸과 맞아야 해서 거르지 않고 받는다
  */
-export function checkRosterRows(rows: RosterEntry[], domain: string): RosterIssue[] {
+export function checkRosterRows(rows: RosterEntry[]): RosterIssue[] {
   const issues: RosterIssue[] = []
   const seen = new Set<string>()
 
@@ -291,7 +286,7 @@ export function checkRosterRows(rows: RosterEntry[], domain: string): RosterIssu
     // CSV와 같은 판정 — 이름 없이 보내면 서버가 거절한다
     if (!row.name.trim()) return issues.push({ line: i + 1, reason: 'NAME_REQUIRED' })
 
-    const reason = checkEmail(email, domain)
+    const reason = checkEmail(email)
     if (reason) return issues.push({ line: i + 1, reason })
 
     const key = email.toLowerCase()

--- a/src/features/operator/admin/managers/components/InviteManagerDialog.tsx
+++ b/src/features/operator/admin/managers/components/InviteManagerDialog.tsx
@@ -14,7 +14,6 @@ import { Spinner } from '@/components/ui/Spinner'
 import { isApiError } from '@/api/_contract'
 import { useInviteManager } from '@/api/member/useMemberMutations'
 import { useGetCurrentMember } from '@/api/member/useMemberQueries'
-import { checkEmail } from '../../_/rules'
 import { useCohortScope } from '../../_/cohortScope'
 import RequiredMark from '../../_/components/RequiredMark'
 
@@ -27,8 +26,9 @@ import RequiredMark from '../../_/components/RequiredMark'
   담당 반은 **선택**이다 — 사람을 먼저 뽑고 반을 나중에 정하는 순서가 실제로 있다.
   비워 두면 목록에 `미배정`으로 남고, 반 쪽에는 `담당 필요` 경고가 그대로 있다.
 
-  **도메인 밖 주소는 `저장 실패`가 아니라 다른 문구로 답한다** — 재시도해도 안 되는
-  일이라 "다시 시도"를 권하면 거짓말이 된다(케이스 표 `DOMAIN_NOT_ALLOWED`).
+  **기관 도메인 제한은 없앴다(8/18 결정).** 교육생 명단과 달리 매니저는 재직 여부를
+  도메인으로 가늠할 필요가 없다고 판단 — 어떤 주소든 초대할 수 있다. 서버가 그래도
+  `DOMAIN_NOT_ALLOWED`를 돌려줄 가능성에 대비해 그 케이스의 에러 문구 분기만 남겨 둔다.
 */
 type Props = {
   open: boolean
@@ -39,24 +39,11 @@ export default function InviteManagerDialog({ open, onOpenChange }: Props) {
   const [email, setEmail] = useState('')
   const [error, setError] = useState<string | null>(null)
 
-  /*
-    **기관 도메인은 세션이 준다**(9차 Q3-④로 `/members/me`에 `emailDomain`이 들어왔다).
-    전에는 `getOrg()`를 따로 불렀는데, 오퍼레이터는 `GET /organizations/{id}`가 403이라
-    그 길이 애초에 없었다 — 프론트 상수로 두면 기관이 둘이 되는 순간 틀린다.
-
-    **`null`일 수 있다**(기관에 도메인을 안 정한 경우) — 그때는 도메인 제한을 걸지 않는다.
-  */
   const { data: me } = useGetCurrentMember()
   const scope = useCohortScope()
   const invite = useInviteManager()
 
   const organizationId = me?.organizationId
-  const domain = me?.emailDomain ?? undefined
-  /** `@`를 치기 전에는 판정하지 않는다 — 다 치기 전에 붉어지면 타이핑을 방해한다 */
-  const domainProblem =
-    domain !== undefined &&
-    email.includes('@') &&
-    checkEmail(email.trim(), domain) === 'DOMAIN_NOT_ALLOWED'
 
   /*
     **닫으면 비운다.** 성공했을 때만 비우고 있어서, 주소를 치다 취소하고 다시 열면
@@ -88,7 +75,7 @@ export default function InviteManagerDialog({ open, onOpenChange }: Props) {
       const code = isApiError(e) ? e.code : undefined
       setError(
         code === 'DOMAIN_NOT_ALLOWED'
-          ? `${domain ?? '기관'} 주소로만 초대할 수 있습니다.`
+          ? '이 주소로는 초대할 수 없습니다.'
           : code === 'ALREADY_INVITED'
             ? '이미 초대한 주소입니다. 목록에서 재발송할 수 있습니다.'
             : '초대를 보내지 못했습니다. 이미 등록된 주소인지 확인해 주세요.',
@@ -124,15 +111,10 @@ export default function InviteManagerDialog({ open, onOpenChange }: Props) {
               type="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              placeholder={domain ? `name@${domain}` : ''}
-              aria-invalid={domainProblem || undefined}
+              placeholder="name@company.com"
             />
             <FieldDescription>
-              {domainProblem ? (
-                <span className="text-danger">{domain} 주소만 초대할 수 있습니다.</span>
-              ) : (
-                '이 주소로 초대가 나가고, 받는 사람은 이름과 비밀번호만 정하면 됩니다.'
-              )}
+              이 주소로 초대가 나가고, 받는 사람은 이름과 비밀번호만 정하면 됩니다.
             </FieldDescription>
           </Field>
 
@@ -158,9 +140,7 @@ export default function InviteManagerDialog({ open, onOpenChange }: Props) {
             취소
           </Button>
           <Button
-            disabled={
-              invite.isPending || email.trim().length === 0 || domainProblem || !organizationId
-            }
+            disabled={invite.isPending || email.trim().length === 0 || !organizationId}
             onClick={() => void submit()}
           >
             {invite.isPending && <Spinner className="size-3.5" />}

--- a/src/features/operator/admin/roster/components/AddRosterDialog.tsx
+++ b/src/features/operator/admin/roster/components/AddRosterDialog.tsx
@@ -78,7 +78,10 @@ export default function AddRosterDialog({ open, onOpenChange, onAdded }: Props) 
   /** 진행 중인 CSV 등록 요청 — 닫으면서 취소할 수 있게 들고 있는다 */
   const submitAbortRef = useRef<AbortController | null>(null)
 
-  /** 기관 도메인은 세션이 준다(9차 Q3-④) — `null`이면 도메인 제한을 걸지 않는다 */
+  /*
+    기관 도메인은 세션이 준다(9차 Q3-④) — 등록 판정에는 더 안 쓴다(8/18, 도메인 제한
+    없앰). CSV 양식·직접 입력 placeholder의 **예시**로만 남긴다.
+  */
   const { data: me } = useGetCurrentMember()
   const domain = me?.emailDomain ?? undefined
   const scope = useCohortScope()
@@ -91,7 +94,7 @@ export default function AddRosterDialog({ open, onOpenChange, onAdded }: Props) 
     여기서 한 줄씩 `checkEmail`을 돌렸을 때 CSV가 잡는 것 둘을 놓쳤다: 빈 행이 앞에
     있으면 줄 번호가 밀렸고, 입력칸 사이 중복을 아예 안 봤다.
   */
-  const typedIssues: RosterIssue[] = domain ? checkRosterRows(rows, domain) : []
+  const typedIssues: RosterIssue[] = checkRosterRows(rows)
   /** 걸리지 않은 행만 등록 후보다. 번호가 칸과 맞으므로 그 번호로 걸러낸다 */
   const typedValid = rows.filter(
     (r, i) => r.email.trim().length > 0 && !typedIssues.some((x) => x.line === i + 1),
@@ -258,7 +261,7 @@ export default function AddRosterDialog({ open, onOpenChange, onAdded }: Props) 
 
             <TabsContent value="csv" className="pt-3">
               {/*
-                **파일 자체를 들고 있는다.** 화면이 그 자리에서 형식·도메인을 판정하고
+                **파일 자체를 들고 있는다.** 화면이 그 자리에서 형식을 판정하고
                 (`parseRosterCsv`), 서버에는 **원본 파일을 그대로** 보낸다 — 파싱한 결과를
                 다시 CSV로 만들어 보내면 판정 규칙이 두 벌이 된다.
               */}
@@ -281,8 +284,7 @@ export default function AddRosterDialog({ open, onOpenChange, onAdded }: Props) 
                 }}
               />
               <p className="text-fg-subtle mt-2 text-2xs">
-                수십~수백 명을 한 번에 넣을 때 씁니다. 기관 도메인 밖 주소는 등록되지 않습니다. 반
-                배정은 등록한 뒤 배정 모드에서 합니다.
+                수십~수백 명을 한 번에 넣을 때 씁니다. 반 배정은 등록한 뒤 배정 모드에서 합니다.
               </p>
             </TabsContent>
 


### PR DESCRIPTION
## 요약

- 백엔드에서 매니저 초대·교육생 등록의 기관 이메일 도메인 제한을 없애기로 해, 프론트엔드의 대응 검증 로직을 전부 제거했습니다.
- 실제 초대 이메일로 매니저 가입·교육생 활성화 플로우를 끝까지 검증 완료한 뒤, 로그인 화면에 있던 개발용 목(mock) 초대 링크를 제거했습니다.

## 작업 내용

- InviteManagerDialog.tsx: 도메인 검사(`checkEmail`) 및 관련 UI(placeholder, 에러 문구, 버튼 비활성 조건) 제거
- rules.ts: `isOrgEmail` 삭제, `checkEmail`/`parseRosterCsv`/`checkRosterRows`에서 `domain` 파라미터 제거
- api/types.ts: `RosterIssueReason`에서 `DOMAIN_NOT_ALLOWED` 제거 (서버 계약이 아닌 순수 클라이언트 사전 체크용 타입이라 안전하게 삭제)
- labels.ts: `DOMAIN_NOT_ALLOWED` 라벨 제거
- RosterCsvField.tsx / RosterIssueList.tsx: 관련 주석 정리, CSV 템플릿의 `domain`은 표시용 힌트로만 유지
- AddRosterDialog.tsx: `checkRosterRows` 호출에서 domain 인자 제거, 안내 문구에서 도메인 제한 문구 삭제
- LoginScreen.tsx: 매니저 가입 / 교육생 활성화 목 초대 링크 블록 제거 (실제 이메일 초대 플로우 검증 완료로 더 이상 불필요)

## 리뷰 포인트

- InviteManagerDialog.tsx, rules.ts, api/types.ts, labels.ts, RosterCsvField.tsx, RosterIssueList.tsx, AddRosterDialog.tsx는 jxxnixx님 소유 파일입니다.
- 도메인 제한 제거는 백엔드 정책 변경(도메인 무관 초대 허용)에 맞춘 대응이며, 관련 확인은 진용님이 직접 실제 백엔드 담당자와 확인했습니다.
- 목 초대 링크는 실제 이메일로 매니저 가입 / 교육생 활성화(동의 항목, 만료 처리 포함) 끝까지 수동 테스트해 정상 동작을 확인한 뒤 제거했습니다.

## 완료 조건

- [x] 매니저 초대: 도메인 무관 이메일로 초대 → 실제 메일 수신 → 가입 → 로그인 → 매니저 대시보드 진입 확인
- [x] 교육생 초대: 실제 메일 수신 → 활성화 화면 전체 플로우(동의 항목 5개 포함) → 로그인까지 확인
- [x] 로그인 화면에서 목 링크가 더 이상 노출되지 않음 확인

closes #247