### PR TITLE
[Feat] Show Managed Trainee Report Body on the Timeline Report Line

### DIFF
--- a/src/features/manager/trainees/_/api/api.ts
+++ b/src/features/manager/trainees/_/api/api.ts
@@ -5,16 +5,20 @@ import {
   useFindTraineeRoster,
 } from '@/api/member/useMemberQueries'
 import { useFindTraineeEvaluationDetail } from '@/api/evaluation/useEvaluationQueries'
+import { useFindManagedTraineeReports } from '@/api/reporting/useReportingQueries'
 import type {
   findManagerTraineeDetail_Response,
   findManagerTraineeTimeline_Response,
   findTraineeRoster_Response,
 } from '@/api/member/memberTypes'
+import type { findManagedTraineeReports_Response } from '@/api/reporting/reportingTypes'
 import { listQueryOptions } from '@/lib/listQuery'
 import { stripSeverityTag } from '@/lib/riskSummary'
 import type {
   ConceptReach,
   DetailRound,
+  ManagedReportConcept,
+  ManagedRoundReport,
   RosterView,
   RoundBadgeKind,
   TimelineEvent,
@@ -197,6 +201,66 @@ export function useTraineeEvaluation(
     [query.data],
   )
   return { ...query, data }
+}
+
+/**
+ * MG-06 리포트 라인 — **「리포트 발행」을 펼칠 때만** 부른다(`AssessmentRow`와 같은
+ * 지연 조회 관례). 한 번의 `GET /reports/managed?traineeId=`가 그 교육생의
+ * **회차 전부**를 준다 — 회차별로 다시 안 부른다. 쿼리 키가 `traineeId`뿐이라 같은
+ * 사람의 다른 회차를 펼쳐도 캐시를 그대로 쓴다.
+ *
+ * 회차 id는 `reportsById`의 키다. 타임라인 쪽 `assessmentRoundId`와 같은 값임을
+ * 실측으로 확인했다(강동하 6차: 둘 다 `ad9fb0a0-…`).
+ *
+ * `query.isError`(조회 자체가 실패)와 `data.status !== 'PUBLISHED'`(조회는 됐는데
+ * 이 회차가 아직 리포트를 안 가짐)를 **화면이 구분해야 해서** 값을 뭉개지 않고
+ * `status`를 그대로 돌려준다 — `ManagedRoundReport` 주석의 노지우 6차 사례 참고.
+ */
+export function useManagedTraineeReport(
+  traineeId: string | undefined,
+  roundId: string,
+  enabled: boolean,
+) {
+  const query = useFindManagedTraineeReports(
+    { query: { traineeId: traineeId ?? '' } },
+    { enabled: enabled && !!traineeId },
+  )
+  const data = useMemo<ManagedRoundReport | undefined>(() => {
+    if (!query.data) return undefined
+    const raw = query.data.reportsById[roundId]
+    if (!raw) return { status: 'NOT_FOUND' }
+    if (raw.status !== 'PUBLISHED') return { status: raw.status }
+    return {
+      status: 'PUBLISHED',
+      concepts: (raw.concepts ?? []).map(toManagedConcept),
+      missingConceptCount: raw.missingConceptCount ?? 0,
+      retryState: raw.retryState ?? 'NONE',
+    }
+  }, [query.data, roundId])
+  return { ...query, data }
+}
+
+function clampLevel(level: number | null | undefined): 0 | 1 | 2 | 3 | 4 {
+  if (typeof level !== 'number' || !Number.isFinite(level)) return 0
+  return Math.min(4, Math.max(0, Math.round(level))) as 0 | 1 | 2 | 3 | 4
+}
+
+type ManagedServerConcept = NonNullable<
+  findManagedTraineeReports_Response['reportsById'][string]['concepts']
+>[number]
+
+function toManagedConcept(c: ManagedServerConcept): ManagedReportConcept {
+  if (!c.asked) return { asked: false, name: c.name }
+  return {
+    asked: true,
+    name: c.name,
+    reachedLevel: clampLevel(c.level),
+    said: c.said ?? '',
+    isRetryTarget: c.isRetryTarget,
+    curriculumRef: c.curriculumRef ?? null,
+    explanation: c.explain?.length ? c.explain : null,
+    qa: c.qa?.length ? c.qa.map((q) => ({ ...q })) : null,
+  }
 }
 
 /** 교육생 한 사람 — 헤더·회차 격자 */

--- a/src/features/manager/trainees/_/api/types.ts
+++ b/src/features/manager/trainees/_/api/types.ts
@@ -186,6 +186,50 @@ export type TraineeEvaluation = {
   concepts: EvaluationConcept[]
 }
 
+/* ──────────────────── MG-06 리포트 라인(「리포트 발행」 펼치기) ──────────────────── */
+
+/*
+  교육생 TR-04(`features/trainee/report/_/api/types.ts`)와 **모양이 같다** — 서버가
+  같은 `TraineeReportsResponse`를 준다(39차 회신). 그래도 여기 따로 두는 이유는
+  레이어 린트가 features 간 교차 import를 막기 때문이다(decision-log D33 · SA-03과
+  같은 사정) — 계약은 같아도 타입은 각 feature가 자기 것을 갖는다.
+
+  ⚠ **여기는 잠금이 없다.** 교육생 쪽은 `isRetryTarget`인데 다시 보기 전이면
+  `explanation`·`qa`가 빠지지만, 매니저에게는 서버가 그 잠금을 걸지 않는다(스펙) —
+  지도하려면 학생이 뭐라고 답했는지를 봐야 하기 때문이다.
+*/
+export type ManagedReportConcept =
+  | { asked: false; name: string }
+  | {
+      asked: true
+      name: string
+      reachedLevel: 0 | 1 | 2 | 3 | 4
+      said: string
+      isRetryTarget: boolean
+      curriculumRef: { chapter: string; pages: string; title: string } | null
+      explanation: string[] | null
+      qa: { questionLabel: string; question: string; answer: string }[] | null
+    }
+
+/*
+  🔴 **「불러오지 못했습니다」 한 줄로 뭉개지 않는다.** 실제로 있었던 상황 —
+  타임라인에 `REPORT`(리포트 발행) 이벤트가 있는 회차인데도 `reportsById`가 그 회차를
+  아직 `PENDING_PUBLISH`로 준 적이 있다(노지우 6차, 실측). 조회 자체가 실패한 것과
+  회차가 아직 리포트를 안 가진 것은 다른 사건이라 화면이 구분해 말해야 한다 —
+  `status`를 그대로 들고 있다가 서버 문서(`RoundReportResponse.status` 표)의 말을
+  그대로 쓴다.
+*/
+export type ManagedRoundReport =
+  | {
+      status: 'PUBLISHED'
+      concepts: ManagedReportConcept[]
+      missingConceptCount: number
+      retryState: 'NONE' | 'PENDING' | 'DONE'
+    }
+  | { status: 'PENDING_PUBLISH' | 'NOT_STARTED' | 'NOT_ATTEMPTED' | 'VOID_ATTEMPT' | 'STOPPED' }
+  /** 회차 id가 `reportsById`에 아예 없다 — 정상 스펙엔 없는 경우라 방어적으로만 둔다 */
+  | { status: 'NOT_FOUND' }
+
 export type RosterView = {
   rows: TraineeRow[]
   /** 필터 적용 후 전체 인원 — 페이저의 분모 */

--- a/src/features/manager/trainees/components/Timeline.tsx
+++ b/src/features/manager/trainees/components/Timeline.tsx
@@ -7,13 +7,17 @@ import {
   Minus,
   FileOutput,
   MessageSquare,
+  BookOpenIcon,
+  CircleSlashIcon,
 } from 'lucide-react'
 import { cn } from '@/lib/utils/cn'
 import { Empty, EmptyTitle, EmptyDescription } from '@/components/ui/Empty'
 import { RoundBadge } from './RoundBadge'
 import { REACH_STYLE } from '@/components/common/reach'
-import { useTraineeEvaluation } from '../_/api/api'
+import { useManagedTraineeReport, useTraineeEvaluation } from '../_/api/api'
 import type {
+  ManagedReportConcept,
+  ManagedRoundReport,
   RoundBadgeKind,
   TimelineEvent,
   TimelineGroup,
@@ -286,21 +290,167 @@ function ReviewRow({ event }: { event: TimelineEvent }) {
   )
 }
 
-function ReportRow({ event }: { event: TimelineEvent }) {
-  return (
-    <div className="flex items-start gap-4 border-t border-border px-5 py-3">
-      <DateCell label={event.dateLabel} />
-      <EventIcon tone="info">
-        <FileOutput className="size-3" />
-      </EventIcon>
-      <span className="flex min-w-0 flex-1 flex-wrap items-baseline gap-2 text-sm">
-        <b className="font-bold">리포트 발행</b>
-        <span className="text-fg-muted">
-          {event.reviewTargetCount
-            ? `다시 보기 ${event.reviewTargetCount}건 지정`
-            : '다시 보기 없음'}
-        </span>
+/**
+ * MG-06 리포트 라인 — 펼치면 그 회차 리포트 본문을 그린다(교육생이 보는 것과 같은
+ * 내용, 잠금만 없다). `AssessmentRow`와 같은 지연 조회 관례 — 펼칠 때만 부른다.
+ */
+function ReportRow({
+  event,
+  traineeId,
+  roundId,
+}: {
+  event: TimelineEvent
+  traineeId: string
+  roundId: string
+}) {
+  const [opened, setOpened] = useState(false)
+  const report = useManagedTraineeReport(traineeId, roundId, opened)
+
+  const summary = (
+    <>
+      <b className="font-bold">리포트 발행</b>
+      <span className="text-fg-muted">
+        {event.reviewTargetCount ? `다시 보기 ${event.reviewTargetCount}건 지정` : '다시 보기 없음'}
       </span>
+    </>
+  )
+
+  return (
+    <details
+      className="group/ev border-t border-border"
+      onToggle={(e) => setOpened((e.currentTarget as HTMLDetailsElement).open)}
+    >
+      <summary className="flex cursor-pointer list-none items-start gap-4 px-5 py-3 marker:content-none hover:bg-surface-2 group-open/ev:bg-primary-soft">
+        <DateCell label={event.dateLabel} />
+        <EventIcon tone="info">
+          <FileOutput className="size-3" />
+        </EventIcon>
+        <span className="flex min-w-0 flex-1 flex-wrap items-baseline gap-2 text-sm">
+          {summary}
+          <span className="ml-auto flex shrink-0 items-center gap-1 text-2xs font-semibold text-primary">
+            <span className="group-open/ev:hidden">자세히</span>
+            <span className="hidden group-open/ev:inline">접기</span>
+            <ChevronRight
+              className="size-3 transition-transform duration-150 group-open/ev:rotate-90"
+              aria-hidden="true"
+            />
+          </span>
+        </span>
+      </summary>
+      <div className="border-t border-border bg-primary-soft py-3 pr-5 pl-[84px]">
+        {report.isPending && <p className="text-2xs text-fg-subtle">리포트를 불러오는 중…</p>}
+        {/*
+          🔴 **「불러오지 못했습니다」한 줄로 뭉개지 않는다** — 조회 자체가 실패한 것과
+          (네트워크·서버 오류) 회차가 아직 리포트를 안 가진 것(생성 중 등)은 다른
+          사건이다. 후자는 서버가 준 `status`로 정확히 말할 수 있는데 뭉개면 매니저가
+          "장애인가, 기다리면 되는 건가"를 판단할 근거가 없어진다.
+        */}
+        {report.isError && (
+          <p className="flex items-center gap-2 text-2xs text-danger">
+            리포트를 불러오지 못했어요 — 네트워크나 서버 오류입니다
+            <button
+              type="button"
+              onClick={() => void report.refetch()}
+              className="font-semibold underline underline-offset-2"
+            >
+              다시 시도
+            </button>
+          </p>
+        )}
+        {report.data && report.data.status !== 'PUBLISHED' && (
+          <p className="text-2xs text-fg-subtle">{REPORT_STATUS_REASON[report.data.status]}</p>
+        )}
+        {report.data?.status === 'PUBLISHED' && (
+          <>
+            {report.data.missingConceptCount > 0 && (
+              <p className="mb-2.5 text-2xs text-warning">
+                개념 {report.data.missingConceptCount}개는 생성에 실패해 결과가 없습니다
+              </p>
+            )}
+            {report.data.concepts.map((c, i) => (
+              <ReportConceptRow key={i} concept={c} />
+            ))}
+          </>
+        )}
+      </div>
+    </details>
+  )
+}
+
+/** `RoundReportResponse.status` 표(스펙)를 그대로 옮긴다 — 화면이 새로 판정하지 않는다 */
+const REPORT_STATUS_REASON: Record<Exclude<ManagedRoundReport['status'], 'PUBLISHED'>, string> = {
+  PENDING_PUBLISH: '리포트를 만드는 중이에요 — 회차 마감 후 한꺼번에 발행됩니다.',
+  NOT_STARTED: '아직 응시 기록이 없어요 — 제출 마감 전입니다.',
+  NOT_ATTEMPTED: '마감이 지나도록 응시하지 않았어요.',
+  VOID_ATTEMPT: '무효 응시로 확인이 필요해요.',
+  STOPPED: '세션을 시작했지만 끝내지 못했어요.',
+  /** 정상 스펙엔 없는 경우 — 회차 id가 리포트 목록에 아예 없을 때만 */
+  NOT_FOUND: '이 회차의 리포트를 찾을 수 없어요.',
+}
+
+function ReportConceptRow({ concept }: { concept: ManagedReportConcept }) {
+  const [qaOpen, setQaOpen] = useState(false)
+
+  if (!concept.asked) {
+    return (
+      <div className="mb-2.5 flex items-start gap-1.5 text-xs text-fg-subtle last:mb-0">
+        <CircleSlashIcon aria-hidden="true" className="mt-0.5 size-3.5 shrink-0" />
+        {concept.name} — 코드에 이 개념이 없어 묻지 못했습니다
+      </div>
+    )
+  }
+
+  return (
+    <div className="mb-3 last:mb-0">
+      <p className="flex flex-wrap items-center gap-1.5 text-xs font-bold">
+        <span
+          className={cn(
+            'rounded-[5px] px-1.5 py-0.5 text-[11px]',
+            REACH_STYLE[concept.reachedLevel],
+          )}
+        >
+          {concept.reachedLevel}단
+        </span>
+        {concept.name}
+      </p>
+      <p className="mt-1 text-xs leading-relaxed text-fg-muted">{concept.said}</p>
+      {concept.curriculumRef && (
+        <div className="mt-1.5 inline-flex items-center gap-1.5 rounded-full border border-info-border bg-info-soft px-2 py-0.5 text-2xs text-info">
+          <BookOpenIcon aria-hidden="true" className="size-3 shrink-0" />
+          <span>
+            교안 {concept.curriculumRef.chapter} · {concept.curriculumRef.pages} ·{' '}
+            {concept.curriculumRef.title}
+          </span>
+        </div>
+      )}
+      {concept.qa && (
+        <div className="mt-1.5">
+          <button
+            type="button"
+            onClick={() => setQaOpen((v) => !v)}
+            aria-expanded={qaOpen}
+            className="flex items-center gap-1 text-2xs font-semibold text-primary"
+          >
+            <ChevronRight
+              className={cn('size-3 transition-transform', qaOpen && 'rotate-90')}
+              aria-hidden="true"
+            />
+            문답 {concept.qa.length}건 {qaOpen ? '접기' : '보기'}
+          </button>
+          {qaOpen && (
+            <div className="mt-1.5 flex flex-col gap-1.5">
+              {concept.qa.map((row, i) => (
+                <div key={i} className="rounded-md bg-surface p-2">
+                  <p className="text-2xs text-fg-subtle">
+                    <span className="font-medium">{row.questionLabel}</span> {row.question}
+                  </p>
+                  <p className="mt-0.5 text-xs text-fg">{row.answer}</p>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
     </div>
   )
 }
@@ -393,10 +543,12 @@ function EventRow({
   event,
   projectId,
   traineeId,
+  roundId,
 }: {
   event: TimelineEvent
   projectId: string
   traineeId: string
+  roundId: string
 }) {
   switch (event.kind) {
     case 'ASSESSMENT':
@@ -405,7 +557,7 @@ function EventRow({
     case 'REVIEW_CLOSED':
       return <ReviewRow event={event} />
     case 'REPORT':
-      return <ReportRow event={event} />
+      return <ReportRow event={event} traineeId={traineeId} roundId={roundId} />
     case 'INTERVIEW':
       return <InterviewRow event={event} />
   }
@@ -454,7 +606,13 @@ function RoundGroup({
       </button>
       {expanded &&
         events.map((e) => (
-          <EventRow key={e.id} event={e} projectId={group.projectId} traineeId={traineeId} />
+          <EventRow
+            key={e.id}
+            event={e}
+            projectId={group.projectId}
+            traineeId={traineeId}
+            roundId={group.assessmentRoundId}
+          />
         ))}
     </div>
   )


### PR DESCRIPTION
<!-- 제목 형식: [Feat] Add Login Page UI  (규약 docs/handbook/git-convention.md §3) -->

## 작업 내용

`GET /reports/managed`가 `available`로 승격돼(2026-08-19 배포) 매니저 교육생 상세(MG-06) 타임라인의 「리포트 발행」 줄에 리포트 라인을 붙였다.

- `useManagedTraineeReport(traineeId, roundId, enabled)` 신설 — 펼칠 때만 조회(`AssessmentRow`와 같은 관례)
- 펼치면 도달 단계·서술·교안 참조·문답까지 렌더. 매니저에게는 서버가 잠금을 안 걸어서 항상 다 보인다
- 조회 실패와 "회차가 아직 리포트를 안 가짐"(생성 중·미응시·무효 확인 필요 등)을 구분해서 안내 — 서버 `status`를 그대로 문구로 옮긴다

## 리뷰 포인트

- 회차 id(`rounds[].id`)와 타임라인 `assessmentRoundId`가 같은 값이라는 전제가 실측(강동하 6차)으로만 확인됐고 서버 문서에 명시적 보장은 아니다
- 잠금 상태별 문구(`REPORT_STATUS_REASON`)가 스펙 표를 그대로 옮긴 게 맞는지

## 확인

- [x] 로컬에서 동작 확인 (b227 실계정 · 강동하 4차 발행 리포트, 노지우 6차 미발행 상태 둘 다 렌더 확인)
- [x] 하나의 PR = 하나의 기능
closes #291
