### PR TITLE
[Fix] curriculum upload warm-up race

### DIFF
--- a/src/api/uploads.ts
+++ b/src/api/uploads.ts
@@ -96,11 +96,28 @@ export const previewTraineesFromCsv = (params: CsvUpload) =>
  * AWS 자체 6MB 동기 페이로드 상한이 있어 그 이상은 413(실측) — App Runner origin 도메인으로
  * 직접 보내 우회한다(Backend PR #87의 `AiCurriculumClient` 패턴 미러링). origin은 PAUSED
  * 상태를 스스로 못 깨우므로, 실제 업로드 전에 `izClient`로 가벼운 GET을 먼저 보내 깨운다.
+ *
+ * **웜업 결과를 확인한다.** 예전엔 `.catch(() => {})`로 웜업 실패를 통째로 무시하고 바로
+ * origin에 업로드를 쐈다 — App Runner가 아직 준비 안 된 순간(PAUSED에서 막 깨어나는 중 등)에
+ * 이 레이스가 걸리면 origin 요청이 그대로 실패했다(도메인 코드 없는 500이 실측됨, 2026-08-18).
+ * 그래서 웜업을 최대 3회(2초 간격)까지 재시도하고, 그래도 안 깨어나면 origin에 아예 안 쏘고
+ * 에러를 던진다 — 실패를 조용히 삼키는 대신 화면이 재시도를 안내할 근거를 준다.
  */
+const WARMUP_RETRIES = 3
+const WARMUP_RETRY_DELAY_MS = 2000
+
 export const registerCurriculum = async (
   params: { query: { title: string; topic?: string }; file: File } & RequestOptions,
 ) => {
-  await izClient.GET('/api/v0/members/me', { signal: params.signal }).catch(() => {})
+  let warmed = false
+  for (let attempt = 0; attempt < WARMUP_RETRIES && !warmed; attempt++) {
+    if (attempt > 0) await new Promise((resolve) => setTimeout(resolve, WARMUP_RETRY_DELAY_MS))
+    const { error } = await izClient.GET('/api/v0/members/me', { signal: params.signal })
+    warmed = !error
+  }
+  if (!warmed) {
+    throw new Error('서버를 깨우지 못했습니다. 잠시 후 다시 시도해주세요.')
+  }
   return unwrap<RegisterCurriculumResponse>(
     izOriginClient.POST('/api/v0/curricula', {
       params: { query: params.query },


### PR DESCRIPTION
## Summary
- `registerCurriculum`이 App Runner 웜업 GET(`izClient`) 결과를 `.catch(() => {})`로 무시하고 바로 origin 직결 PDF 업로드를 쐈음 — 인스턴스가 아직 준비 안 된 순간에 레이스가 걸리면 등록이 500으로 실패
- 웜업을 최대 3회(2초 간격) 재시도하도록 변경, 그래도 실패하면 origin 업로드 없이 명확한 에러를 던짐

## Context
2026-08-18 도쿄 dev 서버에서 교안 등록/분석 500 에러를 조사하며 발견. DB 조회로 확인된 등록 성공/실패가 몇 분 간격으로 오락가락하는 패턴과 부합.

## Test plan
- [x] `tsc -b` 타입체크 통과
- [x] `oxlint` / `prettier --check` 통과
- [x] `git push` pre-push 훅(CI 재현) 전항목 통과
- [ ] 실제 dev 서버 배포 후 PAUSED 직후 등록 재현 테스트