### PR TITLE
[Fix] Keep Cohort Scope Across Sidebar Navigation

### DIFF
--- a/src/shells/Sidebar.tsx
+++ b/src/shells/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { NavLink } from 'react-router'
+import { NavLink, useSearchParams } from 'react-router'
 import type { SidebarGroup } from './sidebarConfig'
 
 /*
@@ -19,6 +19,18 @@ type Props = {
 }
 
 export default function Sidebar({ sidebar }: Props) {
+  /*
+    **고른 기수는 주소가 갖는다**(`stores/cohortScope.ts`) — 사이드바 이동도 예외가
+    아니다. `item.to`는 순수 경로 문자열이라 그대로 쓰면 `?cohort=`가 떨어져 나가고,
+    다음 화면은 주소에 기수가 없다고 보고 기본값(진행 중 기수)으로 되돌아간다 —
+    탭을 오갈 때마다 기수가 튀던 버그가 이래서 났다. 슈퍼어드민·교육생처럼 기수가
+    없는 역할은 애초에 주소에 `cohort`가 안 실리니 그대로 통과한다(역할별 분기를
+    여기 새로 두지 않는다).
+  */
+  const [params] = useSearchParams()
+  const cohort = params.get('cohort')
+  const cohortSuffix = cohort ? `?${new URLSearchParams({ cohort }).toString()}` : ''
+
   return (
     <nav
       aria-label="주요 메뉴"
@@ -30,7 +42,7 @@ export default function Sidebar({ sidebar }: Props) {
           {group.map((item) => (
             <NavLink
               key={item.to}
-              to={item.to}
+              to={`${item.to}${cohortSuffix}`}
               className={({ isActive }) =>
                 [
                   'mb-0.5 flex items-center gap-2 rounded-md px-3 py-[9px] text-sm',

--- a/src/stores/cohortScope.ts
+++ b/src/stores/cohortScope.ts
@@ -46,11 +46,20 @@ export type CohortScope = {
  *
  * (이슈 277 — admin/_/cohortScope.ts의 `pickDefault`를 그대로 흡수했다. 전에는 이
  * 훅이 `RUNNING > 첫 기수` 2단이라 운영 관리 탭과 다른 값을 고를 수 있었다.)
+ *
+ * **같은 상태 안에서는 가장 최근에 시작한 기수를 고른다.** 서버 응답에 생성일이
+ * 따로 없다 — 있는 시간 필드는 `startDate`(기수 시작일)뿐이라 그것으로 근사한다.
+ * 지금은 RUNNING이 보통 하나뿐이라 차이가 안 보이지만, 여러 기수가 동시에 진행
+ * 중일 때 목록에 먼저 온 것이 아니라 **가장 최근에 시작한 기수**가 열려야 한다.
  */
+function newestFirst(cohorts: readonly Cohort[]): Cohort[] {
+  return [...cohorts].sort((a, b) => (b.startDate ?? '').localeCompare(a.startDate ?? ''))
+}
+
 function pickDefault(cohorts: readonly Cohort[]): Cohort | undefined {
   return (
-    cohorts.find((c) => c.status === 'RUNNING') ??
-    cohorts.find((c) => c.status === 'PLANNED') ??
+    newestFirst(cohorts.filter((c) => c.status === 'RUNNING'))[0] ??
+    newestFirst(cohorts.filter((c) => c.status === 'PLANNED'))[0] ??
     cohorts[0]
   )
 }


### PR DESCRIPTION
## 작업 요약

- 사이드바 메뉴 이동 시 URL의 `?cohort=` 파라미터가 사라져 기수 스코프가 기본값(진행 중 기수)으로 리셋되던 버그 수정 (`src/shells/Sidebar.tsx`)
- 기본 기수 선택 로직(`pickDefault`, `src/stores/cohortScope.ts`)이 같은 상태(RUNNING/PLANNED) 안에 기수가 여럿일 때 `startDate` 기준으로 가장 최근 것을 고르도록 보강

## 리뷰 포인트

- `Sidebar.tsx`: `useSearchParams()`로 읽은 `cohort` 값을 모든 `NavLink to`에 그대로 이어붙이는 방식이 맞는지 — 역할별 분기 없이 전역 적용했습니다(기수 없는 슈퍼어드민·교육생은 애초에 파라미터가 없어 영향 없음)
- `cohortScope.ts`: 서버 응답에 생성일 필드가 없어 `startDate`(기수 시작일)를 생성일의 근사치로 썼습니다 — 이 판단에 동의하시는지
- 사이드바 외 다른 진입점(헤더 로고 등)이 `?cohort=`를 놓치는지는 이번 범위에서 확인 안 했습니다

## 테스트

- [ ] 오퍼레이터/매니저 첫 진입 시 진행 중 기수가 기본으로 열린다
- [ ] 상단 스위처로 기수 변경 후 사이드바의 다른 메뉴를 클릭해도 기수가 유지된다
- [ ] `npm run build` · `npm run lint` 통과

closes #281 