### PR TITLE
[Fix] curriculum delete detail refetch race

### DIFF
--- a/src/features/operator/curricula/components/DeleteCurriculumDialog.tsx
+++ b/src/features/operator/curricula/components/DeleteCurriculumDialog.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import {
   Dialog,
   DialogContent,
@@ -10,6 +11,7 @@ import { Alert, AlertTitle, AlertDescription } from '@/components/ui/Alert'
 import { Button } from '@/components/ui/Button'
 import { Spinner } from '@/components/ui/Spinner'
 import { useDeleteCurriculum } from '@/api/curriculum/useCurriculumMutations'
+import { curriculumKeys } from '@/api/curriculum/curriculumKeys'
 import { errorCopy } from '@/lib/errorCopy'
 
 /*
@@ -37,7 +39,22 @@ export default function DeleteCurriculumDialog({
   onDeleted: () => void
 }) {
   const [failed, setFailed] = useState<unknown>(null)
-  const remove = useDeleteCurriculum()
+  const queryClient = useQueryClient()
+  /*
+    **기본 onSuccess(전체 무효화)가 방금 지운 상세를 다시 불러 404를 냈다**(실측,
+    2026-08-19). 이 다이얼로그는 상세 화면(`CurriculumDetailScreen`)에서 뜨는데,
+    `onDeleted`의 `navigate()`가 아직 안 돈 시점에 `invalidateQueries(curriculumKeys.all)`가
+    먼저 실행돼 여전히 마운트된 `useFindCurriculum({ materialId })`를 재조회시킨다.
+    무효화 자체는 놔두고(다른 목록·프로젝트 쿼리는 새로고침돼야 한다), 이 상세 쿼리만
+    캐시에서 제거해 재조회 대상에서 뺀다.
+  */
+  const remove = useDeleteCurriculum({
+    onSuccess: () => {
+      queryClient.removeQueries({
+        queryKey: curriculumKeys.findCurriculum({ path: { materialId } }),
+      })
+    },
+  })
 
   const run = async () => {
     setFailed(null)


### PR DESCRIPTION
## Summary
- `CurriculumDetailScreen`에서 교안 삭제 시, `useDeleteCurriculum`의 기본 `onSuccess`(`invalidateQueries(curriculumKeys.all)`)가 `onDeleted`의 `navigate()`보다 먼저 실행됨
- 이 시점에 화면은 아직 마운트돼 있어 `useFindCurriculum({ materialId })`가 여전히 활성 쿼리 → 방금 삭제한 교안을 자동 재조회 → 서버는 이미 지운 상태라 404
- `DeleteCurriculumDialog`의 `useDeleteCurriculum` 호출에 `onSuccess`를 추가해 해당 상세 쿼리만 캐시에서 `removeQueries`로 제거(재조회 대상에서 제외). 다른 도메인 쿼리(목록 등)의 무효화는 그대로 유지

## Context
2026-08-19 도쿄 dev 서버에서 `CURRICULUM_MATERIAL_NOT_FOUND`가 반복 관측되던 것을 진단 로깅(#145)으로 원인 추적. DB 대조 결과 매 404가 같은 material의 `deleted_at`보다 1~2초 뒤에 발생 — "죽은 링크"나 오래된 배포가 아니라 삭제할 때마다 매번 한 번씩 나던 원샷 레이스였음.

## Test plan
- [x] `tsc -b` 타입체크 통과
- [x] `oxlint` / `prettier --check` 통과
- [x] `git push` pre-push 훅(CI 재현) 전항목 통과
- [ ] 배포 후 실제 삭제 플로우에서 404 로그 재발 안 하는지 확인