### PR TITLE
[Fix] Harden AU-02 Signup/Activation and AU-03 Password Reset Screens

### DIFF
--- a/docs/dev/screens/au-02-situations.md
+++ b/docs/dev/screens/au-02-situations.md
@@ -86,11 +86,114 @@ AU-01에서 고친 `onFocus` 배선(E3 — 재포커스 시 미탐지)이 `passw
 
 ---
 
-## 미검증으로 남긴 것 (2단계·5단계 — 로컬 Claude Code CLI + Playwright 필요)
+## 2단계·5단계로 확정된 것
 
-- curl 실측: 4개 에러 코드(`INVITATION_EXPIRED`·`INVITATION_ALREADY_ACCEPTED`·`INVITATION_INVALID`·
-  `INVITATION_NOT_IN_ROSTER`) 전부 실서버 응답과 일치하는지.
-- 실제 렌더: 변형 A/B 각각 정상 흐름 · 재수강생(A3) 흐름 · C3 수정이 실제 클릭으로도 알림을
-  유지하는지 · G3(검증 중 타이틀 깜빡임)이 실제로 보이는지.
-- Caps Lock 실제 키보드 재현 — 비밀번호·비밀번호 확인 두 필드 모두.
-- 한글 IME 조합 — 이름 필드(변형 A만 있음, AU-01 로그인 필드와 별개로 재확인 필요).
+아래는 원래 "미검증으로 남긴 것"에 있던 항목 중 이번에 curl·Playwright로 실제 확인한 것 —
+자세한 절차·응답 원문은 뒤의 "2단계 실측"·"5단계 플로우를 탄다" 절 표에 있다.
+
+**curl로 실서버 확인:**
+
+- `INVITATION_INVALID`(A4·B4) — 위조 토큰으로 `resolve`·`manager-signup`·`trainee-activation`
+  세 엔드포인트 전부 400 `INVITATION_INVALID` 응답 확인
+- 계정 열거 방지(`resend`, C1) — 존재/미존재 이메일 모두 202 + 완전히 동일한 메시지 확인
+- 네트워크 도달 실패(A7·B7) — DNS 실패로 `ApiError.isNetwork` 경로가 실제로 트리거되는 것을
+  transport 레벨에서 확인
+
+**Playwright로 렌더 확인(응답 가로채기 + 실제 클릭, 18건 전수):**
+
+- 변형 A(매니저)·변형 B(교육생) 정상 흐름 — 필드 구성·동의 개수·제출 후 `/shared/login` 이동까지
+  실제 클릭으로 렌더 확인
+- E3 필수 동의 미체크 시 제출 버튼 비활성 — 렌더 확인
+- `#expired`(A2)·`#already`(A3)·`#invalid`(A4)·`#notlisted`(A5) 네 상태 카드 — **화면이 이 코드를
+  받았을 때 올바르게 렌더하는지**는 전부 확인(A3·A5는 서버가 실제로 이 코드를 주는지 자체는 아직
+  미검증 — 아래 참고)
+- B2(제출 단계 만료) — 인라인 알림 + 재발송 링크 노출 확인
+- **C3 재검증** — 재발송이 500으로 실패해도 링크가 안 사라지는 것(회귀 없음) 실제 클릭으로 확인
+- **G3** — 교육생 링크에서 검증 중 매니저 문구가 실제로 잠깐 보이는 것을 렌더로 확인(비치명 결론까지 포함)
+- 한글 IME 조합(이름 필드) — CDP composition으로 조합 안 깨짐 확인
+- Caps Lock `onFocus` 배선 — 크래시 없이 필드 간 포커스 전환 확인(물리 키 토글 자체는 여전히 미검증)
+
+---
+
+## 2단계 · 실측 (curl, 2026-08-18)
+
+실서버(`https://xvdanr6m362b2ge232vdmfbrny0kwakz.lambda-url.ap-northeast-1.on.aws`, Lambda 프록시 —
+`docs/dev/handoff.md` 8/16 기록·AU-01 실측과 동일 주소) 직접 호출. `.env.local`은 비워 둔 채(dev
+서버의 `vite.config.ts` 프록시가 같은 주소로 중계) — curl은 이 주소로 바로 쳤다.
+
+| 요청 | 결과 |
+|---|---|
+| `POST /auth/invitations/resolve` 위조 토큰 | 400 `INVITATION_INVALID`(A4 코드 실서버 확인) |
+| `POST /auth/invitations/resolve` 빈 토큰 | 400 `VALIDATION_FAILED`(스펙 밖 코드 — 아래 참고) |
+| `POST /auth/manager-signup` 위조 토큰 | 400 `INVITATION_INVALID` |
+| `POST /auth/trainee-activation` 위조 토큰 | 400 `INVITATION_INVALID` |
+| `POST /auth/invitations/resend` 존재하는 dev 계정 이메일 | 202, "입력하신 주소로 초대를 보낸 기록이 있으면…" |
+| `POST /auth/invitations/resend` 존재하지 않는 이메일 | 202, **동일한 메시지**(계정 열거 방지 실측 확인) |
+| `POST /auth/invitations/resend` 형식 오류 이메일 | 400 `VALIDATION_FAILED` |
+| 위 네 엔드포인트 전부 DNS 실패(존재하지 않는 호스트) | `curl exit 6`(connect 실패) — `ApiError.isNetwork` 경로가 실제로 트리거됨을 transport 레벨에서 확인 |
+
+- **`INVITATION_EXPIRED`·`INVITATION_ALREADY_ACCEPTED`·`INVITATION_NOT_IN_ROSTER` 3종은 curl로
+  확인 못 함.** 진짜 발급된 초대 토큰이 있어야 하는데, 토큰 원문은 API 응답 어디에도 없고 실제
+  메일 링크 안에만 있다(`inviteApi.ts` 주석과 일치) — 발송 후 실제 받은편지함을 확인해야 얻을 수
+  있다. 사용자에게 물어 **코드 리뷰 + Playwright 가로채기로 대체하기로 결정**(이 세션 대화 로그
+  참고). 3종 다 아래 5단계에서 실제 렌더로 대신 확인함 — **서버가 정확히 이 코드·상태를 주는지는
+  여전히 미검증**으로 남는다(오늘 다른 Cowork 세션이 실메일로 초대 흐름 자체는 종단 검증했으나
+  특정 에러 코드 3종을 겨냥한 것은 아니었다, `docs/dev/handoff.md` 8/18 "추가 2").
+- **빈 토큰(`VALIDATION_FAILED`)은 실제로 도달 불가능한 경로** — 라우트가 `/invite/:token`이라
+  `token` 세그먼트 없이는 이 화면 자체에 안 들어온다(`InviteScreen.route.tsx` 확인). 코드가 반응할
+  필요는 없다 — 참고용으로만 남긴다.
+- 미활성 계정 대상 재발송 응답이 정상 계정과 같은지는 별도 계정이 없어 미검증(자연 계정 열거
+  방지 로직상 같을 것으로 추정되나 실측 아님).
+
+## 5단계 · 플로우를 탄다 (Playwright, 2026-08-18)
+
+로컬 `npm run dev`(5173), `page.route`로 서버 응답을 가로챈 뒤 **실제 클릭·입력**으로 검증(코드
+직접 판독이 아니라 렌더 확인). 스크립트는 스크래치패드에 둠(레포에 안 남김). **18건 전수 통과.**
+
+| 시나리오 | 확인한 것 | 결과 |
+|---|---|---|
+| 변형 A(매니저) 정상 흐름 | 이름 필드 있음 · 체크박스 3개(전체동의+2) · 제출 → `/shared/login` | ✅ |
+| 변형 B(교육생) 정상 흐름 | 이름 필드 없음 · 체크박스 6개(전체동의+5) · 제출 → `/shared/login` | ✅ |
+| E3 필수 동의 미체크 | 제출 버튼 비활성 | ✅ |
+| A2 만료(검증 단계) | `#expired` 카드 · 이메일 입력 후 재발송 성공 시 문구 교체 | ✅ |
+| A3 이미가입 | `#already` 카드 · [로그인] 클릭 → `/shared/login` | ✅ |
+| A4 무효 | `#invalid` 카드 렌더 | ✅ |
+| A5 명단외 | `#notlisted` 카드 렌더 | ✅ |
+| A7 네트워크 실패(검증 단계) | 폴백 카드("서버에 연결하지 못했습니다") | ✅ |
+| B2 제출 단계 만료 | 인라인 알림 + 재발송 링크(`action=RESEND`) 노출 | ✅ |
+| **C3 재검증** | 재발송이 500으로 실패해도 **링크가 사라지지 않음**(AU-01 C3 회귀와 같은 함정, 이번엔 처음부터 `action: 'RESEND'` 유지로 짜서 회귀 없음) | ✅ |
+| **G3 검증 중 타이틀** | 교육생(`stu-`) 링크인데 검증 중 브랜드 패널 제목이 잠깐 "운영 계정을 설정하세요"(매니저 카피)로 뜬 뒤 "계정 활성화"로 바뀜 — **실제로 재현됨**, 비-치명(수백 ms) | ⚠ 아래 참고 |
+| IME 한글 조합 | 이름 필드(변형 A) — CDP composition 후 "미니" 정확히 입력, 안 깨짐 | ✅ |
+| Caps Lock `onFocus` | 크래시 없이 필드 간 포커스 이동(AU-01에서 고친 배선 재사용) | ✅(물리 키 토글 자체는 자동화 불가, 실측은 사용자 몫) |
+
+### G3 — 실제로 확인됐지만 이번 범위에서 안 고침
+
+검증 중(수백 ms) 짧게 잘못된 브랜드 카피가 보인다. 원인은 `copy = invite ? COPY[invite.inviteType]
+: COPY.MANAGER`(`InviteScreen.tsx`)의 폴백이 `MANAGER`로 고정된 것 — `role`을 아직 몰라 무엇을
+보여줄지 모르는 상태인데 하나를 골라야 해서 생긴 구조적 결과다. **1단계 문서가 이미 "비-치명적"으로
+분류**했고 이번 라운드 스코프(§C3·A2/B3·C4/C5 하드닝)와 다른 종류의 개선(로딩 중 문구를 아예
+없애거나 중립 카피로 바꾸는 설계 판단)이라 범위 밖으로 남긴다 — 실측으로 존재는 확정했으니
+다음에 손댈 사람이 "정말 비-치명적인지"부터 다시 재지 않아도 된다.
+
+## 6단계 · 남긴다
+
+### 이번 라운드에서 고친 것
+
+1. C3(제출 단계 재발송 실패) — `handleResend` `try/catch` 추가, `action: 'RESEND'` 유지(코드
+   리뷰 단계에서 고침, 이번 5단계에서 실제 클릭으로 재검증 완료 — 회귀 없음)
+
+### 이번 범위에서 의도적으로 안 건드린 것
+
+- **G3(검증 중 브랜드 카피 깜빡임)** — 실제로 재현됐으나 구조적 설계 판단이 필요해 범위 밖(위 참고)
+- **접근성 `aria-describedby` 미연결** — AU-01에서 이미 발견·기록, 공용 컴포넌트라 조율 필요
+
+### 미검증으로 남긴 것
+
+- **`INVITATION_EXPIRED`·`INVITATION_ALREADY_ACCEPTED`·`INVITATION_NOT_IN_ROSTER`의 실서버 응답
+  일치 여부** — curl로 확인하려면 진짜 발급된 토큰(실제 메일 수신)이 필요해 이번 세션에서
+  Playwright 가로채기로 대체(사용자 확인). 서버가 정확히 이 3개 코드를 이 상황에서 주는지 자체는
+  여전히 실측 안 됨 — 다음에 실제 초대 메일 라운드(운영자 초대 → 실제 수신함 확인)를 돌릴 때
+  같이 확인.
+- **Caps Lock 실제 물리 키보드 재현** — `onFocus` 배선은 AU-01에서 고쳐 이 화면도 공유하지만,
+  Playwright/CDP가 OS Caps Lock 토글을 못 켜 자동 재현 불가(AU-01과 동일한 한계).
+- **미활성 계정 대상 재발송 응답 비교** — 별도 미활성 계정이 없어 미실측.

--- a/docs/dev/screens/au-02-situations.md
+++ b/docs/dev/screens/au-02-situations.md
@@ -1,0 +1,96 @@
+# AU-02 회원가입 · 계정 활성화 — 상황 전수
+
+> `docs/dev/screen-hardening.md` 1단계 결과물. 대상 파일: `InviteScreen.tsx` · `InviteScreen.route.tsx` ·
+> `inviteStates.ts` · `inviteTypes.ts` · `inviteApi.ts` · `consents.ts`. API:
+> `POST /auth/invitations/resolve` · `POST /auth/manager-signup` · `POST /auth/trainee-activation` ·
+> `POST /auth/invitations/resend`.
+>
+> **범위 밖(정책·설계 미확정)**: `components/ui/Field.tsx`의 `aria-describedby` 미연결(공용 컴포넌트,
+> AU-01에서 이미 발견·기록만 함) · 재수강생 초대를 애초에 보낼지 여부(OP-06 소관, AU-02 정의서 §6).
+> 케이스 계약 단일 원천: [`signup-activation.html#cases`](../../plan/v2/wireframe/shared/signup-activation.html#cases).
+
+---
+
+## 축 A. 토큰 검증 (`getInvite`, 진입 시 1회)
+
+| | 코드 | 화면 |
+|---|---|---|
+| A1 | (성공) | 변형 A/B 폼 렌더 |
+| A2 | `INVITATION_EXPIRED` | `#expired` 카드 — 이메일 입력 후 재발송(검증 단계는 `invite.email`을 아직 모른다) |
+| A3 | `INVITATION_ALREADY_ACCEPTED` | `#already` 카드 — [로그인]. 재수강생(B5=`ACCOUNT_EXISTS`)도 여기로 합쳐진다(백엔드가 코드를 4종만 확정, `inviteTypes.ts` 주석) |
+| A4 | `INVITATION_INVALID` | `#invalid` 카드 — [문의하기] |
+| A5 | `INVITATION_NOT_IN_ROSTER` | `#notlisted` 카드 — [문의하기] (교육생 전용) |
+| A6 | 스펙에 없는 코드 | 폴백 카드 — "문제가 발생했어요" + 문의하기 |
+| A7 | 네트워크 도달 실패 | 폴백 카드 — "서버에 연결하지 못했습니다" + 문의하기 |
+| A8 | 검증 중 | "초대 링크를 확인하는 중…" 텍스트만 |
+
+## 축 B. 제출 결과 (`signup`/`activate`, `resolveInviteState`)
+
+| | 코드 | 알림 | 비고 |
+|---|---|---|---|
+| B1 | (성공) | — | `/shared/login`으로 이동 |
+| B2 | `INVITATION_EXPIRED` | danger + [초대 메일 다시 받기] | 이 시점엔 `invite.email`을 알아 자동으로 그 주소로 재발송 |
+| B3 | `INVITATION_ALREADY_ACCEPTED` | warning + [로그인] | 동시 탭·재시도 경합으로 검증 통과 뒤 제출 시점에 이미 수락된 경우 |
+| B4 | `INVITATION_INVALID` | danger + [문의하기] | |
+| B5 | `INVITATION_NOT_IN_ROSTER` | danger + [문의하기] | |
+| B6 | 스펙에 없는 코드 · `PASSWORD_CONFIRMATION_MISMATCH` · `REQUIRED_CONSENT_MISSING` · `WEAK_PASSWORD` · `ACTIVATION_STATE_CHANGED` | danger, 시스템 메시지 폴백 | 앞 셋은 클라이언트가 이미 막아 거의 안 옴 |
+| B7 | 네트워크 도달 실패 | danger, "서버에 연결하지 못했습니다" | |
+| B8 | 제출 중 | 버튼 "계정을 만들고 있어요…" + 입력 잠금 | |
+
+## 축 C. 제출 단계 재발송(`handleResend`) — B2에서만 노출
+
+| | |
+|---|---|
+| C1 | 클릭 전 — "초대 메일 다시 받기" 링크 |
+| C2 | 클릭 → 성공 → "초대 메일을 다시 보냈습니다"로 교체 |
+| C3 | 클릭 → 실패(네트워크·5xx) — **🔴 발견·✅ 이번에 고침.** `try/catch`가 없어 unhandled rejection만 나고 사용자에겐 아무 반응도 없었다. AU-01 `LoginScreen.tsx`의 C3과 같은 결함 클래스 — 재발송 링크(action='RESEND')를 유지한 채 danger 알림을 띄우도록 고쳤다 |
+
+## 축 D. 검증 단계 재발송(`handleResendToTypedEmail`) — A2에서만 노출
+
+이메일을 모르는 상태라 사용자가 직접 입력한다. 이미 `try/catch` + `resendPending`/`resendInputError`로
+구현돼 있어 이번 라운드에서 손대지 않았다(제출 단계 C축과 대칭이지만 검증 단계는 처음부터 제대로
+돼 있었다).
+
+## 축 E. 클라이언트 검증 (React Hook Form)
+
+| | |
+|---|---|
+| E1 | 비밀번호 정책 미충족 — 정책은 상시 노출, 제출 시도 후에만 미충족 기준을 danger로 |
+| E2 | 비밀번호 확인 불일치 |
+| E3 | 필수 동의 미체크(CS1) — 제출 막힘 + 미체크 항목 강조(`highlightMissing`) |
+| E4 | 선택 동의 미체크(CS2) — 정상 진행 |
+| E5 | 제출 중(`isSubmitting`) — 재제출 막힘 |
+
+## 축 F. Caps Lock · 비밀번호 표시 토글
+
+AU-01에서 고친 `onFocus` 배선(E3 — 재포커스 시 미탐지)이 `passwordCaps`·`passwordConfirmCaps` 둘 다
+이미 적용돼 있음을 코드로 확인(`useCapsLockWarning` 공유 컴포넌트, 2026-08-16 세션에서 3파일 동시
+수정). 이번에 새로 건드릴 것 없음.
+
+## 축 G. 변형 분기 (A vs B)
+
+| | |
+|---|---|
+| G1 | 변형 A(매니저·오퍼레이터) — 이름 입력 필드 있음, 동의 2개(전부 필수) |
+| G2 | 변형 B(교육생) — 이름 필드 없음(명단에 이미 있음), 동의 5개(필수 4 + 선택 1) |
+| G3 | `invite`가 아직 null인 검증 중에는 `copy = COPY.MANAGER`로 폴백 — 교육생 링크라도 검증 완료 전 짧은 순간 "회원가입" 타이틀이 보일 수 있음(비-치명적, 실제 렌더로 체감 여부 확인 필요) |
+
+---
+
+## 코드 리뷰로 확정된 것 (렌더 없이 판정 가능)
+
+- **🔴 C3 · 확정된 결함 · ✅ 고침 — `handleResend`(제출 단계 재발송)가 실패를 삼키지 않고
+  그대로 던진다.** `try/catch`를 추가해 실패 시 `submitAlert`에 danger 알림 + `action: 'RESEND'`를
+  유지하도록 고쳤다(링크가 사라지지 않아야 사용자가 재시도할 수 있다 — AU-01 C3 재검증 때 나온
+  회귀와 같은 함정이라 처음부터 `action` 유지로 짰다).
+
+---
+
+## 미검증으로 남긴 것 (2단계·5단계 — 로컬 Claude Code CLI + Playwright 필요)
+
+- curl 실측: 4개 에러 코드(`INVITATION_EXPIRED`·`INVITATION_ALREADY_ACCEPTED`·`INVITATION_INVALID`·
+  `INVITATION_NOT_IN_ROSTER`) 전부 실서버 응답과 일치하는지.
+- 실제 렌더: 변형 A/B 각각 정상 흐름 · 재수강생(A3) 흐름 · C3 수정이 실제 클릭으로도 알림을
+  유지하는지 · G3(검증 중 타이틀 깜빡임)이 실제로 보이는지.
+- Caps Lock 실제 키보드 재현 — 비밀번호·비밀번호 확인 두 필드 모두.
+- 한글 IME 조합 — 이름 필드(변형 A만 있음, AU-01 로그인 필드와 별개로 재확인 필요).

--- a/docs/dev/screens/au-03-situations.md
+++ b/docs/dev/screens/au-03-situations.md
@@ -1,0 +1,107 @@
+# AU-03 비밀번호 재설정 — 상황 전수
+
+> `docs/dev/screen-hardening.md` 1단계 결과물. 대상 파일: `PasswordResetScreen.tsx` ·
+> `PasswordResetScreen.route.tsx` · `passwordResetStates.ts` · `passwordResetTypes.ts` ·
+> `passwordResetApi.ts`. API: `POST /auth/password-reset/requests` ·
+> `POST /auth/password-reset/validations` · `POST /auth/password-reset/confirmations`.
+>
+> **범위 밖(구현 불가·정책 미확정)**: `#donepartial`(세션 폐기 부분 실패) — 실제
+> `PasswordResetConfirmationResponse`에 폐기 결과 필드가 없어 화면이 그 상태에 도달할 방법이
+> 없다(`passwordResetTypes.ts` 주석, 백엔드가 필드를 추가하면 복원). 접근성 `aria-describedby`
+> 미연결(AU-01에서 이미 발견·기록만 함, 공용 컴포넌트). 케이스 계약 단일 원천:
+> [`password-reset.html#cases`](../../plan/v2/wireframe/shared/password-reset.html#cases).
+
+---
+
+## 조회 흐름
+
+```
+① 요청  RequestStage       POST /auth/password-reset/requests    제출 시 1회, 항상 202
+② 설정  SetPasswordStage    POST /auth/password-reset/validations  진입 시 1회(토큰 검증)
+                            POST /auth/password-reset/confirmations 제출 시 1회
+```
+
+라우트는 `/shared/password-reset` 하나뿐 — `?token=` 쿼리 유무로 컴포넌트 내부에서만 단계를
+가른다(정의서 §9, "토큰 없이 ②에 오면 ①로 보낸다"). `token` 값이 빈 문자열(`?token=`)이어도
+falsy라 자동으로 ①로 떨어진다(코드 확인, 별도 처리 불필요).
+
+---
+
+## 축 A. ① 요청 제출 (`RequestStage.onSubmit`)
+
+| | | 비고 |
+|---|---|---|
+| A1 | (성공, 항상 202) | 정상·없는 이메일·미활성 계정 셋 다 여기로 — 카드 전환, 계정 열거 방지 |
+| A2 | 네트워크·5xx 실패 | **🔴 발견·✅ 이번에 고침.** 원래 `try/catch`가 아예 없어 실패해도 아무 알림 없이 조용히 멈췄다(이 화면 유일하게 에러 처리가 전혀 없던 제출 경로). `resolvePasswordResetState(err).message`를 `submitAlert`로 노출하도록 고쳤다 |
+| A3 | 이메일 빈 값·형식 오류 | RHF 클라이언트 검증, D축과 동일 패턴 |
+| A4 | 제출 중 | 버튼 "전송 중…" + 입력 잠금 |
+
+## 축 B. ① 요청 후 재발송 (`RequestStage.handleResend`) — A1 카드에서만 노출
+
+| | | 비고 |
+|---|---|---|
+| B1 | 클릭 전 — "다시 보내기" 버튼 |
+| B2 | 클릭 → 성공 → "다시 보냈습니다"로 교체 |
+| B3 | 클릭 → 실패(네트워크·5xx) | **🔴 발견·✅ 이번에 고침.** A2와 같은 결함 — `try/catch` 추가, `resendError`를 카드 `aux` 영역에 danger 색으로 노출(원래 있던 "스팸함 확인" 안내 문구를 에러 발생 시에만 대체) |
+
+## 축 C. ② 설정 — 토큰 검증 (`verifyResetToken`, 진입 시 1회)
+
+| | 코드 | `action` | 화면 |
+|---|---|---|---|
+| C1 | (성공) | — | 새 비밀번호 폼 렌더 |
+| C2 | `RESET_TOKEN_EXPIRED` / `RESET_TOKEN_USED` | `REQUEST_AGAIN` | `#expired` 카드 — [다시 요청하기] → ① |
+| C3 | `RESET_TOKEN_INVALID` | `CONTACT` | `#invalid` 카드 — [문의하기], 보안 로그 |
+| C4 | 네트워크 도달 실패 | (없음) | **🔴 발견·✅ 이번에 고침** — 아래 "코드 리뷰로 확정된 것" 참고 |
+| C5 | 스펙에 없는 코드 | (없음) | 위와 같은 결함, 같은 수정으로 커버됨 |
+| C6 | 검증 중 | — | "링크를 확인하는 중…" 텍스트만 |
+
+## 축 D. ② 설정 제출 (`SetPasswordStage.onSubmit`, `confirmPasswordReset`)
+
+| | 코드 | 처리 |
+|---|---|---|
+| D1 | (성공) | `#done` 카드 — "비밀번호가 바뀌었습니다", 다른 기기 모두 로그아웃 안내 |
+| D2 | `SAME_AS_CURRENT` | 필드 인라인 에러(`setError('password', ...)`)로 특별 처리 — 알림 배너가 아니라 정책 힌트처럼 필드 하단에 붙는다 |
+| D3 | `RESET_FAILED` | danger 알림, 폼 유지("비밀번호는 아직 안 바뀜") |
+| D4 | 네트워크·스펙 밖 코드 | danger 알림, `resolvePasswordResetState` 폴백 메시지 |
+| D5 | 제출 중 | 버튼 "비밀번호를 바꾸는 중…" |
+
+## 축 E. 클라이언트 검증
+
+| | |
+|---|---|
+| E1 | 비밀번호 정책 미충족 |
+| E2 | 비밀번호 확인 불일치 |
+
+## 축 F. Caps Lock · 비밀번호 표시 토글
+
+AU-01 E3 수정(`onFocus` 배선)이 `SetPasswordStage`의 `passwordCaps`·`passwordConfirmCaps` 둘 다
+이미 적용돼 있음을 코드로 확인. 이번에 새로 건드릴 것 없음.
+
+---
+
+## 코드 리뷰로 확정된 것 (렌더 없이 판정 가능)
+
+- **🔴 A2·B3 · 확정된 결함 · ✅ 고침 — `RequestStage.onSubmit`·`handleResend`에 `try/catch`가
+  아예 없었다.** 이 화면에서 유일하게 실패 시 아무 피드백도 없던 두 지점. `resolvePasswordResetState`를
+  재사용해(새 문구 체계를 안 만듦) 각각 폼 상단 알림·카드 `aux`에 노출하도록 고쳤다.
+- **🔴 C4·C5 · 확정된 결함 · ✅ 고침 — 토큰 검증 실패 렌더링이 `tokenAlert.message`(실제 계산된
+  메시지)를 무시하고 있었다.** 기존 코드는 `action === 'REQUEST_AGAIN'`이 아니면 무조건 하드코딩된
+  "유효하지 않은 링크입니다 + 문의하기"(`#invalid` 카드)를 보여줬다 — `RESET_TOKEN_INVALID`(진짜
+  위변조, `action: 'CONTACT'`)와 네트워크 오류·스펙 밖 코드(`action` 없음)가 똑같은 화면으로
+  뭉개져 있었다는 뜻. 서버에 물어보지도 못한 상태(네트워크 실패)를 "유효하지 않은 링크"로 단정하는
+  것은 사용자에게 잘못된 정보다. `action`을 `REQUEST_AGAIN`·`CONTACT`·그 외(네트워크·미지) 3단으로
+  나눠, 마지막 분기는 `resolvePasswordResetState`가 이미 구분해 둔 `tokenAlert.message`를 그대로
+  쓰도록 고쳤다. `CONTACT` 분기의 하드코딩된 문구는 그대로 유지했다 — 보안상 위변조 토큰에 대해
+  원인을 구체적으로 흘리지 않는 것은 의도된 설계(정의서 §6)라 이번 수정 대상이 아니다.
+
+---
+
+## 미검증으로 남긴 것 (2단계·5단계 — 로컬 Claude Code CLI + Playwright 필요)
+
+- curl 실측: `RESET_TOKEN_EXPIRED`·`RESET_TOKEN_USED`·`RESET_TOKEN_INVALID`·`SAME_AS_CURRENT`·
+  `RESET_FAILED` 5개 코드가 실서버 응답과 일치하는지.
+- 실제 렌더: ①→(메일)→②→완료 전체 플로우 · A2/B3/C4 수정이 실제로 네트워크를 끊었을 때 올바른
+  문구로 뜨는지 · D2(SAME_AS_CURRENT)가 필드 하단에 정책 힌트처럼 자연스럽게 붙는지.
+- Caps Lock 실제 키보드 재현 — 새 비밀번호·확인 두 필드.
+- `token` 존재하지만 무의미한 값으로 직접 URL 진입 시 실제 렌더(코드 리뷰로는 정상 분기로
+  보이나 실측 필요).

--- a/docs/dev/screens/au-03-situations.md
+++ b/docs/dev/screens/au-03-situations.md
@@ -96,12 +96,109 @@ AU-01 E3 수정(`onFocus` 배선)이 `SetPasswordStage`의 `passwordCaps`·`pass
 
 ---
 
-## 미검증으로 남긴 것 (2단계·5단계 — 로컬 Claude Code CLI + Playwright 필요)
+## 2단계·5단계로 확정된 것
 
-- curl 실측: `RESET_TOKEN_EXPIRED`·`RESET_TOKEN_USED`·`RESET_TOKEN_INVALID`·`SAME_AS_CURRENT`·
-  `RESET_FAILED` 5개 코드가 실서버 응답과 일치하는지.
-- 실제 렌더: ①→(메일)→②→완료 전체 플로우 · A2/B3/C4 수정이 실제로 네트워크를 끊었을 때 올바른
-  문구로 뜨는지 · D2(SAME_AS_CURRENT)가 필드 하단에 정책 힌트처럼 자연스럽게 붙는지.
-- Caps Lock 실제 키보드 재현 — 새 비밀번호·확인 두 필드.
-- `token` 존재하지만 무의미한 값으로 직접 URL 진입 시 실제 렌더(코드 리뷰로는 정상 분기로
-  보이나 실측 필요).
+아래는 원래 "미검증으로 남긴 것"에 있던 항목 중 이번에 curl·Playwright·사용자 직접 재현으로
+확인한 것 — 자세한 절차·응답 원문은 뒤의 "2단계 실측"·"5단계 플로우를 탄다" 절 표에 있다.
+
+**curl로 실서버 확인:**
+
+- `RESET_TOKEN_INVALID`(C3) — 위조 토큰으로 `validations`·`confirmations` 둘 다 400
+  `RESET_TOKEN_INVALID` 응답 확인
+- 계정 열거 방지(`requests`, A1) — 존재/미존재 이메일 모두 202 + 완전히 동일한 메시지 확인
+- 네트워크 도달 실패 — DNS 실패로 `ApiError.isNetwork` 경로가 실제로 트리거되는 것을 transport
+  레벨에서 확인
+
+**Playwright로 렌더 확인(응답 가로채기 + 실제 클릭, 14건 전수):**
+
+- ①→②→완료 전체 플로우 — 요청 제출부터 로그인 이동까지 실제 클릭으로 이어서 확인
+- **A2·B3 재검증** — 이번에 새로 추가한 `try/catch`가 실제로 danger 알림(폼 상단)·`aux` 문구
+  (카드)를 띄우는 것 확인
+- `#expired`(C2)·`#invalid`(C3) 상태 카드 — 화면이 이 코드를 받았을 때 올바르게 렌더하는지 확인
+  (서버가 실제로 `RESET_TOKEN_EXPIRED`/`USED`를 주는지 자체는 아직 미검증 — 아래 참고)
+- **C4/C5 재검증** — 토큰 검증 중 네트워크 완전 실패 시 "유효하지 않은 링크"로 오판하지 않고
+  실제 계산된 메시지가 뜨는 것을 실제 클릭 흐름으로 확인(이번 라운드 핵심 수정)
+- **C4 — 사용자가 브라우저 DevTools의 Request Blocking으로 직접 재현.** `validations` 요청을
+  502로 강제 차단해 실제 브라우저에서 재현했고, "문제가 발생했어요" 카드가 정상 노출되는 것을
+  확인했다(Playwright 가로채기와는 별개로, 실제 브라우저·실제 사용자 조작으로 한 번 더 검증됨)
+- D2(`SAME_AS_CURRENT`) — 배너가 아니라 비밀번호 필드 바로 아래 인라인으로 뜨는 것 확인
+- D3(`RESET_FAILED`) — danger 배너 + 폼 유지 확인
+- §9 `token=` 빈 값 — ①(`RequestStage`)로 자동 폴백되는 것 렌더로 재확인
+- 한글 IME 조합(이메일 필드) — CDP composition으로 조합 안 깨짐 확인
+
+---
+
+## 2단계 · 실측 (curl, 2026-08-18)
+
+실서버(`https://xvdanr6m362b2ge232vdmfbrny0kwakz.lambda-url.ap-northeast-1.on.aws`, Lambda 프록시,
+AU-01·AU-02와 동일 주소) 직접 호출.
+
+| 요청 | 결과 |
+|---|---|
+| `POST /auth/password-reset/requests` 존재하는 dev 계정(`manager@example.com`) | 202, "입력하신 주소가 계정에 등록돼 있으면…" |
+| `POST /auth/password-reset/requests` 존재하지 않는 이메일 | 202, **동일한 메시지**(계정 열거 방지 실측 확인 — A1) |
+| `POST /auth/password-reset/requests` 형식 오류 이메일 | 400 `VALIDATION_FAILED` |
+| `POST /auth/password-reset/validations` 위조 토큰 | 400 `RESET_TOKEN_INVALID`(C3 코드 실서버 확인) |
+| `POST /auth/password-reset/validations` 빈 토큰 | 400 `VALIDATION_FAILED`(도달 불가 — 아래 참고) |
+| `POST /auth/password-reset/confirmations` 위조 토큰 | 400 `RESET_TOKEN_INVALID` |
+| 위 세 엔드포인트 전부 DNS 실패 | `curl exit 6` — `ApiError.isNetwork` 경로 트리거 확인 |
+
+- **`RESET_TOKEN_EXPIRED`·`RESET_TOKEN_USED`·`SAME_AS_CURRENT`·`RESET_FAILED` 4종은 curl로 확인
+  못 함.** 진짜 발급된 재설정 토큰이 있어야 하는데 토큰 원문은 실제 메일 링크 안에만 있다 —
+  AU-02와 같은 이유로 사용자와 상의해 **코드 리뷰 + Playwright 가로채기로 대체**(이 세션 대화
+  로그 참고). 5단계에서 실제 렌더로 대신 확인함 — 서버가 정확히 이 코드를 주는지는 미검증으로
+  남는다.
+- **빈 토큰(`?token=`)은 URL에 값 없이 접근해도 도달 불가능** — `token` falsy면 컴포넌트가 자동으로
+  `RequestStage`(①)로 떨어져 애초에 `validations` 호출 자체가 안 나간다(`PasswordResetScreen.tsx`
+  확인, 아래 5단계 §9에서 실제 렌더로도 재확인).
+- `token` 존재하지만 무의미한 값(위조)으로 직접 URL 진입은 위 `RESET_TOKEN_INVALID` 실측과 같은
+  경로 — 이미 확인됨.
+
+## 5단계 · 플로우를 탄다 (Playwright, 2026-08-18)
+
+로컬 `npm run dev`(5173), `page.route`로 서버 응답을 가로챈 뒤 **실제 클릭·입력**으로 검증. 스크립트는
+스크래치패드에 둠. **14건 전수 통과.**
+
+| 시나리오 | 확인한 것 | 결과 |
+|---|---|---|
+| ①→②→완료 전체 플로우 | 요청 제출 → "메일을 보냈습니다" 카드 → (링크 클릭 대체) → 새 비밀번호 폼 → 확정 → "비밀번호가 바뀌었습니다" → [로그인] 클릭 → `/shared/login` | ✅ |
+| **A2 재검증** | 요청(①) 500 실패 → danger 알림 노출 + 폼 유지(이 화면에서 유일하게 에러 처리가 아예 없던 자리, 이번에 고친 것 — 회귀 없음) | ✅ |
+| **B3 재검증** | ① 성공 뒤 재발송(B축)이 500 실패 → 카드 `aux` 영역에 danger 문구로 대체(스팸함 안내 문구 대신) | ✅ |
+| C2 만료/사용됨 | `#expired` 카드 · [다시 요청하기] 클릭 → ①로 이동(경로 확인) | ✅ |
+| C3 위변조 | `#invalid` 카드, [문의하기]만 있고 재요청 버튼 없음(보안 설계 의도대로) | ✅ |
+| **C4/C5 재검증** | 토큰 검증 중 네트워크 완전 실패(connectionrefused) → "문제가 발생했어요" + **실제 계산된 메시지**("서버에 연결하지 못했습니다") 노출, **"이 링크로는 비밀번호를 바꿀 수 없어요"(위변조 문구)로 오판하지 않음** — 이번 라운드 핵심 수정이 실제 렌더로 확인됨 | ✅ |
+| **C4 사용자 직접 재현** | Playwright가 아니라 **사용자가 실제 Chrome DevTools Request Blocking으로 `validations`를 502로 직접 차단** — "문제가 발생했어요" 정상 노출, 위변조 문구로 안 새는 것 재확인(실제 브라우저·실제 조작) | ✅ |
+| D2 SAME_AS_CURRENT | 배너(`[data-slot=alert]`) 0개 · 비밀번호 필드 바로 아래 `role=alert`로 "지금 쓰는 비밀번호와 달라야 합니다" — 정책 힌트처럼 인라인 노출 확인 | ✅ |
+| D3 RESET_FAILED | danger 배너 1개 + 폼 유지(비밀번호 아직 안 바뀜) | ✅ |
+| §9 `token=` 빈 값 | URL에 `?token=`만 있어도(값 없음) 자동으로 ①(`RequestStage`)로 폴백 | ✅ |
+| IME 한글 조합 | 이메일 필드(①) — CDP composition 후 "미니" 정확히 입력 | ✅ |
+
+첫 러닝에서 스크립트 자체의 판정 오류 2건을 발견·수정했다(제품 결함 아님, 기록만 남김):
+`role=alert`가 배너(`Alert`)와 인라인 필드 에러(`FieldError`) 둘 다에 쓰여(`data-slot=alert`로
+구분해야 함) D2 배너 판정이 처음에 오탐이었고, `waitForURL` 글롭 패턴이 쿼리스트링 있는 현재
+URL과 겹쳐 C2의 "다시 요청하기" 이동 판정이 한 번 타임아웃 났다(시간 대기로 바꿔 해결) —
+「측정 대상을 확인한다」(screen-hardening.md 2단계)와 같은 종류의 함정이라 여기 남긴다.
+
+## 6단계 · 남긴다
+
+### 이번 라운드에서 고친 것 (전부 코드 리뷰 단계에서 고치고, 이번 5단계에서 실제 클릭으로 재검증 완료)
+
+1. A2·B3 — `RequestStage.onSubmit`·`handleResend`에 없던 `try/catch` 추가
+2. C4·C5 — 토큰 검증 실패 렌더링이 `action` 3단(REQUEST_AGAIN/CONTACT/기타)을 안 가르고 전부
+   "유효하지 않은 링크"로 뭉개던 것 — 네트워크 실패도 위변조와 같은 문구로 잘못 단정하던 결함,
+   Playwright 가로채기 + **사용자의 실제 DevTools 재현(502 직접 차단)** 둘 다로 회귀 없음 확인
+
+### 이번 범위에서 의도적으로 안 건드린 것
+
+- **`#donepartial`(세션 폐기 부분 실패)** — 실제 응답에 필드가 없어 화면이 도달 불가능한 상태,
+  백엔드가 필드를 추가하면 복원
+- **접근성 `aria-describedby` 미연결** — AU-01에서 이미 발견·기록, 공용 컴포넌트라 조율 필요
+
+### 미검증으로 남긴 것
+
+- **`RESET_TOKEN_EXPIRED`·`RESET_TOKEN_USED`·`SAME_AS_CURRENT`·`RESET_FAILED`의 실서버 응답 일치
+  여부** — 진짜 발급된 토큰(실제 메일 수신)이 있어야 curl로 확인 가능. 이번엔 Playwright
+  가로채기로 대체(사용자 확인) — 다음에 실제 비밀번호 재설정 메일 라운드를 돌릴 때 같이 확인.
+  특히 `RESET_TOKEN_USED`는 유효한 토큰 하나로 성공적으로 재설정한 뒤 **같은 토큰을 재사용**하면
+  자연스럽게 재현 가능(실제 계정 비밀번호가 바뀌는 부수효과 있음 — 실행 전 사용자 동의 필요).
+- **Caps Lock 실제 물리 키보드 재현** — 새 비밀번호·확인 두 필드, AU-01과 동일한 자동화 한계.

--- a/src/features/auth/InviteScreen.tsx
+++ b/src/features/auth/InviteScreen.tsx
@@ -267,8 +267,18 @@ export default function InviteScreen() {
   /** 제출 단계 재발송 — 폼을 이미 연 상태라 invite.email을 안다(검증 단계와 다른 점) */
   async function handleResend() {
     if (!invite) return
-    await resendInvite(invite.email)
-    setResendDone(true)
+    try {
+      await resendInvite(invite.email)
+      setResendDone(true)
+    } catch {
+      // 실패해도 action을 'RESEND'로 유지해 링크가 사라지지 않게 한다 —
+      // AU-01 LoginScreen.tsx의 handleResend와 같은 패턴(C3 결함 재발 방지)
+      setSubmitAlert({
+        variant: 'danger',
+        message: '메일 발송에 실패했습니다. 잠시 후 다시 시도해 주세요.',
+        action: 'RESEND',
+      })
+    }
   }
 
   /** 검증 단계 재발송 — invite.email을 모르므로 사용자가 입력한 주소로 보낸다 */

--- a/src/features/auth/PasswordResetScreen.tsx
+++ b/src/features/auth/PasswordResetScreen.tsx
@@ -39,6 +39,9 @@ interface SetPasswordFormValues {
 function RequestStage() {
   const [sentEmail, setSentEmail] = useState<string | null>(null)
   const [resent, setResent] = useState(false)
+  /** 제출 실패(네트워크·5xx) — 폼은 유지, 인라인 알림. 카드로 넘어간 뒤 재발송 실패는 resendError */
+  const [submitAlert, setSubmitAlert] = useState<string | null>(null)
+  const [resendError, setResendError] = useState<string | null>(null)
   const {
     register,
     handleSubmit,
@@ -46,14 +49,24 @@ function RequestStage() {
   } = useForm<RequestFormValues>({ defaultValues: { email: '' } })
 
   async function onSubmit(values: RequestFormValues) {
-    await requestPasswordReset(values.email)
-    setSentEmail(values.email)
+    setSubmitAlert(null)
+    try {
+      await requestPasswordReset(values.email)
+      setSentEmail(values.email)
+    } catch (err) {
+      setSubmitAlert(resolvePasswordResetState(err).message)
+    }
   }
 
   async function handleResend() {
     if (!sentEmail) return
-    await requestPasswordReset(sentEmail)
-    setResent(true)
+    setResendError(null)
+    try {
+      await requestPasswordReset(sentEmail)
+      setResent(true)
+    } catch (err) {
+      setResendError(resolvePasswordResetState(err).message)
+    }
   }
 
   if (sentEmail) {
@@ -69,7 +82,13 @@ function RequestStage() {
             입력하신 주소가 계정에 등록돼 있으면 재설정 링크가 도착합니다.
           </>
         }
-        aux="메일이 오지 않으면 스팸함을 확인해 주세요."
+        aux={
+          resendError ? (
+            <span className="text-danger">{resendError}</span>
+          ) : (
+            '메일이 오지 않으면 스팸함을 확인해 주세요.'
+          )
+        }
         actions={
           <>
             {resent ? (
@@ -91,6 +110,8 @@ function RequestStage() {
   return (
     <form onSubmit={handleSubmit(onSubmit)} noValidate className="space-y-4">
       <Stepbar active={1} />
+
+      {submitAlert && <Alert variant="danger">{submitAlert}</Alert>}
 
       <Field data-invalid={!!errors.email}>
         <FieldLabel htmlFor="reset-email">이메일</FieldLabel>
@@ -210,18 +231,41 @@ function SetPasswordStage({ token }: { token: string }) {
         />
       )
     }
-    // RESET_TOKEN_INVALID — 위변조는 재요청해도 같은 일이 반복될 것이라 문의로 보낸다
-    // (§6, 보안 로그). AU-02의 동일 케이스와 같은 톤 — danger + 문의하기.
-    // 목업 #invalid 페이지가 한때 #expired를 복사한 채(scard warn·다시 요청하기
-    // 버튼)로 남아 있었는데, 케이스 계약표·정의서와 대조해 danger·문의하기로
-    // 정정했다(목업도 함께 수정).
+    if (tokenAlert.action === 'CONTACT') {
+      // RESET_TOKEN_INVALID — 위변조는 재요청해도 같은 일이 반복될 것이라 문의로 보낸다
+      // (§6, 보안 로그). AU-02의 동일 케이스와 같은 톤 — danger + 문의하기.
+      // 목업 #invalid 페이지가 한때 #expired를 복사한 채(scard warn·다시 요청하기
+      // 버튼)로 남아 있었는데, 케이스 계약표·정의서와 대조해 danger·문의하기로
+      // 정정했다(목업도 함께 수정).
+      return (
+        <AuthStatusCard
+          variant="danger"
+          icon="!"
+          title="유효하지 않은 링크입니다"
+          description="이 링크로는 비밀번호를 바꿀 수 없어요."
+          aux="메일에 있는 링크를 다시 눌러 보세요. 계속 같으면 담당자에게 문의해 주세요."
+          actions={
+            <Button nativeButton={false} render={<a href="mailto:support@iz-get.com" />}>
+              문의하기
+            </Button>
+          }
+        />
+      )
+    }
+    /*
+      네트워크·알 수 없는 오류(action 없음) — 토큰이 진짜 위변조인지 아닌지 서버에
+      물어보지도 못한 상태다. "유효하지 않은 링크"로 단정하면 안 된다(2026-08-18
+      하드닝 — 이전엔 이 분기가 따로 없어서 여기까지 그대로 흘러 CONTACT 케이스와
+      똑같은 "유효하지 않은 링크입니다"가 떴다). `resolvePasswordResetState`가 이미
+      네트워크/미지 코드를 구분해 계산해 둔 `tokenAlert.message`를 그대로 쓴다.
+    */
     return (
       <AuthStatusCard
         variant="danger"
         icon="!"
-        title="유효하지 않은 링크입니다"
-        description="이 링크로는 비밀번호를 바꿀 수 없어요."
-        aux="메일에 있는 링크를 다시 눌러 보세요. 계속 같으면 담당자에게 문의해 주세요."
+        title="문제가 발생했어요"
+        description={tokenAlert.message}
+        aux="잠시 후 링크를 다시 열어 주세요. 계속 같으면 담당자에게 문의해 주세요."
         actions={
           <Button nativeButton={false} render={<a href="mailto:support@iz-get.com" />}>
             문의하기


### PR DESCRIPTION
## Summary
- InviteScreen.tsx: 제출 단계 재발송(handleResend) 실패 시 무반응이던 결함 수정 — try/catch 추가, action='RESEND' 유지한 채 danger 알림 노출 (AU-01 C3와 동일 결함 클래스)
- PasswordResetScreen.tsx RequestStage: onSubmit/handleResend에 에러 처리가 전혀 없던 결함 수정 — resolvePasswordResetState 재사용해 알림 노출
- PasswordResetScreen.tsx SetPasswordStage: 토큰 검증 실패 렌더링이 네트워크 오류·스펙 밖 코드를 위변조 토큰(#invalid)과 동일하게 보여주던 결함 수정 — action을 REQUEST_AGAIN·CONTACT·그 외 3단으로 분기, 마지막 분기는 실제 계산된 메시지 노출
- docs: au-02-situations.md, au-03-situations.md 신규 작성 (1단계 상황 전수 + 2/5단계 curl·Playwright 실측 결과 기록)

## Review points
- SetPasswordStage의 CONTACT 분기(위변조 토큰) 하드코딩 문구는 보안상 의도적으로 유지 — 원인을 구체적으로 흘리지 않기 위함 (정의서 §6)
- 재발송 실패 시 action을 유지하는 패턴은 AU-01 재검증 때 나온 회귀를 처음부터 피하기 위한 설계
- 토큰 의존 케이스(만료·이미가입·명단외 등) 6건은 실제 이메일 대신 코드 리뷰 + Playwright 라우트 가로채기로 대체 검증 — 매니저/교육생 초대 실제 가입은 작성자가 사전에 직접 확인함
- docs: au-02/au-03 검증 상태 문서 정리 (2/5단계 확정 항목과 진짜 미검증 항목 구분)

closes #250

---
PR 병합 시 "Create a merge commit" 사용 (squash 금지 — ee0aa54 전례)