### PR TITLE
Fix stale session cache stranding users on broken pages

### DIFF
--- a/src/features/auth/authStore.ts
+++ b/src/features/auth/authStore.ts
@@ -21,8 +21,10 @@
   자동으로 재시도**한다 — 세션 복원을 위한 별도 코드가 없는 이유다.
 */
 import { create } from 'zustand'
+import type { QueryClient } from '@tanstack/react-query'
 import { ApiError, connectAuth, type RefreshResult, type SessionEndReason } from '@/api/_contract'
 import { refresh as refreshApi } from '@/api/auth/authApi'
+import { memberKeys } from '@/api/member/memberKeys'
 import type { Role } from './authTypes'
 
 /**
@@ -73,8 +75,15 @@ export const getAccessToken = () => useAuthStore.getState().accessToken
  *
  * 한 번으로 끝나는 것이 스토어를 쓴 이유다 — 토큰이 React 상태였을 때는 세션이 바뀔 때마다
  * 다시 꽂아야 했고, 그 재주입이 "옛 값에 갇힌다"는 문제의 증상이었다.
+ *
+ * `queryClient`를 받는 이유 — `onSessionExpired`가 `accessToken`만 지우고 `/me` 캐시를
+ * 그대로 두면, `RequireRole`은 캐시된(stale이어도 값은 남아있는) `user`만 보고 로그인
+ * 화면으로 안 보낸다. 그 사이 다른 화면은 진짜 401을 맞아 깨진 채로 방치된다(실측,
+ * 2026-08-19 — 리프레시 토큰 만료 후 헤더는 로그인 상태를 계속 보여주는데 홈 화면은
+ * "불러오지 못했습니다"만 반복). `/me` 캐시를 여기서 지워야 `user`가 `null`이 되고
+ * `RequireRole`이 정상적으로 리다이렉트한다.
  */
-export function connectSession() {
+export function connectSession(queryClient: QueryClient) {
   connectAuth({
     getToken: getAccessToken,
 
@@ -94,6 +103,11 @@ export function connectSession() {
       }
     },
 
-    onSessionExpired: (reason) => useAuthStore.getState().clear(reason),
+    onSessionExpired: (reason) => {
+      useAuthStore.getState().clear(reason)
+      // invalidate가 아니라 remove다 — invalidate는 재조회가 끝날 때까지 옛 data를
+      // 그대로 들고 있어서 그 사이 `user`가 계속 참이다. remove는 즉시 비운다.
+      queryClient.removeQueries({ queryKey: memberKeys.getCurrentMember() })
+    },
   })
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -27,8 +27,6 @@ import './index.css'
   `<Toaster />` — sonner의 렌더 타깃. 어디서든 `toast.success(...)`를 부를 수 있게 여기 한 번만
   심는다. 화면이 각자 심으면 그 화면을 안 거친 라우트에서 부른 toast는 아무 데도 안 뜬다.
 */
-connectSession()
-
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
@@ -84,6 +82,12 @@ const queryClient = new QueryClient({
   이유와 대상은 `api/traineeFreshness.ts`에 있다.
 */
 applyTraineeFreshness(queryClient)
+
+/*
+  `queryClient` 생성 뒤로 옮겼다 — `connectSession`이 세션 종료 시 `/me` 캐시를 지우려면
+  같은 `queryClient` 인스턴스가 필요하다(`authStore.ts` 참고).
+*/
+connectSession(queryClient)
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>


### PR DESCRIPTION
## Summary
- `onSessionExpired`가 Zustand `accessToken`만 지우고 React Query에 캐시된 `GET /members/me`는 그대로 둠
- `RequireRole`은 이 캐시된 `user` 값만 보고 로그인 화면 리다이렉트 여부를 판단하는데, 캐시가 살아있으니 세션이 실제로 끝나도 리다이렉트가 안 됨
- 결과: 헤더는 계속 로그인 상태를 보여주는데, 다른 화면들은 실제 401을 맞아 "불러오지 못했습니다"만 반복 — "다시 시도"를 눌러도 같은 401이 반복될 뿐 안 고쳐짐
- `connectSession`이 `queryClient`를 받도록 바꾸고, `onSessionExpired`에서 `getCurrentMember` 쿼리를 `removeQueries`로 즉시 비움(`invalidateQueries`가 아닌 이유: invalidate는 재조회 끝날 때까지 옛 data를 그대로 보여줘서 `user`가 계속 참으로 남음)

## Context
2026-08-19 스크린샷 제보로 발견: 교육생이 `/trainee/home`에서 헤더엔 로그인 상태(`손지안·교육생`)가 그대로 뜨는데 홈 컨텐츠는 "홈을 불러오지 못했습니다"만 반복. 백엔드 로그 대조 결과 `REFRESH_TOKEN_INVALID`가 직전에 찍혀 있어, 리프레시 토큰 만료 후 캐시 무효화 누락이 원인으로 확인됨.

## Test plan
- [x] `tsc -b` 타입체크 통과
- [x] `oxlint` / `prettier --check` 통과
- [x] `git push` pre-push 훅(CI 재현) 전항목 통과
- [ ] 배포 후 실제로 리프레시 토큰 만료 시나리오에서 로그인 화면으로 정상 리다이렉트되는지 확인