### PR TITLE
[Feat] Split Manager and Operator Dev Login Accounts by Owner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,10 @@ VITE_API_ORIGIN_BASE=https://mmbvymzj5k.ap-northeast-1.awsapprunner.com
 #    없다). 배포 화면에서도 목록을 보려면 스크립트가 함께 만드는 dev-accounts.env 한 줄을
 #    호스팅 환경변수에 넣는다 — 값은 위 JSON과 같은 내용이고, 파일이 있으면 파일이 이긴다.
 # VITE_CASE_ACCOUNTS={"measuredAt":"...","groups":[...]}
+
+# 매니저·오퍼레이터를 팀원별로 나눈 계정 — 위 VITE_CASE_ACCOUNTS와 형태는 같지만
+# scripts/dev-accounts.mjs가 절대 건드리지 않는 별도 파일/변수다(교육생 엑셀을 다시
+# 돌려도 안 사라짐). 로컬은 dev-team-accounts.json(직접 작성, gitignore 대상), 배포는
+# 아래 한 줄을 Vercel 환경변수에 넣는다. className·teamName은 해당 없으면 ""로 둔다.
+# 담당자(owner) 이름은 VITE_CASE_ACCOUNTS의 담당자 목록과 같은 표기를 써야 필터가 합쳐진다.
+# VITE_TEAM_ACCOUNTS={"groups":[{"label":"매니저","hint":null,"total":1,"accounts":[{"email":"...","password":"...","name":"매니저용","className":"","teamName":"","note":null,"owner":"강민수"}]}]}

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ docs/dev/portfolio-security-notes.md
 # .env는 같은 내용을 Vercel 환경변수에 붙여 넣을 한 줄이다
 dev-accounts.json
 dev-accounts.env
+
+# 매니저·오퍼레이터 담당자별 계정 — 손으로 관리한다(스크립트가 안 건드림, quickLoginAccounts.ts 참고)
+dev-team-accounts.json

--- a/src/features/auth/components/CaseAccountPicker.tsx
+++ b/src/features/auth/components/CaseAccountPicker.tsx
@@ -13,7 +13,7 @@ import {
 const ALL = '전체'
 
 /*
-  dev 전용 — 교육생 **상태별** 테스트 계정 고르개.
+  dev 전용 — 케이스(교육생 상태별 · 매니저/오퍼레이터 담당자별) 테스트 계정 고르개.
 
   ## 왜 접어 두나
   계정이 수십 개다. 펼쳐 둔 채로 로그인 화면에 놓으면 원래 있어야 할 것(역할 버튼 넷,
@@ -83,7 +83,7 @@ export default function CaseAccountPicker({
           className={cn('size-3 shrink-0 transition-transform', open && 'rotate-90')}
         />
         <span className="flex-1 text-left">
-          교육생 케이스별 계정 <span className="text-fg-subtle">{CASE_ACCOUNT_TOTAL}개</span>
+          케이스별 계정 <span className="text-fg-subtle">{CASE_ACCOUNT_TOTAL}개</span>
         </span>
         <span>{open ? '접기' : '펼치기'}</span>
       </button>

--- a/src/features/auth/quickLoginAccounts.ts
+++ b/src/features/auth/quickLoginAccounts.ts
@@ -4,20 +4,24 @@
   역할 선택 UI는 정책상 화면에 없다(LoginScreen 주석). 이건 **폼을 우회하는 지름길**일 뿐,
   서버가 역할을 판정하는 로그인 흐름 자체는 그대로 재사용한다.
 
-  ## 두 갈래로 들어온다
+  ## 세 갈래로 들어온다
 
   | | 어디서 | 무엇 |
   |---|---|---|
-  | **역할 버튼** | `.env.local`의 `VITE_DEV_ACCOUNTS` | 역할별 대표 계정 몇 개 |
+  | **역할 버튼** | `.env.local`의 `VITE_DEV_ACCOUNTS` | 역할별 대표 계정 몇 개(담당자 구분 없음) |
   | **상태별 목록** | `dev-accounts.json` | 교육생 상태별 테스트 계정 수십 개 |
+  | **담당자별 목록** | `dev-team-accounts.json` | 매니저·오퍼레이터를 팀원별로 나눈 계정 |
 
-  나눈 이유는 **수와 수명이 다르다.** 앞은 손으로 관리하는 소수이고, 뒤는 백엔드가 준
-  엑셀에서 스크립트로 만든 것이라(`scripts/dev-accounts.mjs`) 엑셀이 갱신되면 통째로
-  다시 만든다. 한 곳에 섞으면 손으로 넣은 것이 재생성 때 날아간다.
+  나눈 이유는 **수와 수명이 다르다.** 역할 버튼은 손으로 관리하는 소수이고, 상태별
+  목록은 백엔드가 준 엑셀에서 스크립트로 만든 것이라(`scripts/dev-accounts.mjs`) 엑셀이
+  갱신되면 통째로 다시 만든다. 담당자별 목록도 손으로 관리하지만 상태별 목록과 같은
+  파일에 두면 스크립트가 재생성할 때 같이 날아가므로 파일을 분리했다(자세한 이유는
+  `readTeamData` 주석). 셋 다 같은 담당자 필터 UI(`CaseAccountPicker`)를 함께 쓴다 —
+  상태별·담당자별 목록은 형태가 같아서(`CaseData`) 그룹만 합친다.
 
   ## 자격 증명을 저장소에 두지 않는다
 
-  둘 다 gitignore 대상이다. **없으면 UI가 아예 안 나온다** — 기능이 조용히 반쯤
+  셋 다 gitignore 대상이다. **없으면 UI가 아예 안 나온다** — 기능이 조용히 반쯤
   동작하는 것보다 없는 편이 낫다.
 
   화면 노출은 이 파일이 아니라 호출부가 막는다(`import.meta.env.DEV || __GIT_BRANCH__`).
@@ -25,7 +29,11 @@
 */
 export type QuickLoginAccount = { label: string; email: string; password: string }
 
-/** 교육생 테스트 계정 하나 — 어느 반·팀 누구인지까지 보여줘야 고를 수 있다 */
+/**
+ * 케이스 계정 하나. 교육생은 어느 반·팀 누구인지까지 보여줘야 고를 수 있고,
+ * 매니저·오퍼레이터처럼 반·팀이 없는 역할은 `className`·`teamName`을 빈 문자열로 둔다
+ * (표시부는 빈 값을 알아서 건너뛴다).
+ */
 export type CaseAccount = {
   email: string
   password: string
@@ -119,8 +127,32 @@ function readCaseData(): CaseData {
 
 const caseData = readCaseData()
 
-function readCaseGroups(): CaseGroup[] {
-  const groups = caseData.groups
+/*
+  매니저·오퍼레이터 담당자별 계정 — **스크립트가 안 건드리는** 별도 소스.
+  위 `dev-accounts.json`은 교육생 엑셀을 다시 돌릴 때마다 통째로 새로 써진다(스크립트
+  자체 동작). 매니저/오퍼레이터를 그 파일 안에 손으로 끼워 넣으면 다음 재생성 때
+  조용히 사라진다 — 그래서 파일을 분리한다. 같은 `CaseData` 모양이라 그룹만 합친다.
+*/
+const teamModules = import.meta.glob<CaseData>('/dev-team-accounts.json', { eager: true })
+
+function readTeamData(): CaseData {
+  const fromFile = Object.values(teamModules)[0]
+  if (Array.isArray(fromFile?.groups)) return fromFile
+
+  const raw = import.meta.env.VITE_TEAM_ACCOUNTS
+  if (!raw) return {}
+  try {
+    return JSON.parse(raw) as CaseData
+  } catch (e) {
+    console.warn('[dev] VITE_TEAM_ACCOUNTS를 읽지 못했습니다', e)
+    return {}
+  }
+}
+
+const teamData = readTeamData()
+
+function readGroups(data: CaseData): CaseGroup[] {
+  const groups = data.groups
   if (!Array.isArray(groups)) return []
   return groups.filter(
     (g): g is CaseGroup =>
@@ -128,7 +160,7 @@ function readCaseGroups(): CaseGroup[] {
   )
 }
 
-export const CASE_ACCOUNT_GROUPS = readCaseGroups()
+export const CASE_ACCOUNT_GROUPS = [...readGroups(caseData), ...readGroups(teamData)]
 
 /**
  * 이 목록의 상태를 **언제 쟀나**.
@@ -145,7 +177,9 @@ export const CASE_ACCOUNT_MEASURED_AT = caseData.measuredAt ?? null
  * 계정을 훑어 모으지 않고 스크립트가 낸 값을 그대로 쓴다. 렌더마다 194개를 도는 것도
  * 아깝고, **순서가 화면마다 흔들리면** 어제 눌렀던 자리에 다른 이름이 온다.
  */
-export const CASE_ACCOUNT_OWNERS = caseData.owners ?? []
+export const CASE_ACCOUNT_OWNERS = [
+  ...new Set([...(caseData.owners ?? []), ...(teamData.owners ?? [])]),
+]
 
 /** 고른 계정 총수 — 토글 라벨이 "N개"를 말하려면 필요하다 */
 export const CASE_ACCOUNT_TOTAL = CASE_ACCOUNT_GROUPS.reduce((n, g) => n + g.accounts.length, 0)


### PR DESCRIPTION
## 작업 내용

* 매니저·오퍼레이터 dev 로그인 계정을 팀원 담당자별로 나눠 볼 수 있는 별도 소스
  (`dev-team-accounts.json` / 배포용 `VITE_TEAM_ACCOUNTS`)를 추가했다.
* 교육생이 쓰던 `CaseAccount`/`CaseGroup` 구조와 `CaseAccountPicker`(담당자 필터 UI)를
  그대로 재사용한다 — 새 컴포넌트나 타입 변경 없음.
* `dev-accounts.json`과 파일을 분리했다 — 그 파일은 교육생 엑셀을 다시 돌릴 때마다
  스크립트가 통째로 재생성하므로 같이 두면 손으로 넣은 값이 날아간다.
* `CaseAccountPicker`의 "교육생 케이스별 계정" 라벨을 "케이스별 계정"으로 일반화.

## 리뷰 포인트

* `quickLoginAccounts.ts`의 `readTeamData`/그룹 병합 로직 — `dev-accounts.json`을
  읽는 기존 `readCaseData`와 같은 모양(`CaseData`)이라 그룹만 이어 붙이는 방식이 맞는지.
* `CASE_ACCOUNT_OWNERS`를 두 소스 합쳐 중복 제거(`Set`)하는 방식 — 교육생 담당자
  이름과 매니저·오퍼레이터 담당자 이름 표기가 같아야 필터가 합쳐짐(문서화함).
* `dev-team-accounts.json`은 실제 계정 자격 증명이 들어가 `.gitignore` 대상이라
  이 PR에는 데이터 파일 자체가 없다. 로컬 검증은 각자 파일을 채워 넣어야 한다.

## 확인

- [x] 로컬에서 동작 확인 (`tsc --noEmit`, `npm run verify:ci` 상당 — 브라우저 렌더는
      다른 세션이 화면 브라우저를 점유해 확인 못함, 코드 리뷰로 대신 부탁)
- [x] 하나의 PR = 하나의 기능

closes #283
