### PR TITLE
[Fix] Unify Back Button Style and Restore Project Detail Breadcrumb

### DIFF
--- a/src/features/manager/projects/ProjectDetailScreen.tsx
+++ b/src/features/manager/projects/ProjectDetailScreen.tsx
@@ -1,5 +1,6 @@
 import { useParams, useNavigate, useSearchParams } from 'react-router'
 import ConsoleShell from '@/shells/ConsoleShell'
+import PageHeader from '@/components/common/PageHeader'
 import { Button } from '@/components/ui/Button'
 import { Empty, EmptyHeader, EmptyTitle, EmptyDescription } from '@/components/ui/Empty'
 import { Skeleton } from '@/components/ui/Skeleton'
@@ -50,7 +51,7 @@ export default function ProjectDetailScreen() {
   const { id = '' } = useParams()
   const navigate = useNavigate()
   const [params, setParams] = useSearchParams()
-  const { cohortId, cohorts, selectCohort } = useManagerCohort()
+  const { cohortId, cohortName, cohorts, selectCohort } = useManagerCohort()
 
   const project = useProject(id)
   const submission = useSubmissionStatus(id)
@@ -124,6 +125,16 @@ export default function ProjectDetailScreen() {
 
   return shell(
     <>
+      {/*
+        교안 상세(MG-09)와 같은 패턴 — 헤더에 breadcrumb(경로)이 없어져 있던 것을 복구한다.
+        h1은 여기(sr-only)가 갖고, DetailHeader의 제목은 span으로 눈에 보이는 큰 글씨만 낸다.
+      */}
+      <div className="[&_h1]:sr-only">
+        <PageHeader
+          breadcrumb={['프로젝트', cohortName, p.name].filter(Boolean).join(' › ')}
+          title={p.name}
+        />
+      </div>
       <DetailHeader project={p} classScope={classScope} />
 
       {/*

--- a/src/features/manager/projects/components/DetailHeader.tsx
+++ b/src/features/manager/projects/components/DetailHeader.tsx
@@ -60,7 +60,8 @@ export default function DetailHeader({
           <ArrowLeft className="size-5" />
         </Button>
         <div className="flex flex-wrap items-baseline gap-2">
-          <h1 className="text-xl font-bold tracking-[-0.01em]">{project.name}</h1>
+          {/* 실제 h1은 위 PageHeader(sr-only)가 갖는다 — 화면당 h1 하나 원칙(교안 상세와 같은 패턴) */}
+          <span className="text-xl font-bold tracking-[-0.01em]">{project.name}</span>
           <Badge variant={STATUS_BADGE[project.status]}>{STATUS_LABEL[project.status]}</Badge>
         </div>
       </div>

--- a/src/features/operator/curricula/CurriculumDetailScreen.tsx
+++ b/src/features/operator/curricula/CurriculumDetailScreen.tsx
@@ -1,7 +1,7 @@
 import { useState, type ReactNode } from 'react'
 import { Link, useLocation, useNavigate, useParams } from 'react-router'
 import {
-  ChevronLeftIcon,
+  ArrowLeft,
   ChevronRightIcon,
   PlayIcon,
   RefreshCwIcon,
@@ -174,23 +174,33 @@ export default function CurriculumDetailScreen() {
   return (
     <ConsoleShell {...shell} user={{ name: me?.name ?? '', role: '오퍼레이터' }}>
       <div className="mb-4">
-        <Link
-          to={listPath}
-          className="text-fg-subtle hover:text-fg inline-flex items-center gap-1 text-xs"
-        >
-          <ChevronLeftIcon className="size-3.5" />
-          교안 목록
-        </Link>
-        <div className="mt-1 flex flex-wrap items-center justify-between gap-3">
-          <h1 className="flex items-center gap-2 text-xl font-bold tracking-[-0.01em]">
-            {data.title ?? data.originalFileName}
-            <span className="text-fg-subtle text-sm font-normal">v{data.versionNo}</span>
-            {analyzed ? (
-              <CurriculumStatusBadge status={data.analysisStatus!} />
-            ) : (
-              <Badge variant="neutral">분석 전</Badge>
-            )}
-          </h1>
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex items-center gap-2">
+            {/*
+              뒤로가기 버튼은 매니저 화면들과 같은 아이콘 전용 스타일로 통일한다 —
+              텍스트 링크("‹ 교안 목록")와 아이콘 버튼이 화면마다 섞여 있던 것을 정리했다.
+              목록으로 돌아갈 때 **`?cohort=`를 그대로 들고 간다**(`listPath` 주석 참고).
+            */}
+            <Button
+              variant="ghost"
+              size="sm"
+              aria-label="교안 목록으로 돌아가기"
+              nativeButton={false}
+              render={<Link to={listPath} />}
+              className="-ml-1.5 p-1.5"
+            >
+              <ArrowLeft className="size-5" />
+            </Button>
+            <h1 className="flex items-center gap-2 text-xl font-bold tracking-[-0.01em]">
+              {data.title ?? data.originalFileName}
+              <span className="text-fg-subtle text-sm font-normal">v{data.versionNo}</span>
+              {analyzed ? (
+                <CurriculumStatusBadge status={data.analysisStatus!} />
+              ) : (
+                <Badge variant="neutral">분석 전</Badge>
+              )}
+            </h1>
+          </div>
           {/*
             **액션은 오른쪽 끝에 모은다.** 한때 이 셋이 `justify-between`의 형제라
             버튼이 늘어나자 **다시 분석이 화면 한가운데로 밀렸다** — 제목과 액션 사이가

--- a/src/features/operator/projects/detail/components/DetailHeader.tsx
+++ b/src/features/operator/projects/detail/components/DetailHeader.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router'
-import { ChevronLeftIcon } from 'lucide-react'
+import { ArrowLeft } from 'lucide-react'
+import { Button } from '@/components/ui/Button'
 import { cn } from '@/lib/utils/cn'
 import { dueLabel, formatDue } from '../../rules'
 import ProjectStatusBadge from '../../components/ProjectStatusBadge'
@@ -29,25 +30,32 @@ export default function DetailHeader({
 
   return (
     <div className="mb-4">
-      {/*
-        (이슈 277 QA) **기수를 실어 간다.** 예전엔 `/operator/projects`로 고정돼 있어서,
-        스위처로 다른 기수를 골라 두고 들어온 회차에서 여기를 누르면 목록이 전역
-        기본값(진행 중 기수)으로 되돌아갔다 — 방금 보던 기수가 사라졌다. 이 회차가
-        실제로 속한 기수(`project.cohortId`)를 실어 보내면 그 문제가 없다.
-      */}
-      <Link
-        to={`/operator/projects?cohort=${project.cohortId}`}
-        className="text-fg-subtle hover:text-fg mb-1.5 inline-flex items-center gap-0.5 text-xs"
-      >
-        <ChevronLeftIcon className="size-3.5" />
-        프로젝트 목록
-      </Link>
-
       <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-        <h1 className="flex items-center gap-2 text-xl font-bold tracking-[-0.01em]">
-          {project.name}
-          <ProjectStatusBadge status={project.status} />
-        </h1>
+        <div className="flex items-center gap-2">
+          {/*
+            (이슈 277 QA) **기수를 실어 간다.** 예전엔 `/operator/projects`로 고정돼 있어서,
+            스위처로 다른 기수를 골라 두고 들어온 회차에서 여기를 누르면 목록이 전역
+            기본값(진행 중 기수)으로 되돌아갔다 — 방금 보던 기수가 사라졌다. 이 회차가
+            실제로 속한 기수(`project.cohortId`)를 실어 보내면 그 문제가 없다.
+
+            뒤로가기 버튼은 매니저 화면들과 같은 아이콘 전용 스타일로 통일한다 —
+            텍스트 링크("‹ 프로젝트 목록")와 아이콘 버튼이 화면마다 섞여 있던 것을 정리했다.
+          */}
+          <Button
+            variant="ghost"
+            size="sm"
+            aria-label="프로젝트 목록으로 돌아가기"
+            nativeButton={false}
+            render={<Link to={`/operator/projects?cohort=${project.cohortId}`} />}
+            className="-ml-1.5 p-1.5"
+          >
+            <ArrowLeft className="size-5" />
+          </Button>
+          <h1 className="flex items-center gap-2 text-xl font-bold tracking-[-0.01em]">
+            {project.name}
+            <ProjectStatusBadge status={project.status} />
+          </h1>
+        </div>
         {/* 마감은 오른쪽 끝으로 — 제목과 같은 줄에 있되 읽는 순서는 나중이다 */}
         <span className="ml-auto text-sm">
           {project.endDate ? (


### PR DESCRIPTION
## 작업 내용

- 운영자 프로젝트 상세·운영자 교안 상세의 텍스트 링크("‹ 목록") 뒤로가기를 매니저 화면들과 같은 아이콘 전용(ArrowLeft) 스타일로 통일
- 매니저 프로젝트 상세(MG-08)에 빠져 있던 breadcrumb을 매니저 교안 상세(MG-09)와 같은 패턴으로 복구

## 리뷰 포인트

- 매니저 프로젝트 상세 DetailHeader의 제목을 `h1` → `span`으로 바꿨습니다. PageHeader의 sr-only h1이 화면의 유일한 h1을 맡는, 교안 상세·기관 상세에서 이미 쓰던 패턴을 그대로 따른 것입니다.
- 운영자 프로젝트 상세·운영자 교안 상세에는 breadcrumb을 추가하지 않았습니다 — 이번 스코프는 사용자가 스크린샷으로 지적한 매니저 프로젝트 상세 1곳입니다. 운영자 쪽 breadcrumb 필요 여부는 이슈의 "하지 않는 것"에 남겨뒀습니다.
- `npm run typecheck`(`tsc -b`)·`npm run format:check`는 통과 확인했습니다. `npm run lint`(oxlint)는 작업 환경의 네이티브 바인딩 문제로 실행하지 못해 로컬에서 한 번 더 확인 부탁드립니다.

## 확인

- [ ] 로컬에서 동작 확인
- [x] 하나의 PR = 하나의 기능

closes #286 