### PR TITLE
[Fix] Roster CSV Filename Display and Curriculum Dialog Cancel Handling

### DIFF
--- a/src/features/operator/admin/_/components/RosterCsvField.tsx
+++ b/src/features/operator/admin/_/components/RosterCsvField.tsx
@@ -79,6 +79,13 @@ export default function RosterCsvField({ domain, onChange }: Props) {
 
   const take = async (file: File | undefined) => {
     if (!file) return
+    /*
+      ⚠ **판정과 상관없이 먼저 표시한다.** 예전엔 성공 경로 끝에서만 불러서, UTF-8·CP949
+      둘 다 아닌 파일을 고르면 인코딩 오류 배너는 뜨는데 버튼의 파일명은 이전 값(또는
+      기본 문구)에 그대로 머물렀다(실측) — 뭘 골랐는지 화면에서 알 수 없었다. 판정이
+      뭐가 됐든 **고른 파일 이름은 사실**이라 여기서 바로 반영한다.
+    */
+    setFileName(file.name)
     const text = await readSheet(file)
     if (text === null) {
       onChange(
@@ -88,7 +95,6 @@ export default function RosterCsvField({ domain, onChange }: Props) {
       )
       return
     }
-    setFileName(file.name)
     onChange(parseRosterCsv(text), file.name, file)
   }
 
@@ -127,7 +133,8 @@ export default function RosterCsvField({ domain, onChange }: Props) {
             엑셀이 그냥 「CSV」로 저장한 CP949도 받는다(29차 회신 Q1). 그래서 **엑셀에서
             바로 저장해도 된다**는 것을 여기서 말한다.
           */}
-          끌어다 놓아도 됩니다 · 「이름」·「이메일」 열만 있으면 됩니다(순서·다른 열 무관) ·{' '}
+          끌어다 놓아도 됩니다 · 「이름」·「이메일」 열만 있으면 순서나 다른 열은 상관없어요
+          <br />
           <a
             className="underline"
             download="교육생-양식.csv"

--- a/src/features/operator/admin/roster/components/AddRosterDialog.tsx
+++ b/src/features/operator/admin/roster/components/AddRosterDialog.tsx
@@ -284,7 +284,8 @@ export default function AddRosterDialog({ open, onOpenChange, onAdded }: Props) 
                 }}
               />
               <p className="text-fg-subtle mt-2 text-2xs">
-                수십~수백 명을 한 번에 넣을 때 씁니다. 반 배정은 등록한 뒤 배정 모드에서 합니다.
+                최대 {MAX_TRAINEE_INVITE.toLocaleString()}명을 한 번에 등록할 때 씁니다. 반 배정은
+                등록 후 배정 모드에서 따로 진행돼요.
               </p>
             </TabsContent>
 

--- a/src/features/operator/curricula/components/DeleteCurriculumDialog.tsx
+++ b/src/features/operator/curricula/components/DeleteCurriculumDialog.tsx
@@ -56,7 +56,8 @@ export default function DeleteCurriculumDialog({
         <DialogHeader>
           <DialogTitle>
             교안을 지울까요?
-            <span className="text-fg-subtle text-xs font-normal"> · {title}</span>
+            <br />
+            <span className="text-fg-subtle text-xs font-normal">{title}</span>
           </DialogTitle>
         </DialogHeader>
 
@@ -74,8 +75,11 @@ export default function DeleteCurriculumDialog({
 
         {/* **무엇이 일어나는지 쓴다**(G4) — `정말 하시겠습니까?`는 판단 근거를 안 준다 */}
         <p className="text-fg-muted text-xs">
-          목록에서 사라지고 프로젝트를 만들 때 더는 고를 수 없습니다. 올린 파일과 분석 결과도 같이
-          지워집니다. <b className="text-danger font-semibold">되돌릴 수 없습니다.</b>
+          교안 목록에서 사라지고 프로젝트를 만들 때 선택할 수 없습니다.
+          <br />
+          업로드한 파일과 분석 결과도 같이 삭제됩니다.
+          <br />
+          <b className="text-danger font-semibold">삭제 작업 후 복구할 수 없습니다.</b>
         </p>
 
         <DialogFooter>

--- a/src/features/operator/curricula/components/RegisterCurriculumDialog.tsx
+++ b/src/features/operator/curricula/components/RegisterCurriculumDialog.tsx
@@ -14,7 +14,7 @@ import { Input } from '@/components/ui/Input'
 import { Spinner } from '@/components/ui/Spinner'
 import { useQueryClient } from '@tanstack/react-query'
 import { registerCurriculum, tooLargeToUpload, MAX_UPLOAD_LABEL } from '@/api/uploads'
-import { useRequestAnalysis } from '@/api/curriculum/useCurriculumMutations'
+import { requestAnalysis } from '@/api/curriculum/curriculumApi'
 import { curriculumKeys } from '@/api/curriculum/curriculumKeys'
 import { isApiError } from '@/api/_contract'
 import { errorCopy } from '@/lib/errorCopy'
@@ -70,9 +70,10 @@ export default function RegisterCurriculumDialog({ open, onOpenChange }: Props) 
     문구를 정하고, 제목 중복은 아래에서 입력란까지 짚는다.
   */
   const [failed, setFailed] = useState<unknown>(null)
+  /** 진행 중인 등록·분석 요청 — 닫으면서 취소할 수 있게 들고 있는다 */
+  const submitAbortRef = useRef<AbortController | null>(null)
 
   const queryClient = useQueryClient()
-  const requestAnalysis = useRequestAnalysis()
 
   /*
     ⚠ **크기는 서버가 아니라 앞단(Lambda)이 막는다** — 그리고 그 실패는 우리 에러 코드가
@@ -93,9 +94,18 @@ export default function RegisterCurriculumDialog({ open, onOpenChange }: Props) 
     setName('')
     setFailed(null)
     setAnalysisFailed(false)
+    // pending 상태에서 닫혔을 수 있다 — 닫혔다 다시 열었을 때 스피너가 안 남게 같이 지운다
+    setSubmitting(false)
   }
 
+  /*
+    **닫으면 진행 중인 요청을 취소한다.** 등록·분석은 이어지는 두 번의 호출이라(아래
+    `submit` 주석), 업로드나 분석 요청이 도는 중에 닫으면(X·ESC·바깥 클릭) 그대로 뒀을 때
+    뒤늦게 도착한 응답이 이미 리셋된 다이얼로그 상태(`failed`·`analysisFailed`)를 다시
+    채울 수 있다 — `AddRosterDialog`가 같은 이유로 먼저 고친 것과 같은 문제다.
+  */
   const close = (next: boolean) => {
+    if (!next) submitAbortRef.current?.abort()
     onOpenChange(next)
     if (!next) reset()
   }
@@ -105,10 +115,19 @@ export default function RegisterCurriculumDialog({ open, onOpenChange }: Props) 
     setSubmitting(true)
     setFailed(null)
     setAnalysisFailed(false)
+    const controller = new AbortController()
+    submitAbortRef.current = controller
     try {
-      const created = await registerCurriculum({ query: { title: name.trim() }, file })
+      const created = await registerCurriculum({
+        query: { title: name.trim() },
+        file,
+        signal: controller.signal,
+      })
       try {
-        await requestAnalysis.mutateAsync({ path: { materialId: created.materialId } })
+        await requestAnalysis({
+          path: { materialId: created.materialId },
+          signal: controller.signal,
+        })
       } catch (e) {
         /*
           ⚠ **「이미 분석 중」은 실패가 아니다 — 우리가 원하던 그 상태다.**
@@ -126,6 +145,8 @@ export default function RegisterCurriculumDialog({ open, onOpenChange }: Props) 
           그래서 이 호출을 지우지 않는다: 서버가 자동으로 안 걸어 주는 경로가 남아 있어도
           여기서 채운다. 이미 돌고 있으면 그대로 성공으로 친다.
         */
+        // 닫으면서 우리가 취소한 것 — 이미 닫힌 다이얼로그에 실패를 띄울 필요는 없다
+        if (controller.signal.aborted) return
         if (!(isApiError(e) && e.code === 'CURRICULUM_ANALYSIS_IN_PROGRESS')) {
           // 교안은 올라갔다 — 목록에서 `다시 분석`으로 이어갈 수 있다
           setAnalysisFailed(true)
@@ -136,10 +157,13 @@ export default function RegisterCurriculumDialog({ open, onOpenChange }: Props) 
       await queryClient.invalidateQueries({ queryKey: curriculumKeys.all })
       close(false)
     } catch (e) {
+      // 닫으면서 우리가 취소한 것 — 이미 닫힌 다이얼로그에 실패를 띄울 필요는 없다
+      if (controller.signal.aborted) return
       // 원본을 그대로 둔다 — 문구는 `errorCopy`가 코드로 정한다(아래 배너)
       setFailed(e)
     } finally {
       setSubmitting(false)
+      submitAbortRef.current = null
     }
   }
 
@@ -256,8 +280,8 @@ export default function RegisterCurriculumDialog({ open, onOpenChange }: Props) 
           </Field>
 
           <p className="text-fg-subtle text-xs">
-            등록하면 분석이 시작됩니다. 분석이 끝나야 <b>가르친 항목</b>이 나오고, 그 전에는
-            프로젝트에 연결할 수 없습니다.
+            등록하면 분석이 시작됩니다. 분석이 끝난 후 <b>가르친 항목</b>이 생성됩니다.
+            <br />그 전까지는 프로젝트에 연결할 수 없습니다.
           </p>
         </div>
 


### PR DESCRIPTION
## 작업 내용

* `RosterCsvField.tsx` — CSV 인코딩 판정에 실패해도(UTF-8·CP949 둘 다 아님) 버튼의 파일명이 갱신되지 않던 버그 수정, 업로드 안내문 재문구화
* `RegisterCurriculumDialog.tsx` — PDF 업로드·분석 요청이 진행 중일 때 다이얼로그를 닫아도 요청이 취소되지 않던 문제 수정(`AbortController` 추가, `AddRosterDialog.tsx`와 같은 패턴), 하단 안내문 재문구화
* `AddRosterDialog.tsx`, `DeleteCurriculumDialog.tsx` — 어색했던 안내 문구 재작성

## 리뷰 포인트

* `RegisterCurriculumDialog.tsx`에서 `useRequestAnalysis` 훅 대신 원본 `requestAnalysis` API 함수를 직접 호출하도록 바꿨습니다 — 훅의 `mutateAsync`가 `signal`을 못 받는 타입이라 취소 지원을 넣으려면 이 경로가 필요했습니다. 쿼리 무효화(`invalidateQueries`)는 기존처럼 컴포넌트가 직접 하고 있어서 동작 손실은 없습니다.
* 문구 변경 4건은 기능 변화 없이 텍스트만 바뀐 것입니다.

## 확인

- [x] 로컬에서 동작 확인 (CSV 등록·교안 등록 정상, 제출 중 닫기 시 요청 취소·낡은 에러 배너 미노출 확인)
- [x] 하나의 PR = 하나의 기능

closes #256