### PR TITLE
[Chore] Superadmin Org List and Settings Cleanup

### DIFF
--- a/src/features/superadmin/orgs/OrgListScreen.tsx
+++ b/src/features/superadmin/orgs/OrgListScreen.tsx
@@ -154,7 +154,10 @@ export default function OrgListScreen() {
   const summary = useFindPlatformSummary()
 
   const result = data ? toPage<findOrganizations_Item>(data) : null
-  const rows = result?.items ?? []
+  // ponytail: 교육생 수가 가장 많은 기관이 눈에 먼저 띄도록 현재 쪽 안에서만 조용히 재정렬한다.
+  // 서버 정렬(name/createdAt)은 그대로 두고 표시 순서만 바꾼다 — 페이지 경계를 넘는 전역
+  // 정렬은 아니다(교육생 수는 배치 집계라 전역 정렬이 안 되는 이유는 위 머리 주석 참고).
+  const rows = [...(result?.items ?? [])].sort((a, b) => b.traineeCount - a.traineeCount)
   const total = result?.total ?? 0
   const totalPages = data?.totalPages ?? 1
 

--- a/src/features/superadmin/orgs/components/detail/SettingsTab.tsx
+++ b/src/features/superadmin/orgs/components/detail/SettingsTab.tsx
@@ -355,7 +355,6 @@ export default function SettingsTab({ org }: { org: Org }) {
         initial={{
           allowManagerInvite: s.allowManagerInvite,
           allowDataExport: s.allowDataExport,
-          allowZipSubmission: s.allowZipSubmission,
           allowGithubIntegration: s.allowGithubIntegration,
         }}
         toPatch={(d, i) => {
@@ -379,12 +378,6 @@ export default function SettingsTab({ org }: { org: Org }) {
               description="리포트·명단을 파일로 내려받을 수 있습니다"
               checked={d.allowDataExport}
               onChange={(v) => set({ allowDataExport: v })}
-            />
-            <SwitchField
-              label="ZIP 코드 제출"
-              description="끄면 GitHub 연동으로만 제출합니다"
-              checked={d.allowZipSubmission}
-              onChange={(v) => set({ allowZipSubmission: v })}
             />
             <SwitchField
               label="GitHub 조직 연동"
@@ -502,9 +495,7 @@ function SwitchField({
 }
 
 const countEnabled = (s: Settings) =>
-  [s.allowManagerInvite, s.allowDataExport, s.allowZipSubmission, s.allowGithubIntegration].filter(
-    Boolean,
-  ).length
+  [s.allowManagerInvite, s.allowDataExport, s.allowGithubIntegration].filter(Boolean).length
 
 /** 서버가 준 값이 선택지에 없으면 무제한이 아니라 **모르는 값**이다 — 그대로 두면 저장 시 덮인다 */
 const tokenKeyOf = (tokens: number | null) =>


### PR DESCRIPTION
## 작업 내용

- ZIP 코드 제출 허용 토글(`allowZipSubmission`) 제거 — 트레이니 제출 화면이 이제 GitHub URL로만 받으므로, 이 토글은 켜져 있어도 학생 화면에 아무 효과가 없는 죽은 설정이었다.
- 기관 목록에서 교육생 수가 가장 많은 기관이 위로 오도록 재정렬 — 서버 정렬은 이름·생성일뿐이라(교육생 수는 배치 집계라 페이지 경계를 넘는 전역 정렬이 안 됨), 현재 불러온 쪽 안에서만 클라이언트 쪽으로 조용히 재배열했다. 필터·정렬 버튼 UI는 추가하지 않았다.

## 리뷰 포인트

- 교육생 수 정렬은 **현재 쪽(최대 20개) 안에서만** 유효하다 — 전체 기관 중 진짜 1등을 보장하지 않는다. 필요해지면 서버 `OrganizationSort` enum에 항목을 추가해야 한다.

## 확인

- [x] 로컬에서 동작 확인
- [x] 하나의 PR = 하나의 기능

closes #345
