### PR TITLE
[Style] Nudge Wordmark Baseline

### DIFF
--- a/src/components/common/Wordmark.tsx
+++ b/src/components/common/Wordmark.tsx
@@ -13,7 +13,7 @@ export default function Wordmark({ light = false }: { light?: boolean }) {
       <span className="inline-flex h-[26px] w-[26px] items-center justify-center rounded-sm bg-primary text-[13px] text-white">
         RZ
       </span>
-      <span>
+      <span className="relative top-[0.75px]">
         R<span className="text-[12px]">eali</span>Z<span className="text-[12px]">e</span>
       </span>
     </div>


### PR DESCRIPTION
## 작업 내용

Wordmark 컴포넌트의 "RealiZe" 텍스트를 RZ 배지 밑선 쪽으로 0.75px 내려
시각적 정렬을 맞췄다. 로직 변경 없음, 순수 CSS(top offset) 조정.

## 리뷰 포인트

- 값(0.75px)이 과하거나 부족해 보이면 조정 가능 — 완전히 밑선을 맞추면
  오히려 처져 보여서 중간보다 살짝 덜 내리는 선으로 잡았다.
- BrandPanel(인증 화면)과 Header(콘솔 헤더) 양쪽에 공용으로 쓰이므로
  두 배경(라이트/다크)에서 다 확인해달라.

## 확인

- [x] 로컬에서 동작 확인
- [x] 하나의 PR = 하나의 기능
