### PR TITLE
[Fix] Add In-Progress Report Status

### DIFF
--- a/src/features/trainee/report/MyReportScreen.tsx
+++ b/src/features/trainee/report/MyReportScreen.tsx
@@ -138,6 +138,23 @@ function RoundBody({ report }: { report: RoundReport }) {
         />
       )
     /*
+      2026-08-20 추가 — 백엔드가 응시 미완료(코드 제출 전·분석 중·이해도 확인 세션
+      준비/진행 중)를 PENDING_PUBLISH("응시 완료")로 잘못 내려보내던 버그를 고치며
+      새로 생긴 상태다. `PENDING_PUBLISH`와 같은 문구를 쓰면 안 된다 — 이해도 확인을
+      마쳤는지가 갈리는 축이다. 세부 단계는 이 화면 계약에 없다 — 홈의 스테퍼가
+      더 자세히 보여주므로 여기서는 "가서 이어서 하라"는 안내만 한다.
+    */
+    case 'IN_PROGRESS':
+      return (
+        <ReportStatusCard
+          variant="default"
+          icon={<ClockIcon className="size-5" />}
+          title="아직 진행 중이에요"
+          description="코드 제출부터 이해도 확인까지 마치면 리포트가 만들어집니다."
+          aux="홈에서 진행 상황을 이어서 확인할 수 있어요"
+        />
+      )
+    /*
       **`NOT_STARTED`와 `NOT_ATTEMPTED`는 정반대다**(26차 A1). 둘 다 "응시 기록이
       없다"지만 제출 마감을 기준으로 갈린다 — 앞은 아직 시간이 있는 정상이고, 뒤는
       기회가 지나간 것이다. 그래서 매니저 안내(`aux`)는 **뒤에만** 붙는다. 마감 전

--- a/src/features/trainee/report/_/api/api.ts
+++ b/src/features/trainee/report/_/api/api.ts
@@ -40,7 +40,23 @@ function toView(s: Server): ReportsData {
 function toReport(r: ServerReport): RoundReport {
   const base = { id: r.id, label: r.label }
 
-  switch (r.status) {
+  /*
+    🔴 **`as ... | 'IN_PROGRESS'` 캐스트가 필요하다**(2026-08-20). 생성 타입
+    (`ServerReport['status']`, `npm run api:gen`으로 나온다)이 아직 이 값을 모른다 —
+    백엔드 PR이 머지·배포되고 스키마를 다시 생성하기 전까지는 그렇다. 캐스트를
+    빼면 컴파일은 되지만(스위치가 여전히 소진적이라) 실제로 서버가 `IN_PROGRESS`를
+    보내는 순간 아래 case가 죽은 코드 취급돼 무시되고 `undefined`가 반환돼 화면이
+    죽는다. 스키마 재생성 후에는 이 캐스트를 지워도 된다 — 그때는 생성 타입 자체가
+    `IN_PROGRESS`를 포함해서 필요 없어진다.
+
+    지역 변수로 뽑아서 switch를 거는 이유는, `r.status`를 캐스트 없이 그대로
+    switch에 걸어야 case 안에서 `r.status`를 다시 읽을 때도 좁혀진 타입을 그대로
+    받기 때문이다 — `switch (r.status as ...)`처럼 캐스트 식을 바로 걸면 TS가 그
+    좁힘을 `r.status`의 다른 참조로 전파하지 못한다.
+  */
+  const status = r.status as ServerReport['status'] | 'IN_PROGRESS'
+
+  switch (status) {
     case 'PUBLISHED':
       return {
         ...base,
@@ -57,11 +73,13 @@ function toReport(r: ServerReport): RoundReport {
       }
     case 'PENDING_PUBLISH':
       return { ...base, status: 'PENDING_PUBLISH', publishAfter: r.publishAfter ?? null }
+    case 'IN_PROGRESS':
+      return { ...base, status: 'IN_PROGRESS' }
     case 'NOT_STARTED':
     case 'NOT_ATTEMPTED':
     case 'VOID_ATTEMPT':
     case 'STOPPED':
-      return { ...base, status: r.status }
+      return { ...base, status }
   }
 }
 

--- a/src/features/trainee/report/_/api/types.ts
+++ b/src/features/trainee/report/_/api/types.ts
@@ -4,8 +4,9 @@ import type { findMyReports_Response } from '@/api/reporting/reportingTypes'
   TR-04 계약 — **서버 모양을 화면 어휘로 옮긴 것**(api-boundary §1-③).
   확정 모델은 `docs/dev/screens/tr-04-report.md`.
 
-  16차에 요청한 봉투(`rounds` + `reportsById`)가 그대로 왔다. 상태 6종도 글자까지 같아서
-  화면 분기가 산다. 그래서 여기서 새로 짓는 것은 **목이 지어냈던 두 군데뿐**이다.
+  16차에 요청한 봉투(`rounds` + `reportsById`)가 그대로 왔다. 상태는 글자까지 같아서
+  화면 분기가 산다(2026-08-20 기준 7종 — `IN_PROGRESS` 추가). 그래서 여기서 새로
+  짓는 것은 **목이 지어냈던 두 군데뿐**이다.
 */
 
 type Server = findMyReports_Response
@@ -84,7 +85,24 @@ export type PublishedReport = RoundBase & {
 
 export type RoundReport =
   | PublishedReport
+  /**
+   * **이해도 확인까지 실제로 마쳤고** 리포트만 아직 없다(2026-08-20 정정 — 기산점이
+   * 좁혀졌다). `IN_PROGRESS`와 갈라야 한다: 이쪽은 응시가 끝났고, 그쪽은 아직 끝나지
+   * 않았다.
+   */
   | (RoundBase & { status: 'PENDING_PUBLISH'; publishAfter: string | null })
+  /**
+   * 응시 기록은 있지만 **아직 COMPLETED에 이르지 못했다**(2026-08-20 추가) — 코드
+   * 제출 전이거나, 제출은 했는데 분석 중이거나, 분석은 끝났는데 이해도 확인 세션을
+   * 아직 시작 안 했거나, 세션이 진행 중인 경우를 전부 묶는다.
+   *
+   * 🔴 **`PENDING_PUBLISH`로 잘못 뜨던 버그를 고친 값이다.** 백엔드가 응시
+   * 미완료(코드 분석 중 등)를 `PENDING_PUBLISH`("응시 완료")로 잘못 내려보내던 것을
+   * 이 값으로 분리했다 — 실사용 재현: 코드 분석이 진행 중인 회차가 "응시 완료"로
+   * 표시됨. 세부 단계(제출 전/분석 중/세션 준비/세션 진행 중)는 이 화면 계약에
+   * 없다 — 필요하면 TR-01 홈의 스테퍼가 더 자세히 보여준다.
+   */
+  | (RoundBase & { status: 'IN_PROGRESS' })
   /**
    * 제출 마감 **전**이고 아직 응시하지 않았다 — 정상이고 아직 시간이 있다.
    * `NOT_ATTEMPTED`(마감이 지나도록 안 함)와 갈라야 한다(26차 A1) — 한 문구로 묶으면

--- a/src/features/trainee/report/labels.ts
+++ b/src/features/trainee/report/labels.ts
@@ -65,6 +65,14 @@ export function buildRailNote(report: RoundReport | undefined): string | undefin
       if (report.retryState === 'DONE') return '다시 보기 1개 완료'
       return undefined
     }
+    /*
+      2026-08-20 추가 — 백엔드가 응시 미완료(코드 제출 전·분석 중·이해도 확인 세션
+      준비/진행 중)를 `PENDING_PUBLISH`("응시 완료")로 잘못 내려보내던 버그를 고치며
+      새로 생긴 값이다. `PENDING_PUBLISH`와 다른 말이어야 한다 — 그건 "다 봤고
+      리포트만 기다리는 중"이고 이건 "아직 안 끝남"이다.
+    */
+    case 'IN_PROGRESS':
+      return '진행 중'
     // 마감 전(아직 할 수 있다)과 마감 후(기회가 지났다)를 레일에서도 가른다 — 본문과
     // 다른 말을 하면 목록을 훑을 때와 열었을 때 인상이 달라진다
     case 'NOT_STARTED':


### PR DESCRIPTION
## 작업 내용

Team-IZ/Backend PR #162의 프론트 짝입니다. 백엔드가 이해도 확인을 아직 안 끝낸 회차(코드 제출 전·분석 중·세션 준비됨·세션 진행 중)를 `PENDING_PUBLISH`("응시 완료")로 잘못 내려보내던 버그를 고치며 `IN_PROGRESS` 상태를 새로 나눴습니다. 실사용 재현: `s083@codeschool-b.kr` 6차 — 홈 화면은 "코드 분석이 진행 중이에요"라고 정확히 보여주는데, 같은 시각 "내 리포트" 레일은 같은 회차를 "응시 완료"로 보여주고 있었습니다.

- `types.ts`: `RoundReport`에 `IN_PROGRESS` 멤버 추가(추가 필드 없음 — `NOT_STARTED`류와 같은 모양)
- `labels.ts`: 레일 보조문구 "진행 중" — `PENDING_PUBLISH`의 "응시 완료"와 다른 문구
- `MyReportScreen.tsx`: 본문 카드 새 분기. 세부 진행 단계는 여기서 안 그리고 홈으로 안내(중복 방지)
- `api.ts`: `toReport()`의 status switch에 `as ... | 'IN_PROGRESS'` 캐스트 추가 — 생성 스키마(`reportingTypes.ts`)가 백엔드 배포+재생성 전까지는 이 값을 모르기 때문. 캐스트를 지역 변수로 뽑은 이유는 인라인 캐스트를 switch 식에 바로 걸면 다른 case 본문의 타입 좁힘이 깨져서입니다(주석에 상세)

## 리뷰 포인트

- `api.ts`의 캐스트 — 백엔드 PR #162가 머지·배포되고 `npm run api:gen`을 다시 돌리면 지워도 되는 임시 다리입니다. 지금 지우면 `IN_PROGRESS` case가 죽은 코드 취급돼 컴파일이 깨집니다(직접 확인함).
- `MyReportScreen.tsx`의 카피("아직 진행 중이에요" / "홈에서 진행 상황을 이어서 확인할 수 있어요") — 5개 하위 상태(제출 전~세션 진행 중)를 한 문구로 묶은 게 맞는 선택인지 의견 있으면 반영하겠습니다.

## 확인

- [x] `npm run typecheck` 통과
- [x] `npm run lint` 통과(관련 없는 기존 경고만 남음)
- [x] `npm run check:project` / `npm run check:error-copy` 통과
- [x] `npm run verify:ci` 통과(커밋된 상태 기준)
- [x] 하나의 PR = 하나의 기능

closes #