### PR TITLE
[Fix] Center the Interview Brief in the Content Area

### DIFF
--- a/src/features/manager/interviews/InterviewBriefScreen.tsx
+++ b/src/features/manager/interviews/InterviewBriefScreen.tsx
@@ -262,7 +262,17 @@ function BriefSheet({ brief, cohortName }: { brief: Brief; cohortName: string })
   }
 
   return (
-    <>
+    /*
+      머리와 본문을 **한 틀에 넣어 같이 가운데로 보낸다.**
+
+      🔴 전에는 본문에만 `max-w-[820px]`이 있고 `mx-auto`가 없어, 1512폭에서 본문이
+      **왼쪽 0 · 오른쪽 429px**로 통째로 쏠렸다(실측). 본문에만 `mx-auto`를 붙이면
+      이번엔 머리(뒤로가기·이름·배지)가 셸 폭 그대로 남아 **머리와 본문의 왼쪽 선이
+      어긋난다** — 둘은 같은 문서의 제목과 몸통이라 같은 틀을 써야 한다.
+
+      `w-full`이 같이 붙는다 — 안 붙이면 좁은 폭에서 내용만큼만 줄어든다.
+    */
+    <div className="mx-auto w-full">
       <div className="mb-5 flex items-center gap-3">
         <Button
           variant="ghost"
@@ -282,7 +292,7 @@ function BriefSheet({ brief, cohortName }: { brief: Brief; cohortName: string })
         <RiskBadge riskType={brief.riskType} />
       </div>
 
-      <div className="max-w-[820px] pb-8">
+      <div className="pb-8">
         <Block no={1} title="여는 말">
           {/* **서버가 만든 문장을 그대로 읽는다** — 화면이 문장을 짓지 않는다 */}
           <div className="bg-primary-soft text-fg rounded-md p-4 text-sm leading-[1.85] whitespace-pre-line">
@@ -353,7 +363,7 @@ function BriefSheet({ brief, cohortName }: { brief: Brief; cohortName: string })
         </Block>
 
         <Block no={3} title="원인">
-          <div className="flex flex-wrap gap-1.5">
+          <div className="flex flex-wrap gap-3">
             {CAUSE_OPTIONS.map((o) => {
               const active = causes.has(o.key)
               return (
@@ -530,7 +540,7 @@ function BriefSheet({ brief, cohortName }: { brief: Brief; cohortName: string })
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </>
+    </div>
   )
 }
 

--- a/src/features/manager/interviews/components/BriefSkeleton.tsx
+++ b/src/features/manager/interviews/components/BriefSkeleton.tsx
@@ -17,7 +17,7 @@ import { Skeleton } from '@/components/ui/Skeleton'
 
       ⑤ 기록    149px  (상세 사유 · 조치 · 추후 계획)
       액션 줄    34px
-      바깥 폭   max-w-[820px] · pb-8
+      바깥 폭   mx-auto max-w-[820px] · pb-8  (본문과 **같은 틀** — 안 맞추면 도착에서 좌우로 튄다)
 
   ⚠ 질문 수는 사람마다 다르다(4~7개 관측). **직전에 본 개수를 넘길 수 없는 화면**이라
   ②만 평균값으로 두고, 나머지는 내용 길이가 고정에 가까워 그대로 박는다.
@@ -43,7 +43,7 @@ function Block({ bodyH, children }: { bodyH: number; children: React.ReactNode }
 
 export default function BriefSkeleton() {
   return (
-    <div aria-hidden className="pb-8">
+    <div aria-hidden className="mx-auto w-full max-w-[820px] pb-8">
       {/* 머리 — 이름 · 기수 · 반 · 위험 배지 (34px + mb-5) */}
       <div className="mb-5 flex h-[34px] items-center gap-3">
         <Skeleton className="size-8 rounded-md" />


### PR DESCRIPTION
## 작업 내용

면담 브리프 본문이 화면 왼쪽 끝에 붙어 있었습니다. 1512폭 실측:

```
고치기 전   본문 820px  →  좌 0 · 우 429
고친 뒤     본문 820px  →  좌 215 · 우 214
```

- **머리와 본문을 한 틀에 넣었습니다.** 본문에만 `mx-auto`를 붙이면 머리(뒤로가기·이름·반·위험 배지)가 셸 폭 그대로 남아 **왼쪽 선이 어긋납니다** — 둘은 같은 문서의 제목과 몸통입니다
- **`BriefSkeleton`도 같은 폭·정렬로 맞췄습니다.** 주석에는 「바깥 폭 max-w-[820px]」라고 적혀 있었는데 코드에는 폭 제한이 없어 전체 폭으로 그려지고 있었습니다. 그대로 두면 브리프가 도착하는 순간 본문이 좌우로 튑니다 — AI 생성이 20초 넘게 걸리는 화면이라 스켈레톤을 쓰는 이유가 그 튐을 막는 것인데, 세로만 맞추고 가로를 놓친 자리였습니다

## 리뷰 포인트

- **820px은 안 넓혔습니다.** 1920폭에서 본문이 본문영역의 47%만 써서 좌우로 450px씩 비지만, 이 화면은 긴 산문(여는 말·질문·근거)을 읽는 화면이고 820px이면 한글 한 줄이 60자 안팎으로 읽기 폭 상한에 이미 닿습니다. 넓히면 휑함은 줄어도 읽기가 나빠지는 교환입니다
- **창 전체 기준이 아니라 본문영역 기준으로 가운데입니다.** 사이드바 184px 때문에 두 기준이 92px 어긋나는데, 다른 매니저 화면이 전부 본문영역 기준이라 여기만 바꾸면 화면 사이에서 흔들립니다
- `w-full`을 같이 붙였습니다 — 없으면 좁은 폭에서 내용만큼만 줄어듭니다. 1024폭에서 셸 폭에 그대로 맞고 가로 스크롤 없는 것 확인했습니다

## 확인

- [x] 로컬에서 동작 확인 (5175 · 9기 4차 · 송서준 · 1512/1920/1024폭 실측)
- [x] 하나의 PR = 하나의 기능

closes #318
