### PR TITLE
[Fix] Pull Concept Candidates from the Chosen Curriculum Version

### DIFF
--- a/src/features/operator/projects/queries.ts
+++ b/src/features/operator/projects/queries.ts
@@ -276,6 +276,18 @@ export function useConceptCandidates(projectId: string, enabled = true) {
  * 생성 모달은 회차를 만들기 전에 개념을 고르는데 `findConceptCandidates`는
  * `projectId`를 요구한다. 섹션 조회가 같은 매핑을 주고 **겹치는 여섯 필드가 이름·타입·
  * 의미까지 같아서**(9차 R2 회신) 같은 컴포넌트로 그릴 수 있다.
+ *
+ * 🔴 **`versionId`를 반드시 같이 보낸다 — 안 보내면 서버가 최신 버전으로 해석한다.**
+ *
+ * 한때 `materialId`만 보내고 결과를 `c.versionId`로 태깅했다. **가져온 곳과 표시한
+ * 출처가 달랐다** — 고른 것이 v1이어도 후보는 v2에서 왔고, 그 `mappingId`가 그대로
+ * 검증 개념으로 확정된다. 리포트와 면담 브리프는 `curriculumVersionId` + 쪽 번호로
+ * 교안 위치를 펴므로(`types.ts` `VerificationConcept` 주석), **발행된 리포트가 엉뚱한
+ * 쪽을 가리키게 된다.**
+ *
+ * 교안마다 버전이 하나뿐인 동안에는 드러나지 않았는데, 개정판을 올려도 이전 버전이
+ * 연결 후보에 남는 것을 실측으로 확인하면서(45차 R2) 실제로 고를 수 있는 상태가 됐다.
+ * `sections`가 `?versionId=`를 받게 되어 지금은 정확히 지정할 수 있다.
  */
 export function useSectionCandidates(curricula: Curriculum[]) {
   return useQuery({
@@ -297,7 +309,11 @@ export function useSectionCandidates(curricula: Curriculum[]) {
       */
       const lists: ConceptCandidate[][] = []
       for (const c of curricula) {
-        const sections = await findSections({ path: { materialId: c.materialId } })
+        const sections = await findSections({
+          path: { materialId: c.materialId },
+          // 고른 그 버전에서 가져온다 — 아래 `curriculumVersionId`와 반드시 같은 값이어야 한다
+          query: { versionId: c.versionId },
+        })
         lists.push(
           sections.flatMap((s) =>
             s.items.map((it) => ({


### PR DESCRIPTION
## 작업 내용

회차를 만들 때 고르는 **개념 후보를 고른 버전이 아니라 최신 버전에서 가져오고 있었다.**

```ts
const sections = await findSections({ path: { materialId: c.materialId } })  // ← 최신에서 가져옴
...
curriculumVersionId: c.versionId,                                           // ← 고른 버전으로 태깅
```

가져온 곳과 표시한 출처가 다르다. v1을 골라도 후보는 v2에서 오고, 그 `mappingId`가 그대로 검증 개념으로 확정된다. 리포트와 면담 브리프는 `curriculumVersionId` + 쪽 번호로 교안 위치를 펴므로 **발행된 리포트가 엉뚱한 쪽을 가리킨다.** `findSections`에 `?versionId=`를 같이 넘긴다.

## 리뷰 포인트

- **`#308`에 이 커밋이 있었는데 머지 스냅샷에 안 들어갔다** — 푸시와 머지 버튼 타이밍이 엇갈렸다. 그 커밋(`28102fd`)을 그대로 체리픽했고, 필요한 `?versionId=` 재생성은 이미 develop에 있다
- 교안마다 버전이 하나뿐인 동안에는 드러나지 않던 자리다. 새 버전 업로드가 #308로 열리면서 실제로 밟히는 경로가 됐다

## 확인

- [x] 로컬에서 동작 확인
- [x] 하나의 PR = 하나의 기능

closes #313
