### PR TITLE
[Fix] Wire the Review-Session Open API Into the Retry Button

### DIFF
--- a/src/features/trainee/home/labels.ts
+++ b/src/features/trainee/home/labels.ts
@@ -102,7 +102,6 @@ const ACTION_ROUTES: Partial<Record<ActionCode, string>> = {
   RESUBMIT_REPOSITORY: '/trainee/submission',
   RESUBMIT_ZIP: '/trainee/submission',
   START_ASSESSMENT: '/trainee/session',
-  START_REVIEW: '/trainee/session?retry=1',
   /*
     **이어하기를 연다.** 예전에는 일부러 경로를 안 줬다 — "시작하면 중간에 나갈 수
     없어요"라는 약속을 지키려고. 그런데 실제로 일어나는 일은 학생이 *약속을 어기는* 것이
@@ -314,6 +313,16 @@ function buildCta(round: CurrentRound, now: number): StatusContent['cta'] {
     `undefined`를 그리다 터진다(실측). 갈 수 있는지 판정은 `canViewReport`가 한다.
   */
   if (action === 'VIEW_REPORT' && round.canViewReport && round.id) {
+    return { label: ACTION_LABELS[action], to: `/trainee/report?round=${round.id}` }
+  }
+
+  /*
+    🔴 **`/trainee/session?retry=1`로 바로 보내지 않는다.** 다시 보기 응시를 실제로
+    만드는 것은 리포트 화면의 버튼뿐이다(`POST /assessment-sessions/reviews` 개설 호출) —
+    세션 화면은 그 쿼리를 읽지 않아 곧장 보내면 "응시 없음" 화면으로 빠진다(실사용
+    재현). 리포트로 보내면 같은 버튼을 타므로 개설 → 시작이 항상 붙어 다닌다.
+  */
+  if (action === 'START_REVIEW' && round.canViewReport && round.id) {
     return { label: ACTION_LABELS[action], to: `/trainee/report?round=${round.id}` }
   }
 

--- a/src/features/trainee/report/MyReportScreen.tsx
+++ b/src/features/trainee/report/MyReportScreen.tsx
@@ -9,8 +9,11 @@ import {
   TriangleAlertIcon,
 } from 'lucide-react'
 import { useState } from 'react'
-import { Link, useSearchParams } from 'react-router'
+import { useNavigate, useSearchParams } from 'react-router'
+import { isApiError } from '@/api/_contract'
+import { useOpenReviewSession } from '@/api/assessment/useAssessmentMutations'
 import StatusMessageCard from '@/components/common/StatusMessageCard'
+import { Alert } from '@/components/ui/Alert'
 import { Button } from '@/components/ui/Button'
 import { Card } from '@/components/ui/Card'
 import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from '@/components/ui/Empty'
@@ -211,10 +214,55 @@ function RoundBody({ report }: { report: RoundReport }) {
   }
 }
 
+/*
+  `POST /assessment-sessions/reviews`의 오류 4종 — schema.d.ts의 표를 그대로 옮긴다.
+  `REVIEW_NOT_ELIGIBLE`은 실패가 아니라 안내다(스펙 명시) — 그래서 톤을 `info`로 가른다.
+*/
+function reviewOpenErrorMessage(e: unknown): { variant: 'info' | 'danger'; text: string } {
+  const code = isApiError(e) ? e.code : null
+  switch (code) {
+    case 'REVIEW_NOT_ELIGIBLE':
+      return { variant: 'info', text: '다시 볼 개념이 없어요.' }
+    case 'REVIEW_ALREADY_COMPLETED':
+      return { variant: 'info', text: '이 회차의 다시 보기를 이미 마쳤어요. 새로고침해 주세요.' }
+    case 'REVIEW_SOURCE_NOT_READY':
+      return { variant: 'danger', text: '아직 준비되지 않았어요. 잠시 후 다시 시도해 주세요.' }
+    case 'REVIEW_REPORT_NOT_ACCESSIBLE':
+      return { variant: 'danger', text: '리포트를 찾을 수 없어요. 새로고침해 주세요.' }
+    default:
+      return {
+        variant: 'danger',
+        text: '다시 보기를 시작하지 못했어요. 잠시 후 다시 시도해 주세요.',
+      }
+  }
+}
+
 function PublishedBody({ report }: { report: Extract<RoundReport, { status: 'PUBLISHED' }> }) {
   // 문항 없음은 재시험 대상이 아니다 — 못한 게 아니라 안 물어본 것이라 다시 볼 것도 없다
   const retryCount = askedConcepts(report.concepts).filter((c) => c.isRetryTarget).length
   const relative = formatRelativeMonths(report.publishedAt, Date.now())
+  const navigate = useNavigate()
+  const openReview = useOpenReviewSession()
+  const [reviewError, setReviewError] = useState<{
+    variant: 'info' | 'danger'
+    text: string
+  } | null>(null)
+
+  /*
+    🔴 **버튼이 예전엔 그냥 `<Link to="/trainee/session?retry=1">`였다.** 세션 화면은
+    `retry` 쿼리를 어디서도 읽지 않고, REVIEW 응시를 만드는 것은 이 개설 API뿐이다
+    (`AssessmentReviewService.openReview` 참고) — 그래서 눌러도 "응시 없음" 화면으로
+    빠졌다(실사용 재현: 배하린 계정 등). 개설부터 하고 성공했을 때만 세션으로 보낸다.
+  */
+  async function handleStartReview() {
+    setReviewError(null)
+    try {
+      await openReview.mutateAsync({ body: { reportId: report.reportId } })
+      navigate('/trainee/session')
+    } catch (e) {
+      setReviewError(reviewOpenErrorMessage(e))
+    }
+  }
 
   return (
     <div className="flex flex-col gap-6">
@@ -250,13 +298,15 @@ function PublishedBody({ report }: { report: Extract<RoundReport, { status: 'PUB
           <Button
             size="sm"
             className="shrink-0"
-            nativeButton={false}
-            render={<Link to="/trainee/session?retry=1" />}
+            disabled={openReview.isPending}
+            onClick={handleStartReview}
           >
-            다시 보기
+            {openReview.isPending ? '여는 중…' : '다시 보기'}
           </Button>
         </div>
       )}
+
+      {reviewError && <Alert variant={reviewError.variant}>{reviewError.text}</Alert>}
 
       {/*
         🔴 **리포트 단위 잠금은 없어졌다.** 남는 가림막은 도달 2단 미만 개념의

--- a/src/features/trainee/report/_/api/api.ts
+++ b/src/features/trainee/report/_/api/api.ts
@@ -63,6 +63,9 @@ function toReport(r: ServerReport): RoundReport {
         status: 'PUBLISHED',
         // 상태가 PUBLISHED면 서버가 반드시 채우는 값들 — 스키마는 옵셔널이지만
         // 설명문이 "PUBLISHED에서만"이라고 못박았다. 없으면 빈 값이 낫다(화면이 죽지 않는다)
+        // reportId만 예외 — 없으면 다시 보기 개설이 애초에 걸 상대가 없으므로 회차 id로
+        // 대체해 서버가 REVIEW_REPORT_NOT_ACCESSIBLE로 명확히 거절하게 둔다(조용히 죽지 않는다)
+        reportId: r.reportId ?? r.id,
         publishedAt: r.publishedAt ?? '',
         curriculum: r.curriculum ?? '',
         concepts: (r.concepts ?? []).map(toConcept),

--- a/src/features/trainee/report/_/api/types.ts
+++ b/src/features/trainee/report/_/api/types.ts
@@ -69,6 +69,8 @@ type RoundBase = { id: string; label: string }
 
 export type PublishedReport = RoundBase & {
   status: 'PUBLISHED'
+  /** 다시 보기 개설(`POST /assessment-sessions/reviews`)에 넘기는 값 — `id`(회차)와 다르다 */
+  reportId: string
   publishedAt: string
   curriculum: string
   concepts: ConceptReport[]


### PR DESCRIPTION
## Summary
- The "다시 보기" button (home card CTA and report screen) only ever navigated to `/trainee/session?retry=1`. Nothing in the frontend reads that query param, and the only thing that actually creates a REVIEW attempt is `POST /assessment-sessions/reviews` (`useOpenReviewSession`, already generated but never called anywhere in the codebase). The session screen's plain "current session" check found nothing and fell back to a generic completed/no-session screen instead of starting the review.
- `MyReportScreen.tsx`'s retry button now calls `useOpenReviewSession({ body: { reportId } })` first and only navigates to `/trainee/session` on success, with per-error-code messages for the 4 documented failure cases (`REVIEW_NOT_ELIGIBLE` is an info notice per spec, not an error).
- The home status card's `START_REVIEW` CTA now routes to `/trainee/report?round=...` instead of straight to the dead session route, since that's where the fixed button lives.
- Added `reportId` to the `PublishedReport` type (needed to call the open-review API; distinct from the round id already on `RoundBase`).

## Root cause
Real, reproducible on production today for at least 2 accounts. The backend endpoint (`AssessmentReviewService.openReview`) was implemented and the frontend API client was code-generated, but nothing in the UI ever called it.

## Test plan
- [x] `npm run typecheck` / `npm run lint` / `npm run build` — all green
- [x] `npm run verify:ci` — full CI reproduction green
- [x] Live-verified against production data via a local dev server (proxies `/api` to the real backend): clicked the retry button on a real account with a pending retry, confirmed `POST /assessment-sessions/reviews` → `201` with a real `sessionId`/`mode: REVIEW`, and landed on the actual review intro screen ("다시 보기 시작하기 전에...") instead of the dead-end screen.