### PR TITLE
[Chore] Generate Dev Accounts from the Cohort Roster without Real Names

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,29 +11,43 @@ VITE_API_BASE=
 # 웜업 GET을 보낸 뒤에만 이 도메인을 쓴다. 코드에 하드코딩 기본값이 있어 필수는 아니다.
 VITE_API_ORIGIN_BASE=https://mmbvymzj5k.ap-northeast-1.awsapprunner.com
 
-# dev 전용 역할 전환 버튼(로그인 화면 하단 · 헤더 드롭다운)이 쓸 계정.
-# 없으면 그 버튼이 아예 안 나온다 — 기능이 없는 것이지 고장 난 것이 아니다.
+# ─────────────────────────────────────────────────────────────────────────────
+# dev 전용 테스트 계정 — 셋 다 gitignore 대상이고, 없으면 그 UI가 안 나올 뿐이다
+# (기능이 없는 것이지 고장 난 것이 아니다).
 #
-# ⚠️ 자격 증명이라 .env.example에는 값을 적지 않는다. .env.local에 넣는다(gitignore 대상).
+#   VITE_DEV_ACCOUNTS    로그인 화면 위쪽 「역할별 바로 입장」 버튼 — 역할당 하나
+#   VITE_TEAM_ACCOUNTS   그 아래 「케이스별 계정」 목록 — 한 기수 전원
+#   VITE_CASE_ACCOUNTS   같은 목록에 합쳐지는 두 번째 소스(아래 참고, 지금은 안 씀)
+#
+# ⚠️ **이 값들은 번들에 들어간다.** 배포본을 받으면 계정과 비밀번호를 볼 수 있다는 뜻이다.
+#    노출을 줄이는 것은 코드가 아니라 **어디에 넣느냐**다 — 운영 환경에는 넣지 않는다.
+#    같은 이유로 **팀원 실명을 넣지 않는다**(예전 owner 필드). 자리 구분이 필요하면
+#    `슬롯 N`처럼 번호만 쓰고, 누가 몇 번인지는 저장소 밖에서 정한다.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ⚠️ 자격 증명이라 .env.example에는 값을 적지 않는다. .env.local에 넣는다.
 #    JSON 배열 한 줄이고 label · email · password 세 키가 필요하다.
 # VITE_DEV_ACCOUNTS=[{"label":"슈퍼 어드민","email":"...","password":"..."},{"label":"오퍼레이터","email":"...","password":"..."}]
 
-# 교육생 상태별 테스트 계정은 위 한 줄이 아니라 별도 파일에서 온다 — 수십 개라 env로는
-# 담을 수 없다. 백엔드가 준 엑셀을 스크립트로 변환한다(출력은 gitignore 대상):
+# 한 기수 전원(오퍼레이터·매니저·교육생). 수백 개라 손으로 못 적는다 — 기관이 준
+# 마크다운 명부를 스크립트로 바꾼다(출력 둘 다 gitignore 대상):
 #
-#   node scripts/dev-accounts.mjs <엑셀경로>
+#   node scripts/dev-team-accounts.mjs <마크다운경로>
+#     → dev-team-accounts.json   로컬이 읽는다
+#     → dev-team-accounts.env    이 안의 두 줄을 Vercel 환경변수에 붙여 넣는다
 #
-# 비밀번호는 엑셀에 없어 위 VITE_DEV_ACCOUNTS의 값을 재사용한다. 파일이 없으면 로그인
-# 화면의 그 목록만 안 나오고 나머지는 그대로 동작한다.
-#
-# ⚠️ 배포본에는 그 파일이 없다(gitignore 대상이라 저장소에 없고, 저장소에 없으면 번들에도
-#    없다). 배포 화면에서도 목록을 보려면 스크립트가 함께 만드는 dev-accounts.env 한 줄을
-#    호스팅 환경변수에 넣는다 — 값은 위 JSON과 같은 내용이고, 파일이 있으면 파일이 이긴다.
-# VITE_CASE_ACCOUNTS={"measuredAt":"...","groups":[...]}
+# 파일이 있으면 파일이 이긴다 — 로컬에서 명부를 다시 돌렸을 때 환경변수에 박힌 낡은
+# 목록이 이기면 안 되기 때문이다. 배포본에는 파일이 없으므로(저장소에 없으면 번들에도
+# 없다) 환경변수가 유일한 경로다.
+# VITE_TEAM_ACCOUNTS={"groups":[{"label":"매니저","hint":null,"total":1,"accounts":[{"email":"...","password":"...","name":"...","className":"","teamName":"","note":"슬롯 1","owner":null}]}]}
 
-# 매니저·오퍼레이터를 팀원별로 나눈 계정 — 위 VITE_CASE_ACCOUNTS와 형태는 같지만
-# scripts/dev-accounts.mjs가 절대 건드리지 않는 별도 파일/변수다(교육생 엑셀을 다시
-# 돌려도 안 사라짐). 로컬은 dev-team-accounts.json(직접 작성, gitignore 대상), 배포는
-# 아래 한 줄을 Vercel 환경변수에 넣는다. className·teamName은 해당 없으면 ""로 둔다.
-# 담당자(owner) 이름은 VITE_CASE_ACCOUNTS의 담당자 목록과 같은 표기를 써야 필터가 합쳐진다.
-# VITE_TEAM_ACCOUNTS={"groups":[{"label":"매니저","hint":null,"total":1,"accounts":[{"email":"...","password":"...","name":"매니저용","className":"","teamName":"","note":null,"owner":"강민수"}]}]}
+# 교육생 **상태별**(미응시·응시중·창 닫힘…) 계정. 백엔드가 상태를 세워 준 엑셀이 올 때만
+# 쓴다 — `node scripts/dev-accounts.mjs <엑셀경로>`.
+#
+# 위 VITE_TEAM_ACCOUNTS와 형태가 같고 화면에서 **그룹만 합쳐진다.** 파일을 나눈 이유는
+# 이쪽이 엑셀을 다시 돌릴 때마다 통째로 재생성되기 때문이다 — 한 파일에 두면 손으로
+# 넣은 것이 재생성 때 날아간다.
+#
+# 지금은 비어 있다: 기수가 바뀌며 예전 상태별 엑셀이 무효가 됐고, 새 명부에는 상태가
+# 없다. 상태별 엑셀을 다시 받으면 그때 이 줄을 채운다.
+# VITE_CASE_ACCOUNTS={"measuredAt":"...","groups":[...]}

--- a/.gitignore
+++ b/.gitignore
@@ -46,5 +46,6 @@ docs/dev/portfolio-security-notes.md
 dev-accounts.json
 dev-accounts.env
 
-# 매니저·오퍼레이터 담당자별 계정 — 손으로 관리한다(스크립트가 안 건드림, quickLoginAccounts.ts 참고)
+# 한 기수 전원 명부 — 기관이 준 마크다운을 scripts/dev-team-accounts.mjs가 바꾼 것
 dev-team-accounts.json
+dev-team-accounts.env

--- a/scripts/dev-team-accounts.mjs
+++ b/scripts/dev-team-accounts.mjs
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+/*
+  기관이 준 **계정 목록 마크다운**을 로그인 화면이 읽는 JSON으로 바꾼다.
+
+    node scripts/dev-team-accounts.mjs <마크다운경로> [--out dev-team-accounts.json]
+
+  ## 왜 또 스크립트인가 — `dev-accounts.mjs`와 무엇이 다른가
+
+  | | 무엇을 받나 | 무엇이 들어 있나 |
+  |---|---|---|
+  | `dev-accounts.mjs` | 백엔드가 준 **엑셀** | 교육생 **상태별**(미응시·응시중·창 닫힘…) |
+  | 이 스크립트 | 기관이 준 **마크다운** | 한 기수 **전원**(오퍼레이터·매니저·교육생) |
+
+  앞은 *"이 상태를 보고 싶다"* 로 고르는 목록이고, 이쪽은 상태가 아예 없다. **역할별
+  전원 명부**라 고르는 축이 다르다(아래 「무엇으로 묶나」).
+
+  ## 입력 형식
+
+  `## <역할>` 밑에 `| # | 이름 | 이메일 | 비밀번호 |` 표가 오면 된다. 역할 이름은
+  `오퍼레이터` · `매니저` · `교육생` 셋을 찾는다.
+
+  ## 무엇으로 묶나 — 상태가 없으면 「소모」가 축이다
+
+  상태가 없으니 `미응시`처럼 화면이 갈리는 축으로는 못 나눈다. 그런데 교육생 계정은
+  **소모된다** — 세션을 시작하면 그 계정은 시작 전으로 안 돌아간다. 그래서 남는
+  질문은 하나다: *"어디까지 썼나."* 이메일의 t번호를 50개 단위로 끊어 **앞에서부터
+  차례로** 쓰게 한다. 이름 가나다순으로 묶으면 이 질문에 답할 수 없다.
+
+  오퍼레이터·매니저는 일곱뿐이라 묶을 것이 없다. 대신 `슬롯 N`을 붙인다.
+
+  ## 담당자 이름을 넣지 않는다
+
+  예전 판은 계정마다 `owner`에 **팀원 이름**을 적어 두고 화면이 그것으로 걸렀다.
+  이 저장소는 **외부에 공개**되고 이 값은 **번들에 그대로 들어가므로**, 팀원 이름을
+  넣으면 실명이 배포본에 실려 나간다. 그래서 `owner`를 전부 비우고 자리 번호만 남긴다 —
+  누가 몇 번인지는 저장소 밖에서 정한다.
+
+  `owner`가 비면 화면의 담당자 줄은 스스로 사라진다(`CaseAccountPicker`). 화면 코드를
+  고칠 필요가 없다.
+
+  ⚠️ **출력에는 비밀번호가 들어간다.** 출력 파일과 함께 만드는 `.env` 한 줄 모두
+  gitignore 대상이다. 배포 번들에 실린다는 사실은 그대로이므로 운영 환경에는 넣지 않는다.
+*/
+import { readFileSync, writeFileSync } from 'node:fs'
+
+/** 교육생을 끊는 단위. 소모된 자리를 앞에서부터 지워 나가는 크기다 */
+const BLOCK = 50
+
+/**
+ * 기수 명부 **밖**의 슈퍼 어드민 — `.env.local`의 기존 `VITE_DEV_ACCOUNTS`에서 가져온다.
+ *
+ * 기관 명부에는 슈퍼 어드민이 없다(기관 소속이 아니라 서비스 운영자다). 그런데 이 역할의
+ * 화면도 테스트해야 하므로 예전부터 쓰던 계정을 그대로 이어 받는다.
+ *
+ * 🔴 **여기에 값을 적어 두지 않는다.** 이 파일은 저장소에 들어가고 저장소는 외부에
+ * 공개된다 — 상수로 박으면 자격 증명이 그대로 공개된다. 자격 증명은 gitignore 대상인
+ * `.env.local`에만 산다.
+ *
+ * 못 찾으면 그 그룹만 빼고 나머지는 그대로 만든다. **하나뿐이라 슬롯을 붙이지 않는다** —
+ * 나눌 것이 없는데 번호를 주면 나눠 쓸 수 있다는 뜻이 된다.
+ */
+function readSuperAdmin() {
+  let raw
+  try {
+    raw = readFileSync('.env.local', 'utf8')
+  } catch {
+    return null
+  }
+  const line = raw.split('\n').find((l) => l.startsWith('VITE_DEV_ACCOUNTS='))
+  if (!line) return null
+  try {
+    const list = JSON.parse(line.slice('VITE_DEV_ACCOUNTS='.length).replace(/^'|'$/g, ''))
+    const hit = list.find((a) => a.label?.includes('슈퍼') || a.label?.includes('어드민'))
+    return hit ? { name: hit.label, email: hit.email, password: hit.password } : null
+  } catch {
+    return null
+  }
+}
+
+const SUPER_ADMIN = readSuperAdmin()
+
+const argv = process.argv.slice(2)
+const src = argv.find((a) => !a.startsWith('--'))
+const out = argv.includes('--out') ? argv[argv.indexOf('--out') + 1] : 'dev-team-accounts.json'
+
+if (!src) {
+  console.error('사용: node scripts/dev-team-accounts.mjs <마크다운경로> [--out 파일]')
+  process.exit(1)
+}
+
+/** `## 역할` 밑의 표를 역할별로 모은다 — 열 순서는 `# · 이름 · 이메일 · 비밀번호` */
+function readSections(text) {
+  const sections = new Map()
+  for (const chunk of text.split(/^## /m).slice(1)) {
+    const lines = chunk.split('\n')
+    const title = lines[0].split('(')[0].trim()
+    const rows = []
+    for (const line of lines.slice(1)) {
+      if (!line.startsWith('|')) continue
+      const cells = line.replace(/^\||\|$/g, '').split('|')
+      const [no, name, email, password] = cells.map((c) => c.trim())
+      // 헤더(`| # | 이름 |`)와 구분선(`|---|`)을 같은 자리에서 걸러낸다
+      if (cells.length < 4 || no === '#' || /^-+$/.test(no)) continue
+      rows.push({ name, email, password })
+    }
+    if (rows.length) sections.set(title, rows)
+  }
+  return sections
+}
+
+const sections = readSections(readFileSync(src, 'utf8'))
+
+const missing = ['오퍼레이터', '매니저', '교육생'].filter((r) => !sections.has(r))
+if (missing.length) {
+  // 조용히 빈 그룹을 내면 "왜 목록이 없지"로 시간을 쓴다
+  console.error(`마크다운에서 찾지 못한 역할: ${missing.join(' · ')}`)
+  console.error('`## 오퍼레이터` 같은 제목 밑에 표가 있어야 합니다.')
+  process.exit(1)
+}
+
+const operators = sections.get('오퍼레이터')
+const managers = sections.get('매니저')
+const trainees = sections.get('교육생')
+
+/** 이름이 비어 있는 행이 실제로 온다 — 빈 칸으로 두면 어느 계정인지 못 읽는다 */
+const account = (row, note = null) => ({
+  email: row.email,
+  password: row.password,
+  name: row.name.replace('(이름 미기재)', '이름 없음') || '이름 없음',
+  /*
+    전원이 같은 기관이라 비운다. 266줄에 같은 기관명을 반복하면 이름·이메일이 들어갈
+    자리만 먹는다 — 모두 같은 값은 아무것도 구분해 주지 않는다.
+  */
+  className: '',
+  teamName: '',
+  note,
+  owner: null,
+})
+
+const group = (label, hint, accounts) => ({ label, hint, total: accounts.length, accounts })
+
+const SHARED_HINT = '7개뿐이라 겹치기 쉬워요 — 슬롯 번호를 나눠 쓰세요'
+const slots = (rows) => rows.map((r, i) => account(r, `슬롯 ${i + 1}`))
+
+const groups = [
+  group('오퍼레이터', SHARED_HINT, slots(operators)),
+  group('매니저', SHARED_HINT, slots(managers)),
+]
+
+if (SUPER_ADMIN) {
+  groups.push(
+    group('슈퍼 어드민', '기수 명부 밖 · 하나뿐이라 여럿이 동시에 쓰면 겹쳐요', [
+      account(SUPER_ADMIN),
+    ]),
+  )
+} else {
+  // 조용히 빠지면 "왜 슈퍼 어드민이 없지"로 시간을 쓴다
+  console.warn('  ⚠️ .env.local의 VITE_DEV_ACCOUNTS에서 슈퍼 어드민을 못 찾아 그룹을 뺐습니다')
+}
+
+// t번호가 있는 것과 없는 것을 가른다 — 번호가 없으면 「어디까지 썼나」에 못 넣는다
+const numbered = []
+const rest = []
+for (const row of trainees) {
+  const m = /^t(\d+)@/.exec(row.email)
+  if (m) numbered.push({ no: Number(m[1]), row })
+  else rest.push(row)
+}
+numbered.sort((a, b) => a.no - b.no)
+
+const TRAINEE_HINT = '쓴 계정은 되돌아오지 않아요 — 앞에서부터 차례로 쓰세요'
+const last = numbered.at(-1)?.no ?? 0
+for (let start = 1; start <= last; start += BLOCK) {
+  const end = start + BLOCK - 1
+  const rows = numbered.filter((n) => n.no >= start && n.no <= end)
+  if (!rows.length) continue
+  const pad = String(last).length
+  const label = `교육생 t${String(start).padStart(pad, '0')}–t${String(end).padStart(pad, '0')}`
+  groups.push(
+    group(
+      label,
+      TRAINEE_HINT,
+      rows.map(({ row }) => account(row)),
+    ),
+  )
+}
+if (rest.length) {
+  groups.push(
+    group(
+      '교육생 그 외',
+      't번호가 아닌 계정',
+      rest.map((r) => account(r)),
+    ),
+  )
+}
+
+const data = { groups }
+writeFileSync(out, JSON.stringify(data, null, 2) + '\n')
+
+/*
+  배포용 한 줄도 같이 낸다. 파일만 내면 배포 화면에서 목록이 영영 안 나온다 —
+  gitignore 대상이라 저장소에 없고, 저장소에 없으면 번들에도 없기 때문이다.
+*/
+const envOut = out.replace(/\.json$/, '') + '.env'
+writeFileSync(
+  envOut,
+  `VITE_TEAM_ACCOUNTS='${JSON.stringify(data)}'\n\n` +
+    `VITE_DEV_ACCOUNTS='${JSON.stringify(
+      [
+        SUPER_ADMIN && { label: '슈퍼 어드민', ...pick(SUPER_ADMIN) },
+        { label: '오퍼레이터', ...pick(operators[0]) },
+        { label: '매니저', ...pick(managers[0]) },
+        { label: '교육생', ...pick(numbered[0]?.row ?? trainees[0]) },
+      ].filter(Boolean),
+    )}'\n`,
+)
+
+function pick({ email, password }) {
+  return { email, password }
+}
+
+const total = groups.reduce((n, g) => n + g.total, 0)
+console.log(`${src} → ${out} · ${envOut}`)
+console.log(`  계정 ${total}개 · 그룹 ${groups.length}종`)
+for (const g of groups) console.log(`    ${g.label.padEnd(20)} ${String(g.total).padStart(3)}`)
+
+// 같은 계정이 두 줄에 있으면 하나는 이미 남이 쓴 것이다 — 조용히 넘기면 안 된다
+const emails = groups.flatMap((g) => g.accounts.map((a) => a.email))
+const dupes = emails.filter((e, i) => emails.indexOf(e) !== i)
+if (dupes.length)
+  console.warn(`  ⚠️ 이메일 중복 ${dupes.length}건: ${[...new Set(dupes)].join(' ')}`)

--- a/scripts/dev-team-accounts.mjs
+++ b/scripts/dev-team-accounts.mjs
@@ -14,19 +14,32 @@
   앞은 *"이 상태를 보고 싶다"* 로 고르는 목록이고, 이쪽은 상태가 아예 없다. **역할별
   전원 명부**라 고르는 축이 다르다(아래 「무엇으로 묶나」).
 
-  ## 입력 형식
+  ## 입력 형식 — 열 자리는 **헤더에서 찾는다**
 
-  `## <역할>` 밑에 `| # | 이름 | 이메일 | 비밀번호 |` 표가 오면 된다. 역할 이름은
-  `오퍼레이터` · `매니저` · `교육생` 셋을 찾는다.
+  `## <역할>` 밑에 표가 오면 된다. 역할 이름은 `오퍼레이터` · `매니저` · `교육생`
+  셋을 찾는다. 열 수는 역할마다 다르다:
 
-  ## 무엇으로 묶나 — 상태가 없으면 「소모」가 축이다
+    오퍼레이터  | # | 이름 | 이메일 | 상태 | 비밀번호 |
+    매니저      | # | 이름 | 이메일 | 상태 | 담당 반 | 비밀번호 |
+    교육생      | # | 이름 | 이메일 | 상태 | 반 | 팀(4차) | 비밀번호 |
 
-  상태가 없으니 `미응시`처럼 화면이 갈리는 축으로는 못 나눈다. 그런데 교육생 계정은
-  **소모된다** — 세션을 시작하면 그 계정은 시작 전으로 안 돌아간다. 그래서 남는
-  질문은 하나다: *"어디까지 썼나."* 이메일의 t번호를 50개 단위로 끊어 **앞에서부터
-  차례로** 쓰게 한다. 이름 가나다순으로 묶으면 이 질문에 답할 수 없다.
+  🔴 처음엔 넷으로 고정해 읽었는데 `상태`·`반`·`팀`이 끼어들며 어긋났다. 네 번째 칸을
+  비밀번호로 읽어 **전 계정의 비밀번호가 `ACTIVE`가 됐다**(실측). 표는 266줄을 멀쩡히
+  뱉고 로그인만 전부 실패하므로 눈으로는 안 잡힌다.
 
-  오퍼레이터·매니저는 일곱뿐이라 묶을 것이 없다. 대신 `슬롯 N`을 붙인다.
+  ## 무엇으로 묶나 — **반**이다
+
+  예전 명부에는 반이 없어 이메일의 t번호를 50개씩 끊었다("어디까지 썼나"). 이제 명부가
+  반·팀을 주므로 반으로 묶는다 — 화면을 볼 때 묻는 것이 "t120번 썼나"가 아니라
+  *"이 반 매니저로 이 반 학생을 보고 싶다"* 이기 때문이다.
+
+  **매니저가 자기 반 맨 앞에 선다.** 두 화면을 같은 반으로 짝지어 보게 되는데, 역할별로
+  목록이 갈려 있으면 두 그룹을 오가며 이름을 맞춰야 한다. 한 사람이 두 반을 맡으면
+  (`담당 반: E반, G반`) 양쪽에 다 넣는다.
+
+  소모 순서는 **팀 번호**가 대신한다 — 반 안에서 1팀부터 차례로 쓰면 된다.
+
+  오퍼레이터·슈퍼 어드민은 반이 없고 수가 적어 겹치기 쉽다. `슬롯 N`을 붙여 맨 앞에 둔다.
 
   ## 담당자 이름을 넣지 않는다
 
@@ -42,9 +55,6 @@
   gitignore 대상이다. 배포 번들에 실린다는 사실은 그대로이므로 운영 환경에는 넣지 않는다.
 */
 import { readFileSync, writeFileSync } from 'node:fs'
-
-/** 교육생을 끊는 단위. 소모된 자리를 앞에서부터 지워 나가는 크기다 */
-const BLOCK = 50
 
 /**
  * 기수 명부 **밖**의 슈퍼 어드민 — `.env.local`의 기존 `VITE_DEV_ACCOUNTS`에서 가져온다.
@@ -88,22 +98,47 @@ if (!src) {
   process.exit(1)
 }
 
-/** `## 역할` 밑의 표를 역할별로 모은다 — 열 순서는 `# · 이름 · 이메일 · 비밀번호` */
+const cellsOf = (line) =>
+  line
+    .replace(/^\||\|$/g, '')
+    .split('|')
+    .map((c) => c.trim())
+
+/**
+ * `## 역할` 밑의 표를 역할별로 모은다 — **열 자리는 헤더에서 찾는다.**
+ *
+ * 🔴 자리를 박아 두면 안 된다. 역할마다 열이 다르고(오퍼레이터 5 · 매니저 6 · 교육생 7),
+ * 다음 명부에서 또 바뀐다. 박아 두었을 때 네 번째 칸(`상태`)을 비밀번호로 읽어 전
+ * 계정이 `ACTIVE`가 됐는데, **표는 266줄을 멀쩡히 뱉어서** 로그인해 보기 전까지
+ * 몰랐다. 이름으로 찾으면 열이 늘어도 그대로 맞고, 없으면 아래에서 멈춘다.
+ */
 function readSections(text) {
   const sections = new Map()
   for (const chunk of text.split(/^## /m).slice(1)) {
-    const lines = chunk.split('\n')
-    const title = lines[0].split('(')[0].trim()
-    const rows = []
-    for (const line of lines.slice(1)) {
-      if (!line.startsWith('|')) continue
-      const cells = line.replace(/^\||\|$/g, '').split('|')
-      const [no, name, email, password] = cells.map((c) => c.trim())
-      // 헤더(`| # | 이름 |`)와 구분선(`|---|`)을 같은 자리에서 걸러낸다
-      if (cells.length < 4 || no === '#' || /^-+$/.test(no)) continue
-      rows.push({ name, email, password })
-    }
-    if (rows.length) sections.set(title, rows)
+    const all = chunk.split('\n')
+    const title = all[0].split('(')[0].trim()
+    const table = all.filter((l) => l.startsWith('|'))
+    if (!table.length) continue
+
+    const head = cellsOf(table[0])
+    // `팀(4차)`처럼 괄호로 단서를 달아 오므로 앞부분만 맞으면 같은 열로 본다
+    const at = (name) => head.findIndex((h) => h.split('(')[0].trim() === name)
+    const col = { name: at('이름'), email: at('이메일'), password: at('비밀번호') }
+
+    const rows = table
+      .slice(1)
+      .map(cellsOf)
+      // 구분선(`|---|`)은 헤더 바로 밑에 온다
+      .filter((cells) => !/^-+$/.test(cells[0]))
+      .map((cells) => ({
+        name: cells[col.name],
+        email: cells[col.email],
+        password: cells[col.password],
+        /** 역할마다 다른 열(`반`·`팀`·`담당 반`)은 호출부가 이름으로 꺼낸다 */
+        get: (colName) => cells[at(colName)],
+      }))
+
+    if (rows.length) sections.set(title, { col, rows })
   }
   return sections
 }
@@ -118,37 +153,57 @@ if (missing.length) {
   process.exit(1)
 }
 
-const operators = sections.get('오퍼레이터')
-const managers = sections.get('매니저')
-const trainees = sections.get('교육생')
+/*
+  🔴 **필요한 열이 없으면 여기서 멈춘다.** 없는 열은 `-1`이 되어 `cells[-1]`,
+  즉 `undefined`를 조용히 낸다 — 비밀번호가 통째로 빈 목록이 나오고 그것을 로그인
+  화면에서야 알게 된다. 이름·이메일·비밀번호 셋은 없으면 계정 구실을 못한다.
+*/
+for (const [role, { col }] of sections) {
+  const gone = Object.entries(col)
+    .filter(([, i]) => i < 0)
+    .map(([k]) => ({ name: '이름', email: '이메일', password: '비밀번호' })[k])
+  if (gone.length) {
+    console.error(`「${role}」 표에서 못 찾은 열: ${gone.join(' · ')}`)
+    console.error('헤더 이름이 바뀌었는지 확인하세요.')
+    process.exit(1)
+  }
+}
 
-/** 이름이 비어 있는 행이 실제로 온다 — 빈 칸으로 두면 어느 계정인지 못 읽는다 */
-const account = (row, note = null) => ({
+const operators = sections.get('오퍼레이터').rows
+const managers = sections.get('매니저').rows
+const trainees = sections.get('교육생').rows
+
+/**
+ * 이름이 비어 있는 행이 실제로 온다 — 빈 칸으로 두면 어느 계정인지 못 읽는다.
+ *
+ * `className`·`teamName`은 목록에서 이름 앞에 붙는다(`A반 1팀 문재윤`). 기관명은
+ * 전원이 같아 안 넣는다 — 266줄에 같은 값을 반복하면 이름·이메일 자리만 먹고 아무것도
+ * 구분해 주지 않는다. 반·팀은 다르다: **그것으로 그룹을 나누고 순서를 정한다.**
+ */
+const account = (row, { className = '', teamName = '', note = null } = {}) => ({
   email: row.email,
   password: row.password,
   name: row.name.replace('(이름 미기재)', '이름 없음') || '이름 없음',
-  /*
-    전원이 같은 기관이라 비운다. 266줄에 같은 기관명을 반복하면 이름·이메일이 들어갈
-    자리만 먹는다 — 모두 같은 값은 아무것도 구분해 주지 않는다.
-  */
-  className: '',
-  teamName: '',
+  className,
+  teamName,
   note,
   owner: null,
 })
 
 const group = (label, hint, accounts) => ({ label, hint, total: accounts.length, accounts })
 
-const SHARED_HINT = '7개뿐이라 겹치기 쉬워요 — 슬롯 번호를 나눠 쓰세요'
-const slots = (rows) => rows.map((r, i) => account(r, `슬롯 ${i + 1}`))
+const SHARED_HINT = '수가 적어 겹치기 쉬워요 — 슬롯 번호를 나눠 쓰세요'
+const slots = (rows) => rows.map((r, i) => account(r, { note: `슬롯 ${i + 1}` }))
 
-const groups = [
-  group('오퍼레이터', SHARED_HINT, slots(operators)),
-  group('매니저', SHARED_HINT, slots(managers)),
-]
+/*
+  **반이 없는 역할이 맨 앞이다.** 오퍼레이터·슈퍼 어드민은 기수 전체를 보는 자리라
+  어느 반에도 안 붙는다. 뒤에 두면 반 열 개를 지나야 나오는데, 화면 전체를 훑는 일은
+  반을 고르는 일보다 자주 온다.
+*/
+const groups = [group('오퍼레이터', SHARED_HINT, slots(operators))]
 
 if (SUPER_ADMIN) {
-  groups.push(
+  groups.unshift(
     group('슈퍼 어드민', '기수 명부 밖 · 하나뿐이라 여럿이 동시에 쓰면 겹쳐요', [
       account(SUPER_ADMIN),
     ]),
@@ -158,40 +213,63 @@ if (SUPER_ADMIN) {
   console.warn('  ⚠️ .env.local의 VITE_DEV_ACCOUNTS에서 슈퍼 어드민을 못 찾아 그룹을 뺐습니다')
 }
 
-// t번호가 있는 것과 없는 것을 가른다 — 번호가 없으면 「어디까지 썼나」에 못 넣는다
-const numbered = []
-const rest = []
-for (const row of trainees) {
-  const m = /^t(\d+)@/.exec(row.email)
-  if (m) numbered.push({ no: Number(m[1]), row })
-  else rest.push(row)
-}
-numbered.sort((a, b) => a.no - b.no)
+/*
+  ## 반으로 묶는다 — 매니저가 자기 반 맨 앞에 선다
 
-const TRAINEE_HINT = '쓴 계정은 되돌아오지 않아요 — 앞에서부터 차례로 쓰세요'
-const last = numbered.at(-1)?.no ?? 0
-for (let start = 1; start <= last; start += BLOCK) {
-  const end = start + BLOCK - 1
-  const rows = numbered.filter((n) => n.no >= start && n.no <= end)
-  if (!rows.length) continue
-  const pad = String(last).length
-  const label = `교육생 t${String(start).padStart(pad, '0')}–t${String(end).padStart(pad, '0')}`
-  groups.push(
-    group(
-      label,
-      TRAINEE_HINT,
-      rows.map(({ row }) => account(row)),
-    ),
-  )
+  매니저 화면과 교육생 화면은 **같은 반을 놓고 짝으로** 본다. 역할별로 목록이 갈려
+  있으면 A반을 열려고 두 그룹을 오가며 이름을 맞춰야 한다.
+
+  한 사람이 두 반을 맡는다(`담당 반: E반, G반`). 그때는 **양쪽에 다 넣는다** — 그 반을
+  여는 데 필요한 계정이라 한쪽에만 두면 나머지 반에서 찾을 수 없다.
+
+  **설명(`hint`)은 안 붙인다.** 목록이 이미 그 말을 하고 있다 — 맨 윗줄이 `매니저 ·
+  담당 A반`이고 그 아래로 `A반 1팀`부터 번호가 올라간다. 같은 말을 문장으로 한 번 더
+  쓰면 스물여섯 줄을 밀어내고 첫 화면에서 계정이 그만큼 덜 보인다.
+*/
+const byClass = new Map()
+const noClass = []
+
+/** `A반` · `E반, G반` 모두 받는다 — 빈 칸(`-`)이면 배정이 없다는 뜻이다 */
+const classesOf = (raw) =>
+  (raw ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s && s !== '-')
+
+const into = (className) => {
+  if (!byClass.has(className)) byClass.set(className, { managers: [], students: [] })
+  return byClass.get(className)
 }
-if (rest.length) {
-  groups.push(
-    group(
-      '교육생 그 외',
-      't번호가 아닌 계정',
-      rest.map((r) => account(r)),
-    ),
-  )
+
+for (const row of managers) {
+  const owns = classesOf(row.get('담당 반'))
+  if (!owns.length) noClass.push(account(row, { note: '매니저 · 담당 반 없음' }))
+  for (const c of owns) {
+    into(c).managers.push(account(row, { className: c, note: `매니저 · 담당 ${owns.join(' ')}` }))
+  }
+}
+
+for (const row of trainees) {
+  const [className] = classesOf(row.get('반'))
+  const teamName = classesOf(row.get('팀'))[0] ?? ''
+  if (!className) {
+    noClass.push(account(row, { note: '교육생 · 반 배정 없음' }))
+    continue
+  }
+  into(className).students.push(account(row, { className, teamName }))
+}
+
+/** `1팀` → 1. 반 안에서는 팀 번호가 「어디까지 썼나」를 대신한다 */
+const teamNo = (a) => Number(/\d+/.exec(a.teamName)?.[0] ?? Number.MAX_SAFE_INTEGER)
+
+for (const className of [...byClass.keys()].sort()) {
+  const { managers: mgr, students } = byClass.get(className)
+  students.sort((a, b) => teamNo(a) - teamNo(b) || a.name.localeCompare(b.name, 'ko'))
+  groups.push(group(className, null, [...mgr, ...students]))
+}
+
+if (noClass.length) {
+  groups.push(group('반 없음', '명부에 반이 안 적혀 있다 — 반으로 갈리는 화면은 못 본다', noClass))
 }
 
 const data = { groups }
@@ -210,7 +288,7 @@ writeFileSync(
         SUPER_ADMIN && { label: '슈퍼 어드민', ...pick(SUPER_ADMIN) },
         { label: '오퍼레이터', ...pick(operators[0]) },
         { label: '매니저', ...pick(managers[0]) },
-        { label: '교육생', ...pick(numbered[0]?.row ?? trainees[0]) },
+        { label: '교육생', ...pick(trainees[0]) },
       ].filter(Boolean),
     )}'\n`,
 )
@@ -224,8 +302,14 @@ console.log(`${src} → ${out} · ${envOut}`)
 console.log(`  계정 ${total}개 · 그룹 ${groups.length}종`)
 for (const g of groups) console.log(`    ${g.label.padEnd(20)} ${String(g.total).padStart(3)}`)
 
-// 같은 계정이 두 줄에 있으면 하나는 이미 남이 쓴 것이다 — 조용히 넘기면 안 된다
-const emails = groups.flatMap((g) => g.accounts.map((a) => a.email))
-const dupes = emails.filter((e, i) => emails.indexOf(e) !== i)
-if (dupes.length)
-  console.warn(`  ⚠️ 이메일 중복 ${dupes.length}건: ${[...new Set(dupes)].join(' ')}`)
+/*
+  같은 계정이 **한 그룹 안에** 두 번 있으면 명부가 겹쳐 적힌 것이다 — 조용히 넘기면
+  안 된다. 그룹을 가로질러 겹치는 것은 정상이다: 두 반을 맡은 매니저는 양쪽에 일부러
+  넣는다(위 「반으로 묶는다」). 그래서 검사도 그룹 안에서만 한다.
+*/
+for (const g of groups) {
+  const seen = g.accounts.map((a) => a.email)
+  const dupes = [...new Set(seen.filter((e, i) => seen.indexOf(e) !== i))]
+  if (dupes.length)
+    console.warn(`  ⚠️ ${g.label} 이메일 중복 ${dupes.length}건: ${dupes.join(' ')}`)
+}


### PR DESCRIPTION
## 작업 내용

기수가 바뀌며 테스트 계정 명부가 통째로 갈렸다(상태별 엑셀 → 기관이 준 마크다운 명부).

* `scripts/dev-team-accounts.mjs` 추가 — 명부 마크다운을 `dev-team-accounts.json`과
  배포용 `.env` 두 줄로 바꾼다. 의존성 없이 node만 쓴다(`dev-accounts.mjs`와 같은 방침).
* **팀원 실명(`owner`) 제거** — 자리 구분이 필요한 오퍼레이터에는 `슬롯 N`만 남긴다.
* **열 자리를 헤더에서 찾는다** — 역할마다 열 수가 다르고 다음 명부에서 또 바뀐다.
* **반으로 묶는다** — 매니저가 자기 반 맨 앞, 학생은 팀 순.
* `.env.example` 정리 — 세 변수가 각각 무엇인지, 번들에 실린다는 경고.
* `.gitignore`에 `dev-team-accounts.env` 추가.

## 리뷰 포인트

**① 🔴 열을 박아 읽으면 조용히 깨진다 — 실제로 깨졌다**

반·팀이 붙은 명부를 넣었더니 **전부 멀쩡히 나오고 로그인만 실패**했다.

```
{"email":"op1@naver.com","password":"ACTIVE"}
```

열을 넷(`# · 이름 · 이메일 · 비밀번호`)으로 고정해 읽는데 `상태`·`반`·`팀`이 끼어들어
역할마다 열 수가 달라졌다:

```
오퍼레이터  | # | 이름 | 이메일 | 상태 | 비밀번호 |
매니저      | # | 이름 | 이메일 | 상태 | 담당 반 | 비밀번호 |
교육생      | # | 이름 | 이메일 | 상태 | 반 | 팀(4차) | 비밀번호 |
```

개수도 맞고 표도 정상이라 **로그인해 보기 전까지 모른다.** 헤더 이름으로 자리를 찾게
바꾸고, 이름·이메일·비밀번호 중 하나라도 없으면 **그 자리에서 멈춘다** — 없는 열은
`cells[-1]`, 즉 `undefined`를 조용히 낸다.

**② 묶는 축을 t번호 → 반으로 옮겼다**

t번호 50개씩 끊은 것은 **명부에 반이 없던 시절의 차선책**이었다. 상태가 없으니 남는
축이 「어디까지 썼나」뿐이라 그렇게 했는데, 이제 명부가 반·팀을 준다.

화면을 볼 때 묻는 것은 *"t120번 썼나"* 가 아니라 *"이 반 매니저로 이 반 학생을 보고
싶다"* 이다. 소모 순서는 **팀 번호**가 대신한다 — 반 안에서 1팀부터 차례로 쓰면 된다.

```
슈퍼 어드민  1     A반 26   C반 26   E반 26   G반 26   I반 25
오퍼레이터   7     B반 26   D반 26   F반 26   H반 26   J반 26
                                                      반 없음 3
```

**③ 매니저를 자기 반 맨 앞에 세웠다**

```
F반 박지현      jihyun@naver.com   매니저 · 담당 A반 F반
F반 1팀 노태현   t137@naver.com
F반 1팀 서윤슬   t142@naver.com
```

두 화면을 **같은 반으로 짝지어** 보는데, 역할별로 목록이 갈려 있으면 A반을 열려고 두
그룹을 오가며 이름을 맞춰야 한다. 한 사람이 두 반을 맡으면(`담당 반: E반, G반`)
**양쪽에 다 넣는다** — 그 반을 여는 데 필요한 계정이라 한쪽에만 두면 나머지 반에서
찾을 수 없다. 그래서 이메일 중복 검사도 **그룹 안에서만** 한다.

**④ 반 그룹에는 설명을 안 붙인다**

맨 윗줄이 `매니저 · 담당 A반`이고 그 아래로 `A반 1팀`부터 번호가 올라간다 — 목록이
이미 그 말을 하고 있다. 같은 말을 문장으로 한 번 더 쓰면 스물여섯 줄을 밀어내고 첫
화면에서 계정이 그만큼 덜 보인다. 오퍼레이터·슈퍼 어드민 쪽은 남겼다(공유 계정이라
나눠 써야 한다는 것은 목록만 봐서는 모른다).

**⑤ 화면 코드는 한 줄도 안 건드렸다**

`owner`를 전부 `null`로 두면 `CaseAccountPicker`가 담당자 줄을 안 그리도록 이미 되어
있어서(`CASE_ACCOUNT_OWNERS`가 비면 그 블록이 통째로 빠진다) 데이터만 바꾸면 됐다.
`className`·`teamName`도 표시부가 빈 값을 알아서 건너뛴다.

**⑥ 슈퍼 어드민을 `.env.local`에서 읽는다**(`readSuperAdmin`)

명부 밖 계정이라 어딘가에서 가져와야 하는데, 스크립트에 상수로 박으면 공개 저장소에
자격 증명이 들어간다. 못 찾으면 그 그룹만 빼고 경고한다.

> `scripts/dev-accounts.mjs`(상태별 엑셀)는 **남겨 뒀다.** 지금은 쓸 엑셀이 없지만
> 상태별 계정을 다시 받으면 필요하고, 두 소스는 화면에서 그룹만 합쳐진다.

## 확인

- [x] 로컬에서 동작 확인
      · `node scripts/dev-team-accounts.mjs <명부.md>` → 270개 / 13그룹
      · 로그인 화면에 「케이스별 계정 270개」, 반별 그룹, 담당자 줄 사라짐
      · **실계정 로그인** — `jihyun@naver.com` → MANAGER 박지현 ·
        `t016@naver.com` → TRAINEE 문재윤 · `op1@naver.com` → OPERATOR 김오퍼
      · 고르개에서 눌러서 `/manager/dashboard`까지 진입
      · 커밋 diff에 비밀번호·계정 이메일·팀원 실명 **0건**
- [x] 하나의 PR = 하나의 기능
- [x] `npm run verify:ci` 10단계 전부 통과

## 배포 시 함께 할 것

계정 데이터는 자격 증명이라 저장소에 없다. Vercel 환경변수를 바꿔야 화면에 뜬다.

* `VITE_DEV_ACCOUNTS` · `VITE_TEAM_ACCOUNTS` → 스크립트가 낸 `dev-team-accounts.env` 값으로 교체
* `VITE_CASE_ACCOUNTS` → **삭제** (예전 상태별 엑셀 데이터, 지금은 안 씀)

> 📌 명부에는 F반 담당이 비어 있었는데(매니저 7명이 아홉 반만 덮었다) 기관이 **박지현을
> F반에 함께 배정**했다고 알려 와서 `담당 반`을 `A반, F반`으로 고쳐 다시 돌렸다. 두 반을
> 맡는 세 번째 사례라 코드는 그대로다 — 양쪽 그룹 맨 앞에 같이 선다.

closes #306
