### PR TITLE
[Fix] Polish Round Grid Table on Analysis Screen

### DIFF
--- a/src/features/operator/analysis/AnalysisScreen.tsx
+++ b/src/features/operator/analysis/AnalysisScreen.tsx
@@ -492,8 +492,8 @@ export default function AnalysisScreen() {
                 </div>
                 {/* 필수/선택 경계가 곧 위험 판정 기준이다 */}
                 <span className="text-fg-subtle text-2xs leading-tight">
-                  1·2단이 <b className="text-fg-muted font-medium">필수</b>
-                  <span className="block">그 아래면 처방 대상입니다</span>
+                  <b className="text-fg-muted font-medium">2단 미만</b>에 도달할 경우
+                  <span className="block">조치 대상으로 판단합니다.</span>
                 </span>
               </div>
             </StaleBlock>

--- a/src/features/operator/analysis/_/components/RoundGridTable.tsx
+++ b/src/features/operator/analysis/_/components/RoundGridTable.tsx
@@ -29,6 +29,15 @@ const graded = (row: GridRow) => row.size - total(row.uncounted)
 
 const KINDS = ['absent', 'invalid', 'aborted'] as const
 
+/*
+  표 전체 폭 계산에 쓰는 열 폭 상수 — 프로젝트(회차) 열이 늘어도 각 열이 이 아래로
+  안 눌리게 표 자체의 최소 폭을 계산한다(사용자 지적: 나중에 프로젝트가 많아지면
+  다른 영역을 침범한다). 아래 리터럴 클래스(`w-[172px]` 등)와 값을 맞춰 둔다.
+*/
+const ROW_NAME_COL = 172
+const UNCOUNTED_COL = 232
+const PROJECT_COL_MIN = 92
+
 /**
  * 미집계 — **총계만 쓰면 어디를 볼지가 안 나온다**(OP-02 §4-2). 세 종류가 서로 다른 곳을
  * 가리킨다: 미응시는 반 운영, 무효는 세션 설계·응시 태도(9-4), 중단은 기술 문제.
@@ -44,7 +53,9 @@ function UncountedCell({ u }: { u: GridRow['uncounted'] }) {
   const n = total(u)
   if (n === 0) {
     // 0을 강조하지 않는다 — 없음과 0을 다르게 표시한다(F3)
-    return <span className="text-fg-subtle pr-[52px]">—</span>
+    // pr 오프셋으로 자리를 흉내 내던 것을 지운다(사용자 지시: 가운데 정렬) — 값이 있는
+    // 행과 똑같이 이 칸 전체 폭(flex)을 쓰고 그 안에서 가운데 정렬한다.
+    return <span className="text-fg-subtle flex justify-center">—</span>
   }
   return (
     <span
@@ -53,7 +64,7 @@ function UncountedCell({ u }: { u: GridRow['uncounted'] }) {
         .map((k) => `${UNCOUNTED_LABEL[k]} ${u[k]}`)
         .join(' · ')}
     >
-      <b className="w-7 text-right text-fg-muted font-semibold tabular-nums">{n}</b>
+      <b className="w-11 text-center text-xs text-fg-muted font-semibold tabular-nums">{n}</b>
       {/*
         **테두리·구분선을 뺐다.** 칩마다 상자를 두면 행 11개 × 선 4개가 잔선으로 쌓여
         표가 지저분해진다 — 폭이 고정돼 있으면 상자 없이도 열이 맞고, **열 머리의 라벨과
@@ -63,7 +74,7 @@ function UncountedCell({ u }: { u: GridRow['uncounted'] }) {
         {KINDS.map((k) => (
           <span
             key={k}
-            className={`w-8 text-center text-2xs tabular-nums ${
+            className={`w-11 text-center text-xs tabular-nums ${
               u[k] > 0 ? `font-medium ${UNCOUNTED_CLASS[k]}` : 'text-fg-subtle/25'
             }`}
           >
@@ -85,7 +96,15 @@ export default function RoundGridTable({ grid }: { grid: RoundGrid }) {
 
   return (
     <div className="overflow-x-auto">
-      <table className="w-full table-fixed border-separate border-spacing-0 text-sm">
+      <table
+        className="table-fixed border-separate border-spacing-0 text-sm"
+        // 프로젝트 열이 늘어도 최소 폭(PROJECT_COL_MIN/열)을 보장 — 부족하면 카드
+        // 밖으로 안 밀려나고 이 표 안에서만 가로 스크롤된다(사용자 지적: 프로젝트가
+        // 많아지면 다른 영역을 침범한다).
+        style={{
+          width: `max(100%, ${ROW_NAME_COL + UNCOUNTED_COL + grid.columns.length * PROJECT_COL_MIN}px)`,
+        }}
+      >
         <thead>
           <tr>
             {/*
@@ -134,20 +153,22 @@ export default function RoundGridTable({ grid }: { grid: RoundGrid }) {
               무엇인지 알 수 없고, 범례는 표 아래 오른쪽 끝이라 눈이 왕복해야 한다.
               표에서 그 일을 하는 것은 열 머리다 — 세 칸 위에 세 라벨을 얹는다.
             */}
-            <th className="w-[216px] pb-2 pl-4 align-bottom">
+            <th className="w-[232px] pb-2 pl-4 align-bottom">
               {/*
-                설명 줄(`채점에서 빠져 분모가 줄었습니다`)을 뺐다 — **행 이름 열이
-                `25명 → 채점 21`로 직접 보여주므로** 같은 말이 두 곳에 있었다.
+                "채점에서 빠진 사람" 제목 줄을 지웠다(사용자 지시) — 대신 첫 칸에 "합계"를
+                넣어 굵은 숫자가 무엇인지 라벨 자리에서 바로 말한다.
               */}
-              <span className="text-fg block text-right text-xs font-semibold">
-                채점에서 빠진 사람
-              </span>
               <span className="mt-0.5 flex items-end justify-end gap-0">
-                <span className="w-7" />
+                <span
+                  className="text-fg-subtle w-11 text-center text-2xs"
+                  title="채점에서 빠진 사람 합계"
+                >
+                  합계
+                </span>
                 {KINDS.map((k) => (
                   <span
                     key={k}
-                    className={`w-8 text-center text-2xs ${UNCOUNTED_CLASS[k]}`}
+                    className={`w-11 text-center text-2xs ${UNCOUNTED_CLASS[k]}`}
                     title={UNCOUNTED_LABEL[k]}
                   >
                     {UNCOUNTED_SHORT[k]}

--- a/src/features/operator/analysis/_/components/RoundToolbar.tsx
+++ b/src/features/operator/analysis/_/components/RoundToolbar.tsx
@@ -423,13 +423,25 @@ function RoundSelect({
         {label && <ControlLabel>{label}</ControlLabel>}
         <SelectValue placeholder={loading ? '불러오는 중' : '고르세요'} />
       </SelectTrigger>
-      <SelectContent>
+      {/*
+        min-w-64 — 기본 min-w-36(144px)이 "10차 미니프로젝트"를 못 담아 "..." 없이
+        그냥 잘렸다(사용자 지적, 실측 렌더 확인). 트리거 폭(placeholder 기준, 위 주석)은
+        그대로 두고 팝업 폭만 넓힌다 — anchor-width보다 min-width가 더 넓으면 그만큼
+        커진다.
+      */}
+      <SelectContent className="min-w-64">
         {rounds.map((r) => (
-          <SelectItem key={r.projectId} value={String(r.no)}>
-            {r.label}
-            <span className="text-fg-subtle ml-1.5 text-2xs">{r.projectName}</span>
+          <SelectItem
+            key={r.projectId}
+            value={String(r.no)}
+            title={`${r.label} · ${r.projectName}${r.published ? '' : ' · 미발행'}`}
+          >
+            {/* 회차 번호는 절대 줄지 않고, 교안명만 남는 공간에서 줄어들다 넘치면
+                "..."로 생략한다(min-w-0이 있어야 flex 안에서 실제로 줄어든다) */}
+            <span className="shrink-0">{r.label}</span>
+            <span className="text-fg-subtle min-w-0 flex-1 truncate text-2xs">{r.projectName}</span>
             {/* **왜 값이 없는지**를 고르는 자리에서 말한다 — 고르고 나서 빈 열을 보지 않게 */}
-            {!r.published && <span className="text-fg-subtle ml-1.5 text-2xs">미발행</span>}
+            {!r.published && <span className="text-fg-subtle shrink-0 text-2xs">미발행</span>}
           </SelectItem>
         ))}
         {/*

--- a/src/features/operator/analysis/_/labels.ts
+++ b/src/features/operator/analysis/_/labels.ts
@@ -106,14 +106,16 @@ export const REACH_STEPS = [
  * 아니라 **표의 용도**라 걸리지 않는다 — 다만 한 줄을 넘기면 그때부터 잔소리다.
  */
 export const TAB_PURPOSE = {
-  rounds: '기수와 견줘 어느 반이 계속 벗어나 있는지 봅니다 — 붉은 칸이 가로로 이어지면 그 반입니다',
-  cohorts: '교안을 고친 것이 효과가 있었는지 봅니다 — 버전이 바뀐 개념의 값을 견줍니다',
+  rounds: '기수 전체와 비교해 어느 반이 계속 벗어나는지 보여줍니다.',
+  cohorts: '교안을 변경한 것이 효과가 있었는지 확인합니다.',
 } as const
 
 /** 정렬 4종은 **서로 다른 질문**이다(OP-02 §4-3) */
 export const ROUND_SORT_LABEL: Record<RoundSort, string> = {
-  LATEST_WORST: '최근 발행 프로젝트 나쁜 순',
-  WORSE_COUNT: '기준보다 나쁜 프로젝트가 많은 순',
+  // 문구 다듬음(사용자 지적) — WORSE_COUNT가 15자라 트리거(w-60)에서 잘렸다.
+  // 뜻은 그대로 두고 이 레포가 이미 같은 뜻으로 쓰는 "미달"(ClassOps.tsx 등)을 썼다.
+  LATEST_WORST: '최근 프로젝트 나쁜 순',
+  WORSE_COUNT: '기준 미달 많은 순',
   UNCOUNTED: '미집계 많은 순',
   NAME: '이름순',
 }


### PR DESCRIPTION
## 작업 내용

- 표 자체 최소폭을 프로젝트 열 개수 기반으로 계산해, 프로젝트가 늘어도 카드
  밖으로 안 밀리고 표 안에서만 가로 스크롤되도록 함
- "채점에서 빠진 사람" 열 정렬을 가운데로 맞추고 라벨을 "합계"로 축약
- 회차 선택 드롭다운 팝업 최소폭을 넓혀 긴 교안명이 안 잘리게 함
- 탭 설명·정렬 옵션 문구 다듬음

## 리뷰 포인트

- `RoundGridTable.tsx`의 표 폭 계산식(`ROW_NAME_COL + UNCOUNTED_COL +
  열수 * PROJECT_COL_MIN`)이 프로젝트 열이 많을 때도 카드 폭 안에서 잘
  동작하는지 실제 렌더로 확인 부탁드립니다
- 미집계 열 라벨을 "채점에서 빠진 사람" → "합계"로 축약한 것이 다른
  문맥에서 오해를 주지 않는지

closes #320