### PR TITLE
[Remove] Drop ZIP Upload From Code Submission

### DIFF
--- a/src/api/uploads.ts
+++ b/src/api/uploads.ts
@@ -28,13 +28,6 @@ type RegisterCurriculumResponse =
 type RegisterCurriculumVersionResponse =
   operations['registerCurriculumVersion']['responses'][201]['content']['application/json']
 /*
-  **`202` — 접수만 하고 분석은 비동기로 돌린다.** 한동안 스펙이 `200`으로 적혀 있었는데
-  서버는 그때도 202를 보내고 있었고, 23차 요청으로 표기가 사실에 맞춰졌다.
-  선언이 바뀌면 여기서 컴파일이 깨지므로 스펙과 어긋난 채로 굳지 않는다.
-*/
-type SubmitZipResponse = operations['submitZip']['responses'][202]['content']['application/json']
-
-/*
   **손으로 쓰는 계약 — multipart 업로드.**
 
   `openapi-fetch`는 본문을 JSON으로 직렬화하는 것을 전제한다. 파일 업로드는 `FormData`를
@@ -170,43 +163,3 @@ export const registerCurriculumVersion = async (
     }) as never,
   )
 }
-
-/*
-  ─── 교육생 코드 제출 (ZIP) ──────────────────────────────────────────────────
-*/
-
-/**
- * ZIP 업로드 제출·재제출 — `POST /api/v0/submissions/zip`
- *
- * **`Idempotency-Key`가 필수다**(생략하면 400). 지금까지 우리가 안 쓰던 헤더인데,
- * 이 오퍼레이션이 처음으로 요구한다 — 서버가 대신 만들어 주지 않는다.
- *
- * ```
- * 재시도(타임아웃·5xx·네트워크)  →  같은 키   →  서버가 최초 결과를 돌려준다
- * 사용자가 다시 제출              →  새 키     →  별개의 제출
- * ```
- *
- * **키를 여기서 만들지 않는다.** 화면이 제출 버튼을 누른 순간 만들어 그 제출이 끝날
- * 때까지 들고 있어야 재시도가 같은 키를 쓴다 — 이 함수 안에서 만들면 호출마다 새 키가
- * 되어 멱등이 성립하지 않는다(스펙이 명시한 실패 방식이다).
- *
- * **접수만 하고 끝난다.** 서버가 보는 것은 크기·압축 형식뿐이고 `EMPTY_CODE` 같은
- * 내용 판정은 분석 단계에서 `failureCode`로 온다.
- */
-export const submitZip = (
-  params: {
-    query: { assessmentRoundId: string }
-    idempotencyKey: string
-    file: File
-  } & RequestOptions,
-) =>
-  unwrap<SubmitZipResponse>(
-    izClient.POST('/api/v0/submissions/zip', {
-      params: {
-        query: params.query,
-        header: { 'Idempotency-Key': params.idempotencyKey },
-      },
-      body: csvBody(params.file) as never,
-      signal: params.signal,
-    }) as never,
-  )

--- a/src/features/trainee/submission/SubmissionScreen.tsx
+++ b/src/features/trainee/submission/SubmissionScreen.tsx
@@ -6,13 +6,7 @@ import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from '@/components/u
 import { isApiError } from '@/api/_contract'
 import { formatDateTime } from '@/lib/format'
 import ConsoleShell from '@/shells/ConsoleShell'
-import {
-  useRepositoryCheck,
-  useSubmission,
-  useSubmitGithub,
-  useSubmitZip,
-  type RepoCheck,
-} from './_/api/api'
+import { useRepositoryCheck, useSubmission, useSubmitGithub, type RepoCheck } from './_/api/api'
 import SubmissionSkeleton from './components/SubmissionSkeleton'
 import type { SubmissionView } from './_/api/types'
 import { buildStateBanner, submitFailureOf, type SubmitFailure } from './labels'
@@ -29,35 +23,19 @@ import SubmittedContentCard from './components/SubmittedContentCard'
   **낙관적 전환을 걷어냈다.** 목은 제출 즉시 화면이 `ANALYZING` 카드를 지어냈는데, 지금은
   서버가 접수만 하고 분석을 비동기로 돌리므로 **제출 후 다시 읽어** 서버가 준 상태를 그린다.
 */
-/** 두 제출 수단 중 실제로 실패한 쪽의 사유. 아무 일 없으면 `null` */
+/** 제출이 실패한 사유. 아무 일 없으면 `null` */
 const failureOf = (e: unknown): SubmitFailure | null =>
   e == null ? null : submitFailureOf(isApiError(e) ? e.code : null)
 
 export default function SubmissionScreen() {
   const { data, isPending, isError, refetch, analysisFailureReason } = useSubmission()
-  const submit = useSubmitZip()
   const github = useSubmitGithub()
   const repoCheck = useRepositoryCheck()
   const [resubmitting, setResubmitting] = useState(false)
 
-  const handleSubmit = async (file: File) => {
-    if (!data) return
-    await submit.mutateAsync({
-      assessmentRoundId: data.assessmentRoundId,
-      /*
-        **제출 버튼을 누른 이 순간 키를 만든다.** 재시도(타임아웃·5xx)는 같은 키라야
-        서버가 최초 결과를 돌려주고, 사용자가 다시 제출하면 새 키가 되어 별개 제출이
-        된다 — `mutateAsync` 한 번이 곧 한 제출이라 여기가 그 경계다.
-      */
-      idempotencyKey: crypto.randomUUID(),
-      file,
-    })
-    setResubmitting(false)
-  }
-
   /*
     저장소 제출은 멱등키가 없다 — 파일을 올리는 것이 아니라 주소를 남기는 것이라
-    같은 주소를 두 번 내도 같은 결과다(ZIP은 재전송이 곧 재업로드라 키가 필요했다).
+    같은 주소를 두 번 내도 같은 결과다.
   */
   const handleSubmitRepository = async (repositoryUrl: string, branch: string) => {
     if (!data) return
@@ -94,11 +72,10 @@ export default function SubmissionScreen() {
             view={data}
             analysisFailureReason={analysisFailureReason}
             resubmitting={resubmitting}
-            submitting={submit.isPending || github.isPending}
-            failure={failureOf(submit.error ?? github.error)}
+            submitting={github.isPending}
+            failure={failureOf(github.error)}
             onResubmitClick={() => setResubmitting(true)}
             onCancelResubmit={() => setResubmitting(false)}
-            onSubmit={handleSubmit}
             onSubmitRepository={handleSubmitRepository}
             onCheckRepository={repoCheck.check}
             checking={repoCheck.isPending}
@@ -117,7 +94,6 @@ function SubmissionBody({
   failure,
   onResubmitClick,
   onCancelResubmit,
-  onSubmit,
   onSubmitRepository,
   onCheckRepository,
   checking,
@@ -131,7 +107,6 @@ function SubmissionBody({
   failure: SubmitFailure | null
   onResubmitClick: () => void
   onCancelResubmit: () => void
-  onSubmit: (file: File) => void
   onSubmitRepository: (repositoryUrl: string, branch: string) => void
   onCheckRepository: (repoUrl: string) => Promise<RepoCheck>
   checking: boolean
@@ -150,9 +125,9 @@ function SubmissionBody({
       {banner && <StateBanner {...banner} />}
 
       {/*
-        **서버가 준 이유를 그대로 옮긴다.** 접수 거절 코드가 13종인데 하나로 뭉치면
-        학생이 무엇을 해야 하는지 모른다 — 압축을 다시 하면 되는 경우와 기다려야 하는
-        경우가 섞인다. 재시도가 의미 없는 경우에는 그 말을 하지 않는다(`labels.ts`).
+        **서버가 준 이유를 그대로 옮긴다.** 접수 거절 코드가 여러 종인데 하나로 뭉치면
+        학생이 무엇을 해야 하는지 모른다 — 다시 내면 되는 경우와 기다려야 하는 경우가
+        섞인다. 재시도가 의미 없는 경우에는 그 말을 하지 않는다(`labels.ts`).
       */}
       {failure && (
         <div className="rounded-md bg-danger-soft px-4 py-3 text-sm text-danger">
@@ -171,7 +146,6 @@ function SubmissionBody({
         <SubmissionForm
           submitting={submitting}
           availableMethods={view.availableMethods}
-          onSubmit={onSubmit}
           onSubmitRepository={onSubmitRepository}
           onCheckRepository={onCheckRepository}
           checking={checking}
@@ -198,7 +172,6 @@ function SubmissionBody({
             <SubmissionForm
               submitting={submitting}
               availableMethods={view.availableMethods}
-              onSubmit={onSubmit}
               onSubmitRepository={onSubmitRepository}
               onCheckRepository={onCheckRepository}
               checking={checking}

--- a/src/features/trainee/submission/_/api/api.ts
+++ b/src/features/trainee/submission/_/api/api.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo } from 'react'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useQueryClient } from '@tanstack/react-query'
 import { isApiError } from '@/api/_contract'
 import { useGetMyAssessmentRounds } from '@/api/assessment/useAssessmentQueries'
 import { assessmentKeys } from '@/api/assessment/assessmentKeys'
@@ -10,7 +10,6 @@ import {
 import { submissionKeys } from '@/api/submission/submissionKeys'
 import type { findMySubmission_Response } from '@/api/submission/submissionTypes'
 import { useCheckRepository, useSubmitGithubUrl } from '@/api/submission/useSubmissionMutations'
-import { submitZip } from '@/api/uploads'
 import type { SubmissionMethod, SubmissionView } from './types'
 
 /*
@@ -206,43 +205,16 @@ function toView(s: Server, availableMethods: SubmissionMethod[]): SubmissionView
 }
 
 /**
- * ZIP 제출·재제출.
- *
- * **멱등키를 화면이 만들어 넘긴다.** 제출 버튼을 누른 순간 하나 만들어 그 제출이 끝날
- * 때까지 들고 있어야 재시도가 같은 키를 쓴다 — 여기서 만들면 호출마다 새 키가 되어
- * 멱등이 성립하지 않는다(uploads.ts 주석).
- *
- * **성공하면 제출 현황과 홈을 다시 읽는다.** 서버가 접수만 하고 분석은 비동기로 돌리므로
- * 화면이 상태를 지어내지 않고 서버가 준 것을 그린다 — 목이 하던 낙관적 전환을 걷어냈다.
- * 홈까지 무효화하는 이유는 카드의 대표 상태가 제출로 바뀌기 때문이다.
- */
-export function useSubmitZip() {
-  const queryClient = useQueryClient()
-  return useMutation({
-    mutationFn: (vars: { assessmentRoundId: string; idempotencyKey: string; file: File }) =>
-      submitZip({
-        query: { assessmentRoundId: vars.assessmentRoundId },
-        idempotencyKey: vars.idempotencyKey,
-        file: vars.file,
-      }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: submissionKeys.all })
-      queryClient.invalidateQueries({ queryKey: assessmentKeys.all })
-    },
-  })
-}
-
-/**
  * GitHub 저장소 제출.
  *
- * ZIP과 달리 **파일이 아니라 주소만 보낸다** — 서버는 형식·호스트만 검사하고 실제
- * 접근 가능 여부는 마감 후 분석에서 판정한다(스펙). 그래서 여기서 성공했다고 코드가
- * 읽혔다는 뜻은 아니다.
+ * **파일이 아니라 주소만 보낸다** — 서버는 형식·호스트만 검사하고 실제 접근 가능
+ * 여부는 마감 후 분석에서 판정한다(스펙). 그래서 여기서 성공했다고 코드가 읽혔다는
+ * 뜻은 아니다.
  *
  * `branch`는 비워도 된다 — AI 서버가 기본 브랜치를 골라 `resolvedBranch`로 회신한다.
  *
- * ⚠️ **ZIP과 똑같이 `Idempotency-Key`가 필수다**(생략하면 400). 파일을 안 올린다고
- * 예외가 아니다 — 재시도했을 때 제출이 둘로 갈리지 않게 하는 장치라 수단과 무관하다.
+ * ⚠️ **`Idempotency-Key`가 필수다**(생략하면 400) — 재시도했을 때 제출이 둘로
+ * 갈리지 않게 하는 장치다.
  */
 export function useSubmitGithub() {
   const queryClient = useQueryClient()
@@ -258,7 +230,7 @@ export function useSubmitGithub() {
         /*
           **제출 버튼을 누른 이 순간 키를 만든다.** 재시도는 같은 키라야 서버가 최초
           결과를 돌려주고, 사용자가 주소를 고쳐 다시 내면 새 키가 되어 별개 제출이 된다
-          — `submit` 한 번이 곧 한 제출이라 여기가 그 경계다(ZIP과 같은 규칙).
+          — `submit` 한 번이 곧 한 제출이라 여기가 그 경계다.
         */
         header: { 'Idempotency-Key': crypto.randomUUID() },
         body: {

--- a/src/features/trainee/submission/components/SubmissionForm.tsx
+++ b/src/features/trainee/submission/components/SubmissionForm.tsx
@@ -1,30 +1,17 @@
-import { CheckIcon, LockIcon, UploadIcon, XIcon } from 'lucide-react'
-import { useRef, useState } from 'react'
-import {
-  Attachment,
-  AttachmentActions,
-  AttachmentAction,
-  AttachmentContent,
-  AttachmentDescription,
-  AttachmentMedia,
-  AttachmentTitle,
-  AttachmentTrigger,
-} from '@/components/ui/Attachment'
+import { CheckIcon } from 'lucide-react'
+import { useState } from 'react'
 import { Button } from '@/components/ui/Button'
-import { ButtonGroup } from '@/components/ui/ButtonGroup'
 import { Card } from '@/components/ui/Card'
 import { Field, FieldDescription, FieldError, FieldLabel } from '@/components/ui/Field'
 import { Input } from '@/components/ui/Input'
 import { Spinner } from '@/components/ui/Spinner'
-import { ZIP_HELP, validateZipSize } from '../labels'
 import type { RepoCheck } from '../_/api/api'
 import type { SubmissionMethod } from '../_/api/types'
 
 type Props = {
   submitting: boolean
-  /** 서버가 허용한 수단. `GITHUB_URL`이 없으면 그 탭이 잠긴다 */
+  /** 서버가 허용한 수단. `GITHUB_URL`이 없으면 폼 대신 안내만 보인다 */
   availableMethods: SubmissionMethod[]
-  onSubmit: (file: File) => void
   /** 저장소 주소로 낸다. 브랜치는 비우면 서버가 기본 브랜치를 고른다 */
   onSubmitRepository: (repositoryUrl: string, branch: string) => void
   /** 제출 전에 주소를 미리 확인한다 — 오타를 마감 직전에 알게 되는 것을 막는다 */
@@ -33,13 +20,18 @@ type Props = {
 }
 
 /*
-  제출 폼.
+  제출 폼 — GitHub 저장소 하나만 받는다.
+
+  🔴 **ZIP 업로드를 지웠다**(사용자 지시 — 지금 GitHub URL로만 제출이 가능하다).
+  `SubmissionMethod`·`METHOD_LABEL`은 그대로 둔다 — 이 값을 없애면 **예전에 ZIP으로
+  낸 제출**(`SubmittedContentCard`가 그리는 과거 기록)의 타입·표시 라벨이 없어진다.
+  지우는 것은 "새로 낼 때 고르는 경로"뿐이다.
 
   ## 어느 수단을 쓸 수 있는지는 서버가 정한다
 
   `availableSubmissionMethods`가 기관 정책을 말해 준다 — 화면이 판단하지 않는다.
-  `GITHUB_URL`이 빠져 있으면 그 탭이 잠기고, 왜 못 쓰는지 한 줄로 말한다(탭을 아예
-  지우면 "이 기관은 GitHub을 안 쓴다"는 사실 자체가 안 보인다).
+  `GITHUB_URL`이 빠져 있으면(지금은 없는 조합이지만 계약상 있을 수 있다) 폼 대신
+  안내를 보여준다 — ZIP이 없어진 지금은 대체 수단이 없으므로 매니저에게 알리라고 한다.
 
   ## 저장소는 내기 전에 한 번 확인한다
 
@@ -50,34 +42,14 @@ type Props = {
 export default function SubmissionForm({
   submitting,
   availableMethods,
-  onSubmit,
   onSubmitRepository,
   onCheckRepository,
   checking,
 }: Props) {
   const githubAllowed = availableMethods.includes('GITHUB_URL')
-  const [method, setMethod] = useState<SubmissionMethod>(
-    githubAllowed ? 'GITHUB_URL' : 'ZIP_WITH_GITLOG',
-  )
-  const [file, setFile] = useState<File | null>(null)
-  const [zipError, setZipError] = useState<string | null>(null)
-  const fileInputRef = useRef<HTMLInputElement>(null)
-
   const [repoUrl, setRepoUrl] = useState('')
   const [branch, setBranch] = useState('')
   const [repoCheck, setRepoCheck] = useState<RepoCheck | null>(null)
-
-  const handleFilePicked = (picked: File | undefined) => {
-    if (!picked) return
-    const result = validateZipSize(picked)
-    if (!result.ok) {
-      setZipError(result.message)
-      setFile(null)
-      return
-    }
-    setZipError(null)
-    setFile(picked)
-  }
 
   /*
     주소가 바뀌면 확인 결과를 버린다 — 예전 주소에 대한 `확인했어요`가 남아 있으면
@@ -94,53 +66,19 @@ export default function SubmissionForm({
     setRepoCheck(await onCheckRepository(url))
   }
 
-  const canSubmit =
-    method === 'GITHUB_URL'
-      ? !submitting && !checking && repoUrl.trim().length > 0
-      : !submitting && !!file && !zipError
+  const canSubmit = githubAllowed && !submitting && !checking && repoUrl.trim().length > 0
 
   const hintText = () => {
-    if (submitting) return method === 'GITHUB_URL' ? '제출하는 중이에요…' : '올리는 중이에요…'
-    if (method === 'GITHUB_URL') {
-      return repoUrl.trim()
-        ? '제출하면 코드 분석이 시작돼요'
-        : '저장소 주소를 적으면 제출할 수 있어요'
-    }
-    return file
-      ? '파일을 골랐어요 — 제출하면 코드 분석이 시작돼요'
-      : '파일을 고르면 제출할 수 있어요'
+    if (!githubAllowed) return '지금은 제출할 수 있는 방법이 없어요.'
+    if (submitting) return '제출하는 중이에요…'
+    return repoUrl.trim()
+      ? '제출하면 코드 분석이 시작돼요'
+      : '저장소 주소를 적으면 제출할 수 있어요'
   }
 
   return (
     <Card className="p-5">
-      <ButtonGroup className="mb-4">
-        <Button
-          type="button"
-          variant={method === 'GITHUB_URL' ? 'primary' : 'ghost'}
-          size="sm"
-          disabled={!githubAllowed}
-          onClick={() => setMethod('GITHUB_URL')}
-        >
-          {!githubAllowed && <LockIcon className="size-3.5" />}
-          GitHub 저장소
-        </Button>
-        <Button
-          type="button"
-          variant={method === 'ZIP_WITH_GITLOG' ? 'primary' : 'ghost'}
-          size="sm"
-          onClick={() => setMethod('ZIP_WITH_GITLOG')}
-        >
-          ZIP 업로드
-        </Button>
-      </ButtonGroup>
-
-      {!githubAllowed && (
-        <p className="mb-3 text-xs text-fg-subtle">
-          이 기관은 GitHub 저장소 제출을 쓰지 않아요. ZIP으로 올려 주세요.
-        </p>
-      )}
-
-      {method === 'GITHUB_URL' ? (
+      {githubAllowed ? (
         <div className="flex flex-col gap-4">
           <Field>
             <FieldLabel htmlFor="repo-url">저장소 주소</FieldLabel>
@@ -192,65 +130,14 @@ export default function SubmissionForm({
           </Field>
         </div>
       ) : (
-        <div className="flex flex-col gap-3">
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept=".zip"
-            className="sr-only"
-            onChange={(e) => handleFilePicked(e.target.files?.[0])}
-          />
-          <Attachment
-            state={zipError ? 'error' : file ? 'done' : 'idle'}
-            className="w-full"
-            onDragOver={(e) => e.preventDefault()}
-            onDrop={(e) => {
-              e.preventDefault()
-              handleFilePicked(e.dataTransfer.files[0])
-            }}
-          >
-            {!file && <AttachmentTrigger onClick={() => fileInputRef.current?.click()} />}
-            <AttachmentMedia>
-              <UploadIcon />
-            </AttachmentMedia>
-            {/*
-            AttachmentTitle/Description 기본값은 한 줄 말줄임(truncate)이다 — 이 드롭존
-            안내문은 좁은 화면에서 두 줄이 되는 게 잘리는 것보다 낫다.
-          */}
-            <AttachmentContent>
-              <AttachmentTitle className="!overflow-visible !text-clip !whitespace-normal">
-                {file ? file.name : 'ZIP 파일을 끌어다 놓거나 눌러서 고르세요'}
-              </AttachmentTitle>
-              <AttachmentDescription className="!overflow-visible !text-clip !whitespace-normal">
-                {zipError ?? (file ? `${Math.round(file.size / (1024 * 1024))}MB` : ZIP_HELP)}
-              </AttachmentDescription>
-            </AttachmentContent>
-            {file && (
-              <AttachmentActions>
-                <AttachmentAction
-                  onClick={() => {
-                    setFile(null)
-                    setZipError(null)
-                  }}
-                >
-                  <XIcon />
-                </AttachmentAction>
-              </AttachmentActions>
-            )}
-          </Attachment>
-        </div>
+        <p className="text-sm text-fg-subtle">
+          이 기관은 지금 제출 방법이 설정되어 있지 않아요. 매니저에게 알려 주세요.
+        </p>
       )}
 
       <div className="mt-4 flex items-center justify-between gap-3">
         <span className="text-xs text-fg-subtle">{hintText()}</span>
-        <Button
-          disabled={!canSubmit}
-          onClick={() =>
-            method === 'GITHUB_URL'
-              ? onSubmitRepository(repoUrl.trim(), branch)
-              : file && onSubmit(file)
-          }
-        >
+        <Button disabled={!canSubmit} onClick={() => onSubmitRepository(repoUrl.trim(), branch)}>
           제출
         </Button>
       </div>

--- a/src/features/trainee/submission/components/SubmissionSkeleton.tsx
+++ b/src/features/trainee/submission/components/SubmissionSkeleton.tsx
@@ -8,10 +8,10 @@ import { Skeleton } from '@/components/ui/Skeleton'
   수도, 제출한 내용 카드일 수도 있다. 그래서 스켈레톤은 **둘의 공통 뼈대**만 그린다:
   머리 줄과 그 아래 카드 하나.
 
-  **높이는 실측이다** — 뒤로 19px · 머리 28px · 카드 371px(제출 폼 기준).
+  **높이는 실측이다** — 뒤로 19px · 머리 28px · 카드 309px(제출 폼 기준). ZIP 업로드
+  탭이 있던 시절엔 카드가 371px였다 — 폼이 GitHub 저장소 하나로 줄면서(사용자 지시 —
+  ZIP 제출 삭제) 탭 줄만큼(62px) 낮아졌다. 아래 탭 스켈레톤도 같이 지웠다.
 
-  ▸ 탭 두 개를 그린다 — `GitHub 저장소` / `ZIP 업로드`. 어느 쪽이 열릴지는 서버가
-    정하지만(`availableSubmissionMethods`) **탭 줄 자체는 늘 있다.**
   ▸ 제출한 내용 카드가 오면 폼보다 짧다 — 그때는 위로 당겨진다. 폼이 더 잦은 첫
     진입(미제출)을 기준으로 잡았다.
   ▸ `aria-hidden` — 자리표시자라 읽어 줄 것이 없다.
@@ -28,13 +28,8 @@ export default function SubmissionSkeleton() {
         <Skeleton className="h-4 w-36" />
       </div>
 
-      {/* 폼 카드 — 실측 371px */}
+      {/* 폼 카드 — 실측 309px */}
       <Card className="gap-0 p-5">
-        {/* 수단 탭 둘 */}
-        <div className="mb-4 flex gap-1">
-          <Skeleton className="h-8 w-28" />
-          <Skeleton className="h-8 w-24" />
-        </div>
         <Skeleton className="h-3 w-24" />
         <Skeleton className="mt-2 h-9 w-full" />
         <Skeleton className="mt-2 h-3 w-72" />

--- a/src/features/trainee/submission/labels.ts
+++ b/src/features/trainee/submission/labels.ts
@@ -119,43 +119,19 @@ const failureText = (code: string | null, serverReason?: string | null) =>
   '제출한 코드를 읽지 못했어요. 파일을 확인하고 다시 올려 주세요.'
 
 /*
-  🔴 **서버 상한과 정확히 같은 값이다** — `app.submission.max-zip-bytes` 기본값이고,
-  넘으면 `413 FILE_TOO_LARGE`다. 화면 상한이 더 크면 "올린 뒤에 거절"이 생기고, 더 작으면
-  올릴 수 있는 파일을 막는다. 50MB를 `50 * 1024 * 1024`로 쓰면 같은 값이지만, 스펙이
-  바이트로 못박은 값이라 그대로 적는다.
+  🔴 **ZIP 업로드 검증(`validateZipSize`)을 지웠다**(사용자 지시 — 새 제출은 GitHub URL
+  하나뿐이다). `MAX_ZIP_BYTES`도 함께 지운다 — 파일 업로드 자체가 없어져 크기를 잴
+  일이 없다.
 
-  톰캣 상한(60MB)이 그 앞에 하나 더 있는데 **일부러 넉넉하게 잡은 것**이다 — 톰캣이 먼저
-  끊으면 우리 에러 코드가 안 실려 화면이 사유를 알 수 없기 때문이다(스펙 명시).
+  `METHOD_LABEL`은 **지우지 않는다** — 예전에 ZIP으로 낸 제출 기록을 표시할 때
+  `SubmittedContentCard`가 아직 이 라벨을 읽는다. 지우면 과거 제출 화면이 깨진다.
 */
-export const MAX_ZIP_BYTES = 52_428_800
 
-export type ZipCheckResult = { ok: true } | { ok: false; message: string }
-
-/** 순수 계산 — 네트워크가 필요 없다. **업로드 전에** 막는 것이 목적이다 */
-export function validateZipSize(file: File): ZipCheckResult {
-  if (file.size > MAX_ZIP_BYTES) {
-    /*
-      **올림한다.** 반올림하면 상한을 1바이트 넘긴 파일이 `50MB — 50MB를 넘어…`로 나와
-      제 말과 부딪힌다(실제로 그렇게 보였다). 올림하면 표시값이 상한과 같아지는 일이
-      없어 문구가 늘 성립하고, 실제로 큰 파일에서는 어차피 같은 수가 나온다.
-    */
-    const mb = Math.ceil(file.size / (1024 * 1024))
-    return { ok: false, message: `${file.name} · ${mb}MB — 50MB를 넘어 제출할 수 없어요` }
-  }
-  return { ok: true }
-}
-
-/** 서버 enum을 학생이 읽는 말로 — 폼의 탭 이름과 같은 단어를 쓴다 */
+/** 서버 enum을 학생이 읽는 말로. `ZIP_WITH_GITLOG`는 과거 제출 표시에만 쓰인다 */
 export const METHOD_LABEL: Record<SubmissionMethod, string> = {
   GITHUB_URL: 'GitHub 저장소',
   ZIP_WITH_GITLOG: 'ZIP 업로드',
 }
-
-export const REPO_HELP =
-  '우리 기관 GitHub 조직 안의 저장소는 따로 권한을 주지 않아도 돼요.\n조직 밖이거나 비공개라면 ZIP으로 올려 주세요.'
-export const ZIP_HELP = '최대 50MB · node_modules, .venv 같은 폴더는 빼고 압축해 주세요.'
-export const REPO_NOT_FOUND_HELP =
-  '비공개 저장소이거나 우리 기관 조직 밖에 있으면 열 수 없어요 — 그럴 땐 ZIP으로 올리면 됩니다.'
 
 /*
   제출이 **접수되지 못한** 이유 — 분석 실패(`failureCode`)와 다른 축이다.
@@ -165,27 +141,26 @@ export const REPO_NOT_FOUND_HELP =
   | 접수 실패 | 요청이 거절됐다 | 서버가 파일을 받지도 않았다 |
   | 분석 실패 | 접수는 됐다 | 받아서 열어 보니 분석할 수 없었다 |
 
-  13종이 오는데 화면이 하나로 뭉치면 **학생이 무엇을 해야 하는지 모른다.** 압축을 다시
-  하면 되는 경우와 기다려야 하는 경우와 매니저를 찾아야 하는 경우가 섞인다.
+  여러 종이 오는데 화면이 하나로 뭉치면 **학생이 무엇을 해야 하는지 모른다.** 다시
+  내면 되는 경우와 기다려야 하는 경우와 매니저를 찾아야 하는 경우가 섞인다.
 
   그래서 **다음 행동으로 갈라** 세 갈래만 만든다. 코드를 그대로 노출하지 않는 이유는
   그것이 개발자용 문자열이기 때문이다(F3).
 */
 export type SubmitFailure = {
   message: string
-  /** 같은 파일로 다시 눌러 볼 만한가 — 아니면 버튼을 다시 강조하지 않는다 */
+  /** 같은 내용으로 다시 눌러 볼 만한가 — 아니면 버튼을 다시 강조하지 않는다 */
   retryable: boolean
 }
 
 const SUBMIT_FAILURE: Record<string, SubmitFailure> = {
-  // 학생이 고칠 수 있다 — 파일을 바꿔 다시 낸다
-  ARCHIVE_INVALID: {
-    message: '압축 파일을 열지 못했어요. 다시 압축해서 올려 주세요.',
-    retryable: false,
-  },
-  FILE_TOO_LARGE: { message: '파일이 너무 커요. 50MB 아래로 줄여 주세요.', retryable: false },
+  /*
+    🔴 **`ARCHIVE_INVALID`·`FILE_TOO_LARGE`를 지웠다.** 둘 다 업로드한 파일 자체를
+    거절하는 사유라 ZIP 제출에서만 났다 — GitHub URL 제출은 파일을 안 올리므로 이
+    코드가 다시 올 자리가 없다(사용자 지시로 ZIP 제출을 없앴다).
+  */
 
-  // 기다리면 된다 — 같은 파일로 다시 눌러도 된다
+  // 기다리면 된다 — 같은 내용으로 다시 눌러도 된다
   ARTIFACT_STORE_FAILED: {
     message: '파일을 저장하는 중 문제가 생겼어요. 잠시 후 다시 시도해 주세요.',
     retryable: true,


### PR DESCRIPTION
## 작업 내용

TR-02 코드 제출 화면에서 ZIP 업로드 경로를 지웠습니다. 지금은 GitHub 저장소 주소로만 제출합니다.

## 리뷰 포인트

- `SubmissionMethod` 타입과 `METHOD_LABEL`(ZIP 항목 포함)은 **의도적으로 남겼습니다** — 예전에 ZIP으로 이미 제출된 기록을 `SubmittedContentCard`가 표시해야 해서입니다. 지운 건 새로 낼 때 고르는 경로뿐입니다.
- `src/api/PENDING.md`는 안 건드렸습니다 — 스펙 기반 자동 생성 파일이고, 백엔드 스펙에 `POST /submissions/zip`이 남아 있는 한 `npm run api:gen`이 다시 채웁니다.
- `SubmissionSkeleton.tsx`의 카드 높이(371px → 309px)는 실제 트레이니 계정으로 렌더해 재측정한 값입니다.

## 확인

- [x] 로컬에서 동작 확인
- [x] 하나의 PR = 하나의 기능

closes #341