### PR TITLE
[Fix] Restore Missing Round Options in the Class-Level Picker

### DIFF
--- a/src/features/auth/InviteScreen.tsx
+++ b/src/features/auth/InviteScreen.tsx
@@ -501,6 +501,11 @@ export default function InviteScreen() {
                     autoComplete="new-password"
                     disabled={isSubmitting}
                     aria-invalid={!!errors.password}
+                    aria-describedby={
+                      policyUnmet.length > 0
+                        ? 'invite-password-error'
+                        : 'invite-password-description'
+                    }
                     {...passwordField}
                     onKeyDown={passwordCaps.onKeyDown}
                     onKeyUp={passwordCaps.onKeyUp}
@@ -529,9 +534,11 @@ export default function InviteScreen() {
                 )}
                 {/* 정책은 상시 노출, 제출 실패 시 미충족 기준만 danger로 (case6) */}
                 {policyUnmet.length > 0 ? (
-                  <FieldError>{policyUnmet.join(' · ')}</FieldError>
+                  <FieldError id="invite-password-error">{policyUnmet.join(' · ')}</FieldError>
                 ) : (
-                  <FieldDescription>8자 이상 · 영문·숫자·특수문자 포함</FieldDescription>
+                  <FieldDescription id="invite-password-description">
+                    8자 이상 · 영문·숫자·특수문자 포함
+                  </FieldDescription>
                 )}
               </Field>
 
@@ -545,6 +552,9 @@ export default function InviteScreen() {
                     autoComplete="new-password"
                     disabled={isSubmitting}
                     aria-invalid={!!errors.passwordConfirm}
+                    aria-describedby={
+                      errors.passwordConfirm ? 'invite-password-confirm-error' : undefined
+                    }
                     {...passwordConfirmField}
                     onKeyDown={passwordConfirmCaps.onKeyDown}
                     onKeyUp={passwordConfirmCaps.onKeyUp}
@@ -571,7 +581,9 @@ export default function InviteScreen() {
                     <Kbd>⇪ Caps Lock</Kbd> 켜짐 — 대문자로 입력됩니다.
                   </p>
                 )}
-                <FieldError>{errors.passwordConfirm?.message}</FieldError>
+                <FieldError id="invite-password-confirm-error">
+                  {errors.passwordConfirm?.message}
+                </FieldError>
               </Field>
 
               <ConsentList

--- a/src/features/auth/LoginScreen.tsx
+++ b/src/features/auth/LoginScreen.tsx
@@ -196,12 +196,13 @@ export default function LoginScreen() {
                 autoComplete="username"
                 disabled={isSubmitting}
                 aria-invalid={!!errors.email}
+                aria-describedby={errors.email ? 'login-email-error' : undefined}
                 {...register('email', {
                   required: '이메일을 입력해주세요.',
                   pattern: { value: EMAIL_PATTERN, message: EMAIL_INVALID_MESSAGE },
                 })}
               />
-              <FieldError>{errors.email?.message}</FieldError>
+              <FieldError id="login-email-error">{errors.email?.message}</FieldError>
             </Field>
 
             <Field data-invalid={!!errors.password}>
@@ -214,6 +215,7 @@ export default function LoginScreen() {
                   autoComplete="current-password"
                   disabled={isSubmitting}
                   aria-invalid={!!errors.password}
+                  aria-describedby={errors.password ? 'login-password-error' : undefined}
                   {...passwordField}
                   onKeyDown={passwordCaps.onKeyDown}
                   onKeyUp={passwordCaps.onKeyUp}
@@ -241,7 +243,7 @@ export default function LoginScreen() {
                   <Kbd>⇪ Caps Lock</Kbd> 켜짐 — 대문자로 입력됩니다.
                 </p>
               )}
-              <FieldError>{errors.password?.message}</FieldError>
+              <FieldError id="login-password-error">{errors.password?.message}</FieldError>
             </Field>
 
             {/* 알림은 비밀번호 아래 · 버튼 위 — 폼 위쪽에 두면 뜰 때마다 입력 필드가 밀린다 */}

--- a/src/features/auth/PasswordResetScreen.tsx
+++ b/src/features/auth/PasswordResetScreen.tsx
@@ -122,12 +122,13 @@ function RequestStage() {
           autoComplete="username"
           disabled={isSubmitting}
           aria-invalid={!!errors.email}
+          aria-describedby={errors.email ? 'reset-email-error' : undefined}
           {...register('email', {
             required: '이메일을 입력해주세요.',
             pattern: { value: EMAIL_PATTERN, message: EMAIL_INVALID_MESSAGE },
           })}
         />
-        <FieldError>{errors.email?.message}</FieldError>
+        <FieldError id="reset-email-error">{errors.email?.message}</FieldError>
       </Field>
 
       <div className="pt-1">
@@ -307,6 +308,9 @@ function SetPasswordStage({ token }: { token: string }) {
             autoComplete="new-password"
             disabled={isSubmitting}
             aria-invalid={!!errors.password}
+            aria-describedby={
+              errors.password ? 'reset-password-error' : 'reset-password-description'
+            }
             {...passwordField}
             onKeyDown={passwordCaps.onKeyDown}
             onKeyUp={passwordCaps.onKeyUp}
@@ -334,11 +338,13 @@ function SetPasswordStage({ token }: { token: string }) {
           </p>
         )}
         {errors.password ? (
-          <FieldError>
+          <FieldError id="reset-password-error">
             {policyUnmet.length > 0 ? policyUnmet.join(' · ') : errors.password.message}
           </FieldError>
         ) : (
-          <FieldDescription>8자 이상 · 영문·숫자·특수문자 포함</FieldDescription>
+          <FieldDescription id="reset-password-description">
+            8자 이상 · 영문·숫자·특수문자 포함
+          </FieldDescription>
         )}
       </Field>
 
@@ -352,6 +358,7 @@ function SetPasswordStage({ token }: { token: string }) {
             autoComplete="new-password"
             disabled={isSubmitting}
             aria-invalid={!!errors.passwordConfirm}
+            aria-describedby={errors.passwordConfirm ? 'reset-password-confirm-error' : undefined}
             {...passwordConfirmField}
             onKeyDown={passwordConfirmCaps.onKeyDown}
             onKeyUp={passwordConfirmCaps.onKeyUp}
@@ -378,7 +385,7 @@ function SetPasswordStage({ token }: { token: string }) {
             <Kbd>⇪ Caps Lock</Kbd> 켜짐 — 대문자로 입력됩니다.
           </p>
         )}
-        <FieldError>{errors.passwordConfirm?.message}</FieldError>
+        <FieldError id="reset-password-confirm-error">{errors.passwordConfirm?.message}</FieldError>
       </Field>
 
       <div className="pt-1">

--- a/src/features/operator/analysis/_/api/api.ts
+++ b/src/features/operator/analysis/_/api/api.ts
@@ -175,9 +175,11 @@ async function loadRoundGrid(q: RoundQuery): Promise<RoundGrid> {
   }
 
   /*
-    팀 계층은 **회차 목록을 따로 받는다.** 팀 조회는 고른 회차 하나만 돌려주므로
-    그 응답으로 선택지를 만들면 **고르는 순간 나머지 회차가 사라진다** — 다른 회차로
-    옮길 방법이 없어진다. 반별 조회 한 건이 회차 전체를 준다.
+    **선택지 목록은 항상 무필터 전체 조회에서 만든다.** 위 조회(`r`)는 회차 범위·반
+    필터가 걸린 응답이라 선택지로 못 쓴다 — 반별도 `fromRoundNo`·`toRoundNo`를 보내므로,
+    `r`로 회차 선택지를 만들면 **범위를 좁히는 순간 그 밖의 회차가 선택지에서
+    사라졌다**(사용자 지적, 실측 렌더 확인 — 6차 하나로 좁히면 1~5차가 통째로 없어짐).
+    팀 계층에서 먼저 발견된 것과 같은 문제라, 계층 상관없이 항상 따로 받는다.
   */
   const [r, all] = await Promise.all([
     findCohortRiskTraineeRates({
@@ -191,12 +193,11 @@ async function loadRoundGrid(q: RoundQuery): Promise<RoundGrid> {
         sort: SORT[q.sort],
       },
     }),
-    isTeam ? findCohortRiskTraineeRates({ path: { cohortId: q.cohortId } }) : null,
+    findCohortRiskTraineeRates({ path: { cohortId: q.cohortId } }),
   ])
 
   const columns = toColumns(r.rounds)
-  /** 선택지는 전체, 열은 조회 결과 — 팀 계층에서 둘이 갈린다 */
-  const allRounds = all ? toColumns(all.rounds) : columns
+  const allRounds = toColumns(all.rounds)
 
   /*
     **기준선이 계층에 따라 바뀐다**(OP-02 §3) — 반별이면 기수 전체, 팀이면 **그 반**이다.
@@ -230,11 +231,11 @@ async function loadRoundGrid(q: RoundQuery): Promise<RoundGrid> {
     baselineName: isTeam ? (r.classes[0]?.className ?? '') : '기수 전체',
     level: q.level,
     /*
-      **반 목록은 전량이어야 한다.** 팀 조회 응답(`r`)은 **고른 반 하나만** 담고 있어서
-      그것으로 선택지를 만들면 툴바가 `전체 1반`이 되고 **다른 반으로 옮길 수가 없다**
-      (실측). 회차 목록을 따로 받는 것과 같은 이유다.
+      **반 목록도 전량이어야 한다.** `r`은 반 필터·회차 범위가 걸린 응답이라 그것으로
+      선택지를 만들면 **이미 고른 반만 남고 나머지가 체크박스 목록에서 사라진다** —
+      회차와 같은 이유로 항상 무필터 응답(`all`)에서 만든다.
     */
-    allClasses: toClassOptions(all ?? r),
+    allClasses: toClassOptions(all),
   }
 }
 


### PR DESCRIPTION
## 작업 내용

- 반별(class) 탭에서 회차 범위를 좁히면(예: 6~6차) 회차 셀렉트 선택지가
  같이 좁혀져 나머지 회차가 사라지던 버그 수정 — 선택지를 무필터 전체
  조회로 따로 받도록 변경
- 같은 구조였던 반 체크박스 선택지(allClasses)도 동일 원인이라 같이 수정

## 리뷰 포인트

- `api.ts`는 제 마지막 커밋이 아니라 팀장님(@jxxnixx) 마지막 수정
  파일입니다. 팀 계층(팀별 탭)에서 이미 검증된 "선택지는 무필터 전체
  조회로 따로 받는다" 패턴을 반별에도 그대로 확장한 것이라, 팀 계층
  동작 자체는 안 건드렸습니다.
- 재현: 반별 탭에서 프로젝트를 6차 하나로 좁히면(범위 6~6) 셀렉트를 다시
  열었을 때 1~5차가 사라지는지 확인해주세요(수정 전 재현, 수정 후 안 사라짐).

## 확인

- [ ] 로컬에서 동작 확인
- [ ] 하나의 PR = 하나의 기능

closes #330 