### PR TITLE
[Fix] Paint the Code Highlight Across the Full Scroll Width

### DIFF
--- a/src/features/trainee/session/components/CodePane.tsx
+++ b/src/features/trainee/session/components/CodePane.tsx
@@ -78,21 +78,30 @@ export default function CodePane({
           ref={preRef}
           className="h-full overflow-auto rounded-md bg-code py-3 font-mono text-sm leading-relaxed text-code-fg"
         >
-          {lines.map((row) => (
-            <div
-              key={row.line}
-              data-line={row.line}
-              className={cn(
-                'px-4',
-                inRange(row.line, highlight) && 'border-l-2 border-primary bg-primary/34',
-              )}
-            >
-              <span className="mr-3 inline-block w-6 text-right text-code-dim select-none">
-                {row.line}
-              </span>
-              {row.text}
-            </div>
-          ))}
+          {/*
+            줄을 감싸는 이 div가 **가장 긴 줄의 폭**을 갖는다(w-max) — 줄들은 그 안을
+            100%로 채우므로 어디까지 스크롤해도 하이라이트가 끊기지 않고 오른쪽 끝도
+            가지런하다. 이게 없으면 각 줄이 "보이는 폭"까지만 그려져 가로로 넘친 코드에는
+            하이라이트가 안 깔린다(실측: 380px에서 잘리고 실제 줄은 959px).
+            min-w-full은 파일이 전부 짧을 때 패널을 채우기 위한 것이다.
+          */}
+          <div className="w-max min-w-full">
+            {lines.map((row) => (
+              <div
+                key={row.line}
+                data-line={row.line}
+                className={cn(
+                  'px-4',
+                  inRange(row.line, highlight) && 'border-l-2 border-primary bg-primary/34',
+                )}
+              >
+                <span className="mr-3 inline-block w-6 text-right text-code-dim select-none">
+                  {row.line}
+                </span>
+                {row.text}
+              </div>
+            ))}
+          </div>
         </pre>
       </div>
 


### PR DESCRIPTION
## 작업 내용

이해도 검증 세션 코드 패널에서 하이라이트가 **패널 가시 폭까지만** 칠해지던 것을 고쳤다. 가로로 넘쳐 오른쪽에 숨은 코드에는 하이라이트가 안 깔렸다.

원인은 CSS다. 스크롤 컨테이너(`<pre overflow-auto>`) 안의 줄이 block `div`라 **컨테이너 content box 폭**만큼만 넓어진다 — 넘친 부분은 그리는 상자 밖이다.

줄들을 `w-max min-w-full` 래퍼 하나로 감싸 래퍼가 **가장 긴 줄**의 폭을 갖게 하고, 각 줄은 그 안을 100%로 채우게 했다.

## 리뷰 포인트

**래퍼를 두는 대신 줄마다 `w-max`를 주는 방법도 된다 — 안 골랐다.** 그러면 줄이 각자 내용 길이만큼만 넓어져(실측 477 / 570 / 680 / 959px) 여러 줄이 강조될 때 오른쪽 끝이 계단처럼 어긋난다. 래퍼 하나면 네 줄 모두 1117px로 가지런하다.

`min-w-full`은 파일이 전부 짧아 가로 스크롤이 없을 때 하이라이트가 패널을 채우게 하려고 남겼다.

## 확인

- [x] 로컬에서 동작 확인
- [x] 하나의 PR = 하나의 기능

실제 세션에서 실측했다 (B반 1팀 `t031` · 미프 4차 · `CohortService.java` 243줄, 하이라이트 48–51행):

| | 하이라이트 행 폭 |
|---|---|
| 수정 전 | 380px = 패널 `clientWidth`에서 잘림 |
| 수정 후 | 1117px = `scrollWidth` 전체 (네 줄 모두) |

`scrollLeft=600`으로 민 상태에서도 하이라이트가 끊기지 않는 것을 확인했다.

> 브랜치가 `develop`보다 뒤에 있지만 `develop`은 `CodePane.tsx`를 건드리지 않아 충돌이 없다. 같은 작업 폴더를 다른 세션이 쓰고 있어(§5) `develop` 머지로 워킹 트리를 덮지 않았다.

closes #324