### PR TITLE
[Fix] Align Dialog Title Weight And Close Button Spacing

### DIFF
--- a/src/components/ui/AlertDialog.tsx
+++ b/src/components/ui/AlertDialog.tsx
@@ -43,7 +43,7 @@ function AlertDialogContent({
         data-slot="alert-dialog-content"
         data-size={size}
         className={cn(
-          'group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
+          'group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 gap-5 rounded-xl bg-popover p-4 text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
           className,
         )}
         {...props}
@@ -99,7 +99,7 @@ function AlertDialogTitle({
     <AlertDialogPrimitive.Title
       data-slot="alert-dialog-title"
       className={cn(
-        'font-heading text-base font-medium sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2',
+        'font-heading text-lg leading-tight font-semibold sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2',
         className,
       )}
       {...props}

--- a/src/components/ui/Dialog.tsx
+++ b/src/components/ui/Dialog.tsx
@@ -48,7 +48,7 @@ function DialogContent({
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(
-          'fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
+          'fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-5 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
           className,
         )}
         {...props}
@@ -57,7 +57,9 @@ function DialogContent({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            render={<Button variant="ghost" size="sm" className="absolute top-2 right-2 p-1.5" />}
+            render={
+              <Button variant="ghost" size="sm" className="absolute top-4 right-4 size-8 p-0" />
+            }
           >
             <XIcon />
             <span className="sr-only">Close</span>
@@ -103,7 +105,10 @@ function DialogTitle({ className, ...props }: DialogPrimitive.Title.Props) {
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn('font-heading text-base leading-none font-medium', className)}
+      className={cn(
+        'flex h-8 items-center font-heading text-lg leading-tight font-semibold',
+        className,
+      )}
       {...props}
     />
   )


### PR DESCRIPTION
## 작업 내용

- `DialogTitle`/`AlertDialogTitle`을 text-base/font-medium → text-lg/font-semibold로 키워 본문과 확실히 구분되게 함
- 팝업 내부 섹션 간격 gap-4 → gap-5
- 닫기(X) 버튼 위치를 `top-2 right-2`(8px) → `top-4 right-4`(16px)로, 하단 액션 버튼과 같은 여백으로 맞춤
- 닫기 버튼을 `size-8 p-0`(32px 고정 박스)로, 제목을 `flex h-8 items-center`로 바꿔 — 둘의 높이·세로 중심이 정확히 일치하도록 함

## 리뷰 포인트

- `/ui-preview` → 오버레이 탭에서 다이얼로그 열어서 확인 가능
- Dialog/AlertDialog 둘 다 같은 `@base-ui/react` 프리미티브 위에 있어 두 파일을 함께 고쳤음
- 실측(getBoundingClientRect)으로 확인: 닫기 버튼 상/우 16px, 하단 버튼 하/우 16px, 제목·닫기 버튼 높이 32px·세로 중심 일치

## 확인

- [x] 로컬에서 동작 확인
- [x] 하나의 PR = 하나의 기능

closes #347