### PR TITLE
[Feat] Rebrand Wordmark to RealiZe (RZ Badge)

### DIFF
--- a/src/components/common/Wordmark.tsx
+++ b/src/components/common/Wordmark.tsx
@@ -1,6 +1,9 @@
 /*
-  브랜드 마크 — ◆ + "IZ-Get". 인증 화면(BrandPanel)과 콘솔 셸(Topbar) 양쪽에서
-  같은 로고를 쓰므로 공용으로 둔다. 한 군데서만 고치면 둘 다 바뀐다.
+  브랜드 마크 — "RZ" 배지 + "RealiZe" 워드마크. 인증 화면(BrandPanel)과 콘솔 셸(Topbar)
+  양쪽에서 같은 로고를 쓰므로 공용으로 둔다. 한 군데서만 고치면 둘 다 바뀐다.
+
+  "RealiZe"는 R·Z만 대문자 크기(text-[15px], 부모에서 상속) 그대로 두고 나머지
+  소문자(eali·e)는 text-[12px]로 살짝 줄여 R과 Z가 도드라지게 한다.
 */
 export default function Wordmark({ light = false }: { light?: boolean }) {
   return (
@@ -8,9 +11,11 @@ export default function Wordmark({ light = false }: { light?: boolean }) {
       className={`flex items-center gap-2 text-[15px] font-bold ${light ? 'text-white' : 'text-fg'}`}
     >
       <span className="inline-flex h-[26px] w-[26px] items-center justify-center rounded-sm bg-primary text-[13px] text-white">
-        IZ
+        RZ
       </span>
-      IZ-Get
+      <span>
+        R<span className="text-[12px]">eali</span>Z<span className="text-[12px]">e</span>
+      </span>
     </div>
   )
 }


### PR DESCRIPTION
## 작업 내용
- Wordmark.tsx 배지 "IZ"→"RZ", 텍스트 "IZ-Get"→"RealiZe"로 교체
- RealiZe의 소문자(eali·e)를 12px로 줄여 R·Z가 도드라지게 함

## 리뷰 포인트
- BrandPanel(로그인 계열)과 Header(콘솔) 양쪽 렌더 확인 — `npm run dev`로 직접 볼 것
- 배지(26×26, 13px)에 "RZ" 두 글자가 잘리지 않는지 확인

closes #267 