### PR TITLE
[Fix] Polish Analysis Copy and Trainee Filter Width

### DIFF
--- a/src/components/common/ErrorState.tsx
+++ b/src/components/common/ErrorState.tsx
@@ -31,7 +31,7 @@ export default function ErrorState({ error, subject, onRetry, retrying, action }
     <Empty variant={copy.tone}>
       <EmptyHeader>
         <EmptyTitle>{copy.title}</EmptyTitle>
-        <EmptyDescription>{copy.description}</EmptyDescription>
+        <EmptyDescription className="whitespace-pre-line">{copy.description}</EmptyDescription>
       </EmptyHeader>
       {/* 둘 다 있으면 한 줄에 둔다 — 세로로 쌓이면 아래쪽이 부차적인 선택으로 안 읽힌다 */}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/features/manager/trainees/TraineeListScreen.tsx
+++ b/src/features/manager/trainees/TraineeListScreen.tsx
@@ -291,14 +291,17 @@ export default function TraineeListScreen() {
           value={accountFilter}
           onChange={(v) => changeFilters({ accountFilter: v as FilterValues['accountFilter'] })}
           options={ACCOUNT_OPTIONS.map((o) => ({ value: o.value, label: o.label }))}
-          // 기본 w-32(128px)가 "초대 대기"를 못 담아 잘렸다(사용자 지적, 실측 렌더 확인)
-          className="w-36"
+          // 기본 w-32(128px)가 "초대 대기"를 못 담아 잘렸다(사용자 지적, 실측 렌더 확인).
+          // w-36도 너무 빠듯해 보인다는 지적으로 w-40까지 넓힘(2차 실측 렌더 확인)
+          className="w-40"
         />
         <FilterSelect
           label="정렬"
           value={sort}
           onChange={(v) => changeFilters({ sort: v as TraineeSort })}
           options={SORT_OPTIONS.map((o) => ({ value: o.value, label: o.label }))}
+          // "계정"과 같은 폭으로 맞춘다
+          className="w-40"
         />
       </div>
 

--- a/src/features/operator/analysis/AnalysisScreen.tsx
+++ b/src/features/operator/analysis/AnalysisScreen.tsx
@@ -253,15 +253,15 @@ export default function AnalysisScreen() {
               <EmptyHeader>
                 <EmptyTitle>
                   {needs === 'ROUND'
-                    ? '어느 프로젝트의 팀을 볼지 골라 주세요'
+                    ? '프로젝트를 먼저 골라 주세요'
                     : needs === 'CLASS'
-                      ? '어느 반의 팀을 볼지 골라 주세요'
-                      : '프로젝트와 반을 골라 주세요'}
+                      ? '반을 먼저 골라 주세요'
+                      : '프로젝트와 반을 먼저 골라 주세요'}
                 </EmptyTitle>
                 <EmptyDescription>
-                  팀 번호는 반 안에서만 유일하고,{' '}
-                  <b className="font-semibold">팀은 프로젝트마다 다시 짜일 수 있어</b> 프로젝트를
-                  가로질러 같은 팀으로 볼 수 없습니다.
+                  <b className="font-semibold">팀은 프로젝트마다 다시 구성될 수 있어</b>
+                  <br />
+                  프로젝트를 변경하면 같은 팀이 아닐 수도 있습니다.
                 </EmptyDescription>
               </EmptyHeader>
             </Empty>
@@ -437,7 +437,7 @@ export default function AnalysisScreen() {
               <EmptyHeader>
                 <EmptyTitle>
                   {compare.data.availableCohorts.some((c) => c.comparable)
-                    ? '견줄 기수를 골라 주세요'
+                    ? '비교할 기수를 선택해 주세요'
                     : '비교할 기수가 없습니다'}
                 </EmptyTitle>
                 <EmptyDescription>

--- a/src/features/operator/analysis/_/components/RoundToolbar.tsx
+++ b/src/features/operator/analysis/_/components/RoundToolbar.tsx
@@ -385,7 +385,11 @@ function RoundSelect({
   disabled,
   loading,
 }: {
-  /** `null`이면 아직 안 고른 상태 — 트리거에 `고르세요`가 뜬다 */
+  /**
+   * `null`이면 아직 안 고른 상태 — 트리거는 라벨(`프로젝트`)만 두고 값 칸은 비워 둔다.
+   * `고르세요`를 넣었더니 `프로젝트 · 고르세요`가 트리거 폭 안에서 잘렸다(사용자 지적,
+   * 실측 렌더 확인) — 값이 없다는 것 자체가 "고르라"는 뜻이라 굳이 다시 말 안 해도 된다.
+   */
   value: number | null
   rounds: RoundColumn[]
   onChange: (v: number) => void
@@ -421,7 +425,8 @@ function RoundSelect({
       {/* 폭은 가장 긴 문구(`불러오는 중`)에 맞춘다 — 라벨이 붙는 쪽이 더 넓다 */}
       <SelectTrigger className={label ? 'w-36' : 'w-24'} aria-label="프로젝트" disabled={disabled}>
         {label && <ControlLabel>{label}</ControlLabel>}
-        <SelectValue placeholder={loading ? '불러오는 중' : '고르세요'} />
+        {/* 안 고른 기본값은 비워 둔다 — `고르세요`까지 넣으면 라벨과 합쳐 트리거 폭 안에서 잘렸다 */}
+        <SelectValue placeholder={loading ? '불러오는 중' : ''} />
       </SelectTrigger>
       {/*
         min-w-64 — 기본 min-w-36(144px)이 "10차 미니프로젝트"를 못 담아 "..." 없이

--- a/src/lib/errorCopy.ts
+++ b/src/lib/errorCopy.ts
@@ -66,7 +66,7 @@ const BY_CODE: Record<string, (ctx: Ctx) => ErrorCopy> = {
   */
   COHORT_REPORT_NOT_FOUND: () => ({
     title: '아직 발행된 리포트가 없습니다',
-    description: '미니프로젝트가 모두 끝나고 진단이 확정되면 여기에 리포트가 생깁니다.',
+    description: '미니프로젝트가 모두 끝나고\n진단이 확정되면 여기에 리포트가 생깁니다.',
     retry: false,
     tone: 'pending',
   }),


### PR DESCRIPTION
## 작업 내용

- 오퍼레이터 분석 화면 빈 상태 제목·설명 문구 정리
  ("프로젝트를 먼저/반을 먼저/프로젝트와 반을 먼저 골라 주세요",
  "팀은 프로젝트마다 다시 구성될 수 있어 / 프로젝트를 변경하면 같은 팀이
  아닐 수도 있습니다")
- 기수 비교 빈 상태 제목을 "비교할 기수를 선택해 주세요"로 교체
- 프로젝트 회차 셀렉트(RoundToolbar)의 안 고른 기본값 placeholder를 비워
  트리거 폭 안에서 잘리던 문제 해소("팀별"·"반별" 두 탭 모두 적용)
- 리포트 미발행 빈 상태 설명에 줄바꿈 추가(errorCopy.ts + 공용
  ErrorState.tsx에 whitespace-pre-line 추가)
- 매니저 명부 "계정"·"정렬" 필터 폭을 w-36 → w-40으로 확대

## 리뷰 포인트

- `errorCopy.ts`, `ErrorState.tsx`는 제 마지막 커밋이 아니라 팀장님
  마지막 수정 파일입니다(@jxxnixx) — 이번에 줄바꿈 표시를 위해
  `EmptyDescription`에 `whitespace-pre-line`을 추가했는데, 다른 화면의
  기존 에러 문구(줄바꿈 없는 것들)엔 시각적으로 영향 없는지 한 번
  봐주시면 좋겠습니다.
- `RoundSelect`의 placeholder를 빈 문자열로 바꾼 것 — 안 고른 상태에서
  라벨만 뜨고 값 칸이 비는 게 의도한 모습입니다. "고르세요"가 없어도
  헷갈리지 않는지 확인 부탁드립니다.

## 확인

- [ ] 로컬에서 동작 확인
- [ ] 하나의 PR = 하나의 기능

closes #326 