### PR TITLE
[Fix] Add ANALYSIS_FAILED Report Status

### DIFF
--- a/src/features/trainee/report/MyReportScreen.tsx
+++ b/src/features/trainee/report/MyReportScreen.tsx
@@ -155,6 +155,22 @@ function RoundBody({ report }: { report: RoundReport }) {
         />
       )
     /*
+      2026-08-21 추가 — 코드 분석이 실패해 이해도 확인 문항 자체가 없는 회차. `PENDING_PUBLISH`와
+      같은 문구를 쓰면 안 된다 — 저쪽은 "곧 나온다"는 약속이고 이쪽은 "이 회차는 리포트가
+      안 나온다"는 사실이다(실사용 재현: 이미 지난 발행 예정일을 계속 기다리게 보임).
+      정확한 실패 사유는 이 화면 계약에 없다 — 홈의 ANALYSIS_FAILED 안내가 더 자세히 보여준다.
+    */
+    case 'ANALYSIS_FAILED':
+      return (
+        <ReportStatusCard
+          variant="warning"
+          icon={<TriangleAlertIcon className="size-5" />}
+          title="코드를 분석하지 못했어요"
+          description="제출한 코드 분석이 실패해서 이 회차는 리포트를 만들 수 없어요."
+          aux="제출 화면에서 다시 제출하면 분석이 다시 시작돼요 — 계속 안 되면 매니저에게 알려 주세요"
+        />
+      )
+    /*
       **`NOT_STARTED`와 `NOT_ATTEMPTED`는 정반대다**(26차 A1). 둘 다 "응시 기록이
       없다"지만 제출 마감을 기준으로 갈린다 — 앞은 아직 시간이 있는 정상이고, 뒤는
       기회가 지나간 것이다. 그래서 매니저 안내(`aux`)는 **뒤에만** 붙는다. 마감 전

--- a/src/features/trainee/report/_/api/api.ts
+++ b/src/features/trainee/report/_/api/api.ts
@@ -41,15 +41,17 @@ function toReport(r: ServerReport): RoundReport {
   const base = { id: r.id, label: r.label }
 
   /*
-    **캐스트를 지웠다**(2026-08-20). 백엔드가 배포되고 `npm run api:pull`·`api:gen`을
-    돌려 **생성 타입이 `IN_PROGRESS`를 실제로 포함하게 됐다** — 이 자리에 있던
-    `as ServerReport['status'] | 'IN_PROGRESS'`는 스키마가 그 값을 모르던 동안의
-    임시 조치였고, 그 주석이 "재생성 후에는 지워도 된다"고 적어 둔 그대로다.
+    **캐스트가 다시 필요해졌다**(2026-08-21). `IN_PROGRESS`는 백엔드 배포+스키마
+    재생성으로 캐스트를 지울 수 있었는데(위 히스토리), `ANALYSIS_FAILED`는 아직
+    백엔드 PR이 배포 전이라 생성 타입이 이 값을 모른다. 캐스트를 빼면 컴파일은 되지만
+    (스위치가 여전히 소진적이라) 실제로 서버가 `ANALYSIS_FAILED`를 보내는 순간 아래
+    case가 죽은 코드 취급돼 무시되고 `undefined`가 반환돼 화면이 죽는다. 백엔드
+    배포 후 스키마 재생성하면 이 캐스트는 다시 지워도 된다 — `IN_PROGRESS` 때와 같은 절차.
 
-    이제 상태가 하나 늘면 **컴파일러가 이 switch에서 잡는다** — 캐스트가 남아 있으면
-    그 안전망이 계속 꺼져 있게 된다.
+    지역 변수로 뽑아서 switch를 거는 이유도 그때와 같다 — 캐스트 식을 switch에 바로
+    걸면 case 안에서 `r.status`를 다시 읽을 때 좁혀진 타입이 전파되지 않는다.
   */
-  const status = r.status
+  const status = r.status as ServerReport['status'] | 'ANALYSIS_FAILED'
 
   switch (status) {
     case 'PUBLISHED':
@@ -70,6 +72,8 @@ function toReport(r: ServerReport): RoundReport {
       return { ...base, status: 'PENDING_PUBLISH', publishAfter: r.publishAfter ?? null }
     case 'IN_PROGRESS':
       return { ...base, status: 'IN_PROGRESS' }
+    case 'ANALYSIS_FAILED':
+      return { ...base, status: 'ANALYSIS_FAILED' }
     case 'NOT_STARTED':
     case 'NOT_ATTEMPTED':
     case 'VOID_ATTEMPT':

--- a/src/features/trainee/report/_/api/types.ts
+++ b/src/features/trainee/report/_/api/types.ts
@@ -5,8 +5,8 @@ import type { findMyReports_Response } from '@/api/reporting/reportingTypes'
   확정 모델은 `docs/dev/screens/tr-04-report.md`.
 
   16차에 요청한 봉투(`rounds` + `reportsById`)가 그대로 왔다. 상태는 글자까지 같아서
-  화면 분기가 산다(2026-08-20 기준 7종 — `IN_PROGRESS` 추가). 그래서 여기서 새로
-  짓는 것은 **목이 지어냈던 두 군데뿐**이다.
+  화면 분기가 산다(2026-08-21 기준 8종 — `IN_PROGRESS`·`ANALYSIS_FAILED` 추가). 그래서
+  여기서 새로 짓는 것은 **목이 지어냈던 두 군데뿐**이다.
 */
 
 type Server = findMyReports_Response
@@ -103,6 +103,16 @@ export type RoundReport =
    * 없다 — 필요하면 TR-01 홈의 스테퍼가 더 자세히 보여준다.
    */
   | (RoundBase & { status: 'IN_PROGRESS' })
+  /**
+   * 코드 분석이 실패해 리포트를 만들 근거가 없다(2026-08-21 추가) — 리포트 행이 아예
+   * 없을 때만이다. `PENDING_PUBLISH`와 갈라야 한다: 이쪽은 리포트가 영영 안 나온다는
+   * 사실이고, 그쪽은 곧 나온다는 약속이다.
+   *
+   * 🔴 **`PENDING_PUBLISH`로 잘못 뜨던 버그를 고친 값이다.** 분석 실패로 끝난 회차가
+   * "리포트를 만들고 있어요 · 발행 예정 N월 N일 이후"로 뜨는데 그 발행 예정일은 이미
+   * 지나 있었다(실사용 재현: 문주안 계정 미니프로젝트 3차).
+   */
+  | (RoundBase & { status: 'ANALYSIS_FAILED' })
   /**
    * 제출 마감 **전**이고 아직 응시하지 않았다 — 정상이고 아직 시간이 있다.
    * `NOT_ATTEMPTED`(마감이 지나도록 안 함)와 갈라야 한다(26차 A1) — 한 문구로 묶으면

--- a/src/features/trainee/report/labels.ts
+++ b/src/features/trainee/report/labels.ts
@@ -73,6 +73,13 @@ export function buildRailNote(report: RoundReport | undefined): string | undefin
     */
     case 'IN_PROGRESS':
       return '진행 중'
+    /*
+      2026-08-21 추가 — 분석 실패로 끝났고 리포트가 아예 없는 회차. `PENDING_PUBLISH`의
+      "응시 완료"를 그대로 쓰면 안 된다 — 리포트가 곧 나온다는 뜻인데 이쪽은 영영 안
+      나온다는 뜻이다.
+    */
+    case 'ANALYSIS_FAILED':
+      return '분석 실패'
     // 마감 전(아직 할 수 있다)과 마감 후(기회가 지났다)를 레일에서도 가른다 — 본문과
     // 다른 말을 하면 목록을 훑을 때와 열었을 때 인상이 달라진다
     case 'NOT_STARTED':


### PR DESCRIPTION
## Summary
- A round whose code analysis failed and has no report row was shown with `PENDING_PUBLISH`'s "응시 완료" / "리포트를 만들고 있어요 · 발행 예정 N월 N일 이후" — a promise already weeks past its own date, for a report that can never be generated. The home screen already tells the same student to resubmit; this screen didn't agree with it.
- Adds `ANALYSIS_FAILED` to the `RoundReport` union, the rail note, and `MyReportScreen`'s status card, mirroring the `IN_PROGRESS` addition from yesterday.
- Pairs with **Team-IZ/Backend#164** (not yet deployed), which adds the new status server-side.

## Note on the temporary cast
`api.ts` needs `as ServerReport['status'] | 'ANALYSIS_FAILED'` again since the backend PR isn't live yet and the generated schema doesn't know this value. Same procedure as `IN_PROGRESS` — remove the cast after the backend PR ships and `api:gen` is rerun.

## Test plan
- [x] `npm run typecheck` / `npm run lint` / `npm run build` — all green
- [x] `npm run verify:ci` — full CI reproduction green

**Not merging this PR yet — opening for review only.**