### PR TITLE
[Fix] Fix Interview Round, Role Switch Cache and Demo Review Mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ dev-accounts.env
 # 한 기수 전원 명부 — 기관이 준 마크다운을 scripts/dev-team-accounts.mjs가 바꾼 것
 dev-team-accounts.json
 dev-team-accounts.env
+
+# 헤더 역할 전환 목록(넷) — 위 명부에서 뽑은 것이라 같은 자격 증명이 들어 있다
+header-accounts.env

--- a/scripts/check-demo-engine.mts
+++ b/scripts/check-demo-engine.mts
@@ -183,22 +183,68 @@ test('리포트는 누른 점수로 만들어진다 — 도달 단계가 문제�
   )
 })
 
-test('리포트의 문답이 세션에서 보여준 답변과 같다', () => {
-  const s = playAll([5, 5, 5, 5], [5, 2, 2, 2], [0, 0, 0])
-  const first = buildConcepts(s)[0]
-  assert.ok(first.asked)
-  // 문제1 L1 5점은 녹화된 자리다 — 리포트에도 그 진짜 답변이 있어야 한다
-  assert.match(first.qa?.[0].answer ?? '', /@BeforeEach/)
-  assert.equal(first.qa?.length, 4) // 네 축을 한 번씩
+test('문답은 답한 것이 전부 남는다 — 통과한 축의 답변도', () => {
+  // L1·L2 통과 후 L3에서 힌트 둘 쓰고 미달 → 답한 것은 1+1+3 = 5건
+  const s = playAll([5, 5, 2, 2, 2], [5, 5, 5, 5], [5, 5, 5, 5])
+  const c = buildConcepts(s)[0]
+  assert.ok(c.asked)
+  assert.deepEqual(
+    c.qa?.map((q) => q.questionLabel),
+    ['L1 질문', 'L2 질문', 'L3 질문', 'L3 힌트 1', 'L3 힌트 2'],
+  )
 })
 
-test('막힌 축만 설명에 적는다 — 통과한 축은 안 적는다', () => {
-  const s = playAll([5, 5, 5, 5], [5, 2, 2, 2], [0, 0, 0])
+test('전부 통과하면 네 축의 문답이 다 남는다', () => {
+  const s = playAll([5, 5, 5, 5], [5, 5, 5, 5], [5, 5, 5, 5])
+  const c = buildConcepts(s)[0]
+  assert.ok(c.asked && c.qa)
+  assert.deepEqual(
+    c.qa?.map((q) => q.questionLabel),
+    ['L1 질문', 'L2 질문', 'L3 질문', 'L4 질문'],
+  )
+})
+
+test('해설은 막힌 개념에만 — 전부 통과하면 없다', () => {
+  const s = playAll([5, 5, 5, 5], [5, 5, 2, 2, 2], [5, 5, 5, 5])
   const [all, stuck] = buildConcepts(s)
   assert.ok(all.asked && stuck.asked)
   assert.equal(all.explanation, null) // 전부 통과 → 적을 것이 없다
-  assert.equal(stuck.explanation?.length, 1) // L2 하나만
-  assert.match(stuck.explanation?.[0] ?? '', /설계논리/)
+  // 해설은 요약(`said`)을 되풀이하지 않고 **풀어 쓰는 부분부터** 시작한다
+  assert.doesNotMatch(stuck.explanation?.[0] ?? '', /^문제 \d \[/)
+  assert.ok((stuck.explanation?.length ?? 0) >= 2, '해설이 한 줄뿐이다')
+})
+
+test('`said`는 한 줄 요약이다 — 해설은 `explanation`이 맡는다', () => {
+  /*
+    실측 형식: `문제 1 [개념명] — A는 통과했지만 B를 통과하지 못했습니다.`
+    한때 여기에 세 문장짜리 진단을 넣었다가 "이 멘트 자체가 해설 아니냐"는 지적을 받았다.
+  */
+  const s = playAll([5, 5, 2, 2, 2], [5, 5, 5, 5], [5, 5, 5, 5])
+  const c = buildConcepts(s)[0]
+  assert.ok(c.asked)
+  assert.match(c.said, /^문제 1 \[테스트 경계와 대역 설계\] — /)
+  assert.match(c.said, /통과하지 못했습니다\.$/)
+  assert.ok(c.said.length < 150, `요약이 너무 길다(${c.said.length}자): ${c.said}`)
+  // 상세 설명은 해설 쪽에 있다
+  assert.ok((c.explanation?.length ?? 0) >= 2, '해설이 요약보다 얇다')
+})
+
+test('도달 2단 미만이면 해설·문답이 잠긴다', () => {
+  const s = playAll([0, 0, 0], [5, 5, 5, 5], [5, 5, 5, 5])
+  const c = buildConcepts(s)[0]
+  assert.ok(c.asked && c.isRetryTarget)
+  assert.equal(c.explanation, null)
+  assert.equal(c.qa, null)
+})
+
+test('다시 보기를 마치면 잠금이 풀린다', () => {
+  const first = playAll([0, 0, 0], [5, 5, 5, 5], [5, 5, 5, 5])
+  const r = run([{ type: 'START_REVIEW', problemNo: 1 }, ...answers(5, 5)], first)
+  const c = buildConcepts(r)[0]
+  assert.ok(c.asked)
+  assert.equal(c.reachedLevel, 0) // 배지는 정본 그대로
+  assert.ok(c.explanation, '다시 보기를 마쳤는데 해설이 잠겨 있다')
+  assert.ok(c.qa, '다시 보기를 마쳤는데 문답이 잠겨 있다')
 })
 
 test('시간 초과로 닫힌 개념은 「못한 것」이 아니라고 말한다', () => {
@@ -212,8 +258,10 @@ test('시간 초과로 닫힌 개념은 「못한 것」이 아니라고 말한�
   const first = buildConcepts(s)[0]
   assert.ok(first.asked)
   assert.equal(first.reachedLevel, 2)
-  assert.match(first.said, /시간이 다 됐어요/)
-  assert.equal(first.explanation, null) // 도달 못 한 축을 미달로 적지 않는다
+  // 시간 초과는 미달이 아니다 — "못했다"가 아니라 "묻지 못했다"로 적는다
+  assert.match(first.said, /묻지 못했습니다/)
+  // 해설은 요약을 되풀이하지 않는다
+  assert.doesNotMatch(first.explanation?.[0] ?? '', /^문제 \d \[/)
 })
 
 test('교안 근거가 개념마다 붙는다 — 「어디를 보라」가 비면 리포트가 반쪽이다', () => {
@@ -347,4 +395,126 @@ test('미달 답변은 통과 답변보다 짧다 — 못 하는 학생이 더 �
       )
     }
   }
+})
+
+/* ── 다시 보기(REVIEW) ───────────────────────────────────────────────
+   2단 미만인 개념만 다시 여는 자리다. 여기가 1차 결과를 덮으면 "원래 몇 단이었나"가
+   사라져 성장이 안 보인다.
+*/
+test('다시 보기는 그 문제 하나만 열고 `1 / 1`로 센다', () => {
+  const s = playAll([0, 0, 0], [5, 5, 5, 5], [5, 5, 5, 5])
+  const r = run([{ type: 'START_REVIEW', problemNo: 1 }], s)
+  assert.equal(r.mode, 'REVIEW')
+  assert.equal(r.phase, 'IN_PROBLEM')
+  // 상단이 `2 / 3`으로 나오면 나머지도 다시 푸는 것처럼 읽힌다
+  assert.equal(currentProblem(r).problemNo, 1)
+  assert.equal(currentProblem(r).problemTotal, 1)
+})
+
+test('다시 보기에도 힌트가 있다', () => {
+  const s = playAll([0, 0, 0], [5, 5, 5, 5], [5, 5, 5, 5])
+  const r = run([{ type: 'START_REVIEW', problemNo: 1 }], s)
+  assert.equal(currentProblem(r).current?.hintsLeft, 2)
+  const opened = run([{ type: 'OPEN_HINT' }], r)
+  assert.equal(opened.hintsUsed, 1)
+  assert.equal(currentProblem(opened).current?.shownHints.length, 1)
+})
+
+test('다시 보기도 힌트를 다 쓰고 미달이면 그때 끝난다', () => {
+  const s = playAll([0, 0, 0], [5, 5, 5, 5], [5, 5, 5, 5])
+  const one = run([{ type: 'START_REVIEW', problemNo: 1 }, ...answers(2)], s)
+  assert.equal(one.phase, 'IN_PROBLEM') // 힌트가 남아 아직 안 끝난다
+  const done = run(answers(2, 2), one)
+  assert.equal(done.phase, 'ENDED')
+  assert.equal(done.reviewResults[0].status, 'NOT_PASSED')
+})
+
+test('다시 봐서 통과하면 리포트 내용이 그 결과로 바뀐다', () => {
+  // 1단이라 잠긴 상태로 시작한다 — 해설·문답이 안 온다
+  const first = playAll([5, 2, 2, 2], [5, 5, 5, 5], [5, 5, 5, 5])
+  const before = buildConcepts(first)[0]
+  assert.ok(before.asked && before.isRetryTarget)
+  assert.equal(before.explanation, null)
+
+  // 다시 보기에서 L1·L2를 넘긴다
+  const r = run([{ type: 'START_REVIEW', problemNo: 1 }, ...answers(5, 5)], first)
+  const after = buildConcepts(r)[0]
+  assert.ok(after.asked)
+  assert.equal(after.reachedLevel, 1) // 배지는 1차 그대로
+  assert.deepEqual(after.comparedReach, { before: 1, after: 2 })
+  // 잠금이 풀린다 — 판정(해설)은 1차 기준 그대로다
+  assert.ok(after.explanation, '잠금이 안 풀렸다')
+  // 1차 문답을 지우지 않고 다시 본 것을 뒤에 붙인다
+  const labels = after.qa?.map((q) => q.questionLabel) ?? []
+  assert.ok(
+    labels.some((l) => !l.startsWith('다시 보기')),
+    '1차 문답이 사라졌다',
+  )
+  assert.ok(
+    labels.some((l) => l.startsWith('다시 보기 · ')),
+    '다시 본 문답이 안 남았다',
+  )
+})
+
+test('1차에 답을 못 해도 다시 본 문답은 남는다', () => {
+  // 0단: L1을 세 번 다 미달 → 1차 문답은 L1 셋뿐
+  const first = playAll([0, 0, 0], [5, 5, 5, 5], [5, 5, 5, 5])
+  const r = run([{ type: 'START_REVIEW', problemNo: 1 }, ...answers(5, 5)], first)
+  const c = buildConcepts(r)[0]
+  assert.ok(c.asked && c.qa)
+  const again = c.qa.filter((q) => q.questionLabel.startsWith('다시 보기 · '))
+  assert.deepEqual(
+    again.map((q) => q.questionLabel),
+    ['다시 보기 · L1 질문', '다시 보기 · L2 질문'],
+  )
+})
+
+test('다시 보기는 개념마다 한 번 — 본 개념만 열리고 나머지는 잠긴 채다', () => {
+  // 개념 1·2가 둘 다 2단 미만
+  const first = playAll([0, 0, 0], [5, 2, 2, 2], [5, 5, 5, 5])
+  const before = buildConcepts(first)
+  assert.ok(before[0].asked && before[1].asked)
+  assert.equal(before[0].explanation, null)
+  assert.equal(before[1].explanation, null)
+
+  // 개념 1만 다시 본다
+  const r = run([{ type: 'START_REVIEW', problemNo: 1 }, ...answers(5, 5)], first)
+  const after = buildConcepts(r)
+  assert.ok(after[0].asked && after[1].asked)
+  assert.ok(after[0].explanation, '다시 본 개념이 안 열렸다')
+  // 개념 2는 아직 안 봤으므로 잠긴 채여야 한다 — 그 자리에 버튼이 계속 있다
+  assert.equal(after[1].explanation, null)
+  assert.equal(after[1].comparedReach, null)
+})
+
+test('다시 보기가 1차 결과를 덮지 않는다 — 배지는 원점수 그대로', () => {
+  const first = playAll([0, 0, 0], [5, 5, 5, 5], [5, 5, 5, 5])
+  assert.equal(reachedLevel(first.results, 1), 0)
+
+  // 다시 보기에서 L1·L2를 통과시킨다
+  const r = run([{ type: 'START_REVIEW', problemNo: 1 }, ...answers(5, 5)], first)
+  assert.equal(reachedLevel(r.results, 1), 0) // 1차는 그대로 0단
+  assert.equal(reachedLevel(r.reviewResults, 1), 2) // 다시 보기는 2단
+
+  const c = buildConcepts(r)[0]
+  assert.ok(c.asked)
+  assert.equal(c.reachedLevel, 0) // 배지는 정본(1차)
+  assert.deepEqual(c.comparedReach, { before: 0, after: 2 })
+})
+
+test('다시 보기를 안 한 개념은 비교 줄이 없다', () => {
+  const s = playAll([0, 0, 0], [5, 5, 5, 5], [5, 5, 5, 5])
+  for (const c of buildConcepts(s)) assert.equal(c.asked && c.comparedReach, null)
+})
+
+test('다시 보기 버튼이 붙는 개념 = 2단 미만 (0단·1단 둘 다)', () => {
+  const s = playAll(
+    [0, 0, 0], //       0단
+    [5, 2, 2, 2], //    1단 — L1만 통과
+    [5, 5, 5, 5], //    4단
+  )
+  assert.deepEqual(
+    buildConcepts(s).map((c) => c.asked && c.isRetryTarget),
+    [true, true, false],
+  )
 })

--- a/src/features/auth/LoginScreen.tsx
+++ b/src/features/auth/LoginScreen.tsx
@@ -8,7 +8,6 @@ import { login, resendAccountInvitation } from '@/api/auth/authApi'
 import { resolveAuthState } from './authStates'
 import type { AuthState } from './authStates'
 import { useCapsLockWarning } from './useCapsLockWarning'
-import { QUICK_LOGIN_ACCOUNTS } from './quickLoginAccounts'
 import BrandPanel from './components/BrandPanel'
 import CaseAccountPicker from './components/CaseAccountPicker'
 import AuthForm from './components/AuthForm'
@@ -162,10 +161,9 @@ export default function LoginScreen() {
               </p>
 
               {/*
-                **계정이 없어도 이 줄은 그린다.** 아래 역할 버튼은 `.env.local`의 계정을
-                쓰지만 시연용 목업은 네트워크를 한 번도 안 타므로, 로그인 API가 죽어
-                있든 env가 비어 있든 들어갈 수 있어야 한다 — 그게 이 화면이 존재하는
-                이유다. 그래서 계정 유무와 무관하게 상자 맨 위에 둔다.
+                **계정이 없어도 이 줄은 그린다.** 목업은 네트워크를 한 번도 안 타므로
+                로그인 API가 죽어 있든 env가 비어 있든 들어갈 수 있어야 한다 — 그게 이
+                화면이 존재하는 이유다.
               */}
               <Button
                 variant="ghost"
@@ -174,35 +172,19 @@ export default function LoginScreen() {
                 nativeButton={false}
                 render={<Link to="/demo" />}
               >
-                시연용 목업 — 로그인 없이 교육생 플로우 보기
+                교육생 플로우 목업 (로그인 없이)
               </Button>
 
-              {QUICK_LOGIN_ACCOUNTS.length > 0 && (
-                <>
-                  <div className="grid grid-cols-2 gap-2">
-                    {QUICK_LOGIN_ACCOUNTS.map(
-                      ({ label, email: quickEmail, password: quickPassword }) => (
-                        <Button
-                          key={quickEmail}
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          disabled={isSubmitting}
-                          onClick={() => handleQuickLogin(quickEmail, quickPassword)}
-                        >
-                          {label}
-                        </Button>
-                      ),
-                    )}
-                  </div>
+              {/*
+                🔴 **역할 버튼 넷을 뺐다.** `.env.local`의 역할 계정으로 곧바로
+                로그인시키던 자리인데, 역할당 계정이 하나뿐이라 **여럿이 누르면 전원이
+                같은 계정에 들어간다.** 이 화면을 수백 명이 동시에 여는 자리가 생겨
+                (시연) 그 몰림이 실제 사고가 됐다.
 
-                  {/*
-                    교육생 상태별 계정은 **접어 둔다.** 수십 개라 펼쳐 두면 위 역할 버튼과
-                    아래 입력 칸이 밀린다 — 찾을 때만 여는 것이 맞다.
-                  */}
-                  <CaseAccountPicker disabled={isSubmitting} onPick={handleQuickLogin} />
-                </>
-              )}
+                같은 계정이 필요하면 아래 고르개에서 그 사람을 찾으면 된다 — 역할 계정도
+                전부 명부 안에 있다.
+              */}
+              <CaseAccountPicker disabled={isSubmitting} onPick={handleQuickLogin} />
             </div>
           )}
 

--- a/src/features/auth/PrivacyPolicyScreen.tsx
+++ b/src/features/auth/PrivacyPolicyScreen.tsx
@@ -12,7 +12,7 @@ export default function PrivacyPolicyScreen() {
       <div className="mx-auto max-w-[640px]">
         <h1 className="text-fg text-xl font-bold">개인정보 처리방침</h1>
         <p className="text-fg-muted mt-2 text-sm leading-relaxed">
-          IZ 프로젝트팀(&quot;서비스&quot;)은 「개인정보 보호법」 등 관련 법령을 준수하며, 이용자의
+          IZ는(&quot;서비스&quot;)은 「개인정보 보호법」 등 관련 법령을 준수하며, 이용자의
           개인정보를 안전하게 처리하기 위해 다음과 같이 개인정보 처리방침을 수립·공개합니다.
         </p>
         <p className="text-fg-subtle mt-2 text-sm leading-relaxed">
@@ -24,7 +24,7 @@ export default function PrivacyPolicyScreen() {
         <Section title="1. 운영 주체">
           <table className="w-full border-collapse text-sm">
             <tbody>
-              <Row label="운영">IZ 프로젝트팀</Row>
+              <Row label="운영">IZ</Row>
               <Row label="주소">서울특별시 종로구 청계천로 81 4층</Row>
               <Row label="대표자">김연주</Row>
               <Row label="사업자등록번호">

--- a/src/features/auth/components/CaseAccountPicker.tsx
+++ b/src/features/auth/components/CaseAccountPicker.tsx
@@ -1,47 +1,134 @@
-import { ChevronRightIcon } from 'lucide-react'
-import { useState } from 'react'
+import { SearchIcon } from 'lucide-react'
+import { useMemo, useState } from 'react'
 import { cn } from '@/lib/utils/cn'
-import {
-  CASE_ACCOUNT_GROUPS,
-  CASE_ACCOUNT_MEASURED_AT,
-  CASE_ACCOUNT_OWNERS,
-  CASE_ACCOUNT_TOTAL,
-  type CaseAccount,
-} from '../quickLoginAccounts'
-
-/** 담당자를 안 골랐을 때 — 「전체」도 하나의 선택지다 */
-const ALL = '전체'
+import { CASE_ACCOUNT_GROUPS, ROLES, type CaseAccount, type Role } from '../quickLoginAccounts'
 
 /*
-  dev 전용 — 케이스(교육생 상태별 · 매니저/오퍼레이터 담당자별) 테스트 계정 고르개.
+  dev 전용 계정 고르개.
 
-  ## 왜 접어 두나
-  계정이 수십 개다. 펼쳐 둔 채로 로그인 화면에 놓으면 원래 있어야 할 것(역할 버튼 넷,
-  입력 칸)이 밀려 내려간다. 이 목록은 **찾을 때만 필요하다.**
+  ## 무엇이 달라졌나 — **여섯 명이 아니라 수백 명이 본다**
 
-  ## 왜 케이스를 먼저 고르나
-  `미응시`만 백 명이 넘어 한 목록에 다 넣으면 찾을 수 없다. 케이스를 좁힌 뒤 그 안에서
-  고른다 — 테스트할 때 아는 것은 계정 이름이 아니라 **"무엇을 보고 싶다"** 다.
+  종전 구조는 팀원 여섯이 *자기 담당 계정*을 찾는 자리였다(`owner` 필터 · 케이스 13개
+  격자 · 접힌 목록). 그 전제가 바뀌었다. 시연에서 이 화면을 수백 명이 동시에 연다.
 
-  ## 왜 케이스마다 설명이 붙나
-  백엔드가 엑셀 요약에 *"이 계정들로 무엇을 보나"* 를 적어 준다. 그것을 그대로 보여준다 —
-  계정 목록만 있고 무엇을 확인하는 자리인지 모르면 고를 수가 없다.
+  그때 종전 구조는 **한 계정으로 몰린다.** 위에 크게 놓인 역할 버튼 넷이 곧바로
+  로그인시키고, 270명 명부는 접혀 있어 아무도 안 연다. 결국 전원이 같은 `t001`로
+  들어가 같은 세션을 밀어 댄다.
 
-  ## 왜 담당자로 한 번 더 거르나
-  여섯이 함께 테스트하는데 **계정은 소모된다.** 남이 쓴 것을 열면 이미 끝난 상태를 보게
-  되고, 그러면 "누가 뭘 썼는지"를 매번 말로 맞춰야 한다. 엑셀에 `담당`이 적혀 오므로
-  화면은 그것으로 거르기만 한다 — **배정은 엑셀이 정본이다.**
+  ## 그래서 두 가지를 바꿨다
 
-  ## 왜 반·팀·이름·상태까지 보여주나
-  같은 케이스 계정이 여러 개 있는 이유는 **소모되기 때문**이다(세션을 시작하면 그 계정은
-  돌아오지 않는다). 어느 것을 이미 썼는지 알아보려면 식별이 되어야 하고, 같은 케이스
-  안에서도 화면이 갈리는 계정(`문제 2개`/`3개`)은 **그 차이가 보여야 고를 수 있다.**
+  **① 역할을 「로그인」이 아니라 「갈림길」로.** 역할을 누르면 들어가지지 않고 아래
+  목록이 바뀐다. 누를 수 있는 공용 계정이 화면에서 사라지므로 몰릴 대상이 없다.
 
-  ## 왜 잰 날짜를 말하나
-  **상태에 유효기간이 있다.** 개인 응시 창은 분석 완료 뒤 24시간이라 `응시 가능` 계정
-  아홉이 하루 만에 전부 `창 닫힘`이 됐다(실측). 날짜를 숨기면 라벨을 믿고 눌렀다가
-  다른 화면을 보게 되고, 그때 화면을 의심하게 된다.
+  **② 교육생은 반 → 이름으로 좁힌다.** 각자 **자기 이름**을 고르면 252명이 252개로
+  자연히 흩어진다. 배정표도, 서버 조율도 필요 없다 — 이름이 곧 배정이다.
+
+  ## 왜 `owner` 필터를 뺐나
+
+  지금 데이터에 `owner`가 하나도 없다(`owners: []`). 팀 배정은 엑셀에서 끊겼고, 화면만
+  빈 필터 줄을 그리고 있었다. 다시 배정이 생기면 역할 탭 옆에 되살리면 된다.
 */
+
+/** 한 사람. `groups`가 복수인 이유는 아래 dedupe 주석에 있다 */
+type Row = Omit<CaseAccount, 'className'> & { role: Role; groups: string[] }
+
+const roleOf = (group: string, note: string | null): Role =>
+  group === '슈퍼 어드민'
+    ? '슈퍼 어드민'
+    : group === '오퍼레이터'
+      ? '오퍼레이터'
+      : /매니저/.test(note ?? '')
+        ? '매니저'
+        : '교육생'
+
+/*
+  ## 같은 사람이 여러 그룹에 들어 있다 — **이메일로 합친다**
+
+  🔴 매니저 셋이 두 반을 겸한다(박지현 A·F · 이도윤 B·D · 강민서 E·G). 엑셀이 반마다
+  한 줄씩 적어 오므로 **같은 이메일이 두 그룹에 나온다** — 270행인데 사람은 267명이다.
+
+  합치지 않고 그대로 그리면 그 셋이 목록에 두 번 나오고, `key`가 겹쳐 React가
+  *"두 자식이 같은 키를 씁니다 — 중복되거나 누락될 수 있습니다"* 를 던진다. 실제로
+  탭을 오갈 때마다 카드가 **세 개씩 쌓였다**(실측: 10 → 28 → 31 → 34).
+
+  그래서 이메일로 묶고 담당 반을 배열로 모은다. 화면에는 `A반 · F반`으로 한 줄에 나온다.
+*/
+const ALL_ROWS: Row[] = Object.values(
+  CASE_ACCOUNT_GROUPS.reduce<Record<string, Row>>((acc, g) => {
+    for (const a of g.accounts) {
+      const prev = acc[a.email]
+      if (prev) {
+        prev.groups.push(g.label)
+        continue
+      }
+      acc[a.email] = {
+        email: a.email,
+        password: a.password,
+        name: a.name,
+        teamName: a.teamName,
+        note: a.note,
+        owner: a.owner,
+        groups: [g.label],
+        role: roleOf(g.label, a.note),
+      }
+    }
+    return acc
+  }, {}),
+)
+
+const countOf = (role: Role) => ALL_ROWS.filter((r) => r.role === role).length
+
+/*
+  매니저를 **화면에 보여줄 것이 많은 순**으로 세우는 데 쓴다.
+
+  매니저 화면(대시보드·히트맵)은 담당 반에 데이터가 없으면 빈 화면이다. 시연에서
+  아무나 골라 들어가면 그 빈 화면을 보여주게 된다.
+
+  ## 응시 인원이 아니라 화면에 실제로 차는 것으로 잰다
+
+  🔴 처음엔 4차 응시자 수로 세웠는데 **틀렸다.** `강민서`(E·G반)는 응시 50명으로 1위인데
+  **4차 히트맵이 개념 0개·빈 격자**다. 응시했다고 히트맵이 차는 것이 아니다.
+
+  그래서 두 화면의 실제 응답을 재서 넣는다.
+
+  ```
+  inbox  GET /cohorts/{7기}/analytics/signals            → signals[] 길이
+  heat   GET /cohorts/{7기}/analytics/heatmap            → concepts[] 길이
+         (projectId·assessmentRoundId = 미프 4차, level=CLASS)
+  ```
+
+  히트맵을 4차로 재는 이유는 **그 화면이 4차를 기본으로 열기** 때문이다
+  (`heatmap/_/api/api.ts`의 `currentRound()` — `OPEN` 중 마지막). 로그인 직후 보이는
+  것이 그 회차라 그것으로 재야 맞다.
+
+  ⚠️ **로그인 전에는 이 값을 물어볼 수 없다**(두 API 모두 인증을 요구한다). 2026-08-25
+  실측값을 적어 둔다 — 회차가 넘어가면 위 두 요청을 다시 돌려 갱신한다. 틀려도 순서만
+  어긋나고 로그인 자체에는 영향이 없다.
+*/
+const MANAGER_DATA: Record<string, { inbox: number; heat: number }> = {
+  이도윤: { inbox: 96, heat: 5 },
+  임하늘: { inbox: 49, heat: 5 },
+  박지현: { inbox: 97, heat: 4 },
+  최유진: { inbox: 48, heat: 3 },
+  조은비: { inbox: 49, heat: 1 },
+  강민서: { inbox: 100, heat: 0 },
+  윤서준: { inbox: 49, heat: 0 },
+}
+
+/**
+ * 정렬 점수 — **히트맵이 비면 인박스가 아무리 많아도 뒤로 보낸다.**
+ *
+ * 인박스는 담당 반 수에 거의 비례해(겸임이면 두 배) 변별력이 낮고, 히트맵은 비면
+ * 시연 중에 "여긴 왜 아무것도 없죠"가 나온다. 그래서 히트맵에 가중치를 크게 준다.
+ */
+const dataScore = (name: string) => {
+  const d = MANAGER_DATA[name]
+  return d ? d.heat * 100 + d.inbox : -1
+}
+
+/** 교육생 반 목록 — 데이터 순서를 그대로 쓴다(A~J · 반 없음) */
+const CLASSES = [...new Set(ALL_ROWS.filter((r) => r.role === '교육생').flatMap((r) => r.groups))]
+
 export default function CaseAccountPicker({
   disabled,
   onPick,
@@ -49,166 +136,139 @@ export default function CaseAccountPicker({
   disabled?: boolean
   onPick: (email: string, password: string) => void
 }) {
-  const [open, setOpen] = useState(false)
-  const [groupIndex, setGroupIndex] = useState(0)
-  const [owner, setOwner] = useState(ALL)
+  const [role, setRole] = useState<Role>(ROLES[0])
+  const [klass, setKlass] = useState<string>(CLASSES[0] ?? '')
+  const [query, setQuery] = useState('')
 
-  if (CASE_ACCOUNT_GROUPS.length === 0) return null
+  const rows = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    const found = ALL_ROWS.filter((r) => {
+      if (r.role !== role) return false
+      // 검색 중에는 반을 넘어 찾는다 — 자기 반을 모르는 사람이 이름만 치는 경우가 잦다
+      if (role === '교육생' && !q && !r.groups.includes(klass)) return false
+      if (!q) return true
+      return `${r.name} ${r.groups.join(' ')} ${r.teamName} ${r.email}`.toLowerCase().includes(q)
+    })
+    /*
+      매니저만 데이터 많은 순으로 세운다. 나머지 역할은 데이터 순서를 그대로 둔다 —
+      교육생은 어차피 한 반 안이라 전원 같은 값이고, 이름 순서가 흔들리면 자기 이름을
+      찾던 사람이 매번 다른 자리를 봐야 한다.
+    */
+    return role === '매니저'
+      ? [...found].sort((a, b) => dataScore(b.name) - dataScore(a.name))
+      : found
+  }, [role, klass, query])
 
-  const group = CASE_ACCOUNT_GROUPS[groupIndex]
-  /*
-    담당자를 고르면 그 사람 것만 남긴다. **케이스 버튼의 수도 함께 줄인다** — 「응시중
-    2개」인데 눌러 보니 내 것이 없는 일이 잦아서, 누르기 전에 몇 개인지 보여야 한다.
-  */
-  const mine = (list: CaseAccount[]) =>
-    owner === ALL ? list : list.filter((a) => a.owner === owner)
-  const shown = mine(group.accounts)
-  const measuredLabel = CASE_ACCOUNT_MEASURED_AT
-    ? new Date(CASE_ACCOUNT_MEASURED_AT).toLocaleDateString('ko-KR', {
-        month: 'numeric',
-        day: 'numeric',
-      })
-    : null
+  if (ALL_ROWS.length === 0) return null
 
   return (
-    <div className="mt-2 rounded-md bg-canvas">
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        aria-expanded={open}
-        className="flex w-full items-center gap-1.5 px-3 py-2 text-[11px] text-fg-muted transition-colors hover:text-fg"
-      >
-        <ChevronRightIcon
-          aria-hidden="true"
-          className={cn('size-3 shrink-0 transition-transform', open && 'rotate-90')}
-        />
-        <span className="flex-1 text-left">
-          케이스별 계정 <span className="text-fg-subtle">{CASE_ACCOUNT_TOTAL}개</span>
-        </span>
-        <span>{open ? '접기' : '펼치기'}</span>
-      </button>
+    <div className="mt-2 rounded-md border border-border bg-canvas p-2.5">
+      {/*
+        역할 탭 — **누르면 로그인되지 않는다.** 아래 목록이 바뀔 뿐이다.
+        이 화면에서 공용 계정으로 몰리는 것을 막는 장치가 이것 하나다.
+      */}
+      <div role="tablist" aria-label="역할" className="flex flex-wrap gap-1">
+        {ROLES.map((r) => (
+          <button
+            key={r}
+            type="button"
+            role="tab"
+            aria-selected={r === role}
+            onClick={() => {
+              setRole(r)
+              setQuery('')
+            }}
+            className={cn(
+              'rounded px-2.5 py-1 text-xs transition-colors',
+              r === role
+                ? 'bg-primary font-medium text-white'
+                : 'text-fg-muted hover:bg-surface-2 hover:text-fg',
+            )}
+          >
+            {r} <span className={r === role ? 'opacity-70' : 'text-fg-subtle'}>{countOf(r)}</span>
+          </button>
+        ))}
+      </div>
 
-      {open && (
-        <div className="border-t border-border px-3 pt-2 pb-3">
-          {measuredLabel && (
-            <p className="mb-2 text-[11px] text-fg-subtle">
-              {measuredLabel} 기준 상태입니다 — 응시 창은 24시간이라 지나면 <b>창 닫힘</b>이 됩니다.
-            </p>
-          )}
-          {/* 담당자 줄 — 케이스보다 위에 둔다. 먼저 좁히는 축이 이쪽이다 */}
-          {CASE_ACCOUNT_OWNERS.length > 0 && (
-            <div className="mb-2 flex flex-wrap gap-1 border-b border-border pb-2">
-              {[ALL, ...CASE_ACCOUNT_OWNERS].map((o) => (
-                <button
-                  key={o}
-                  type="button"
-                  onClick={() => setOwner(o)}
-                  aria-current={o === owner}
-                  className={cn(
-                    'rounded px-2 py-1 text-[11px] transition-colors',
-                    o === owner
-                      ? 'bg-primary font-medium text-white'
-                      : 'text-fg-muted hover:bg-surface-2 hover:text-fg',
-                  )}
-                >
-                  {o}
-                </button>
-              ))}
-            </div>
-          )}
-
-          {/*
-            케이스 고르개 — 라벨이 길어 두 칸 격자로 둔다. 고른 것은 채움으로 표시한다:
-            테두리만으로 구분하면 어느 케이스를 보고 있는지 놓친다.
-          */}
-          <div className="grid grid-cols-2 gap-1">
-            {CASE_ACCOUNT_GROUPS.map((g, i) => (
+      {role === '교육생' && (
+        <>
+          {/* 반 → 이름. 252명을 한 목록에 두면 자기 이름을 못 찾는다 */}
+          <div className="mt-2 flex flex-wrap gap-1 border-t border-border pt-2">
+            {CLASSES.map((c) => (
               <button
-                key={g.label}
+                key={c}
                 type="button"
-                onClick={() => setGroupIndex(i)}
-                aria-current={i === groupIndex}
+                onClick={() => {
+                  setKlass(c)
+                  setQuery('')
+                }}
+                aria-current={c === klass && !query}
                 className={cn(
-                  'rounded px-2 py-1.5 text-left text-[11px] transition-colors',
-                  /*
-                    선택은 **연한 파랑 + 진한 파랑 글씨**다(리포트 회차 목록과 같은 패턴).
-                    진한 파랑을 배경으로 쓰면 그 위에 올릴 글자색 토큰이 없어 글씨가
-                    검정으로 남는다 — 실제로 안 읽혔다.
-                  */
-                  i === groupIndex
+                  'rounded px-2 py-1 text-xs transition-colors',
+                  c === klass && !query
                     ? 'bg-primary-soft font-medium text-primary'
                     : 'text-fg-muted hover:bg-surface-2 hover:text-fg',
                 )}
               >
-                {g.label}
-                {/*
-                  **담당자를 고르면 그 사람 몫만 센다.** 전체 수를 보여 주면 눌러 보고서야
-                  내 것이 없다는 것을 알게 된다 — `응시중`은 계정이 둘뿐이라 넷은 못 본다.
-                */}
-                <span className={cn('ml-1', i === groupIndex ? 'opacity-70' : 'text-fg-subtle')}>
-                  {mine(g.accounts).length}
-                  {owner !== ALL && `/${g.accounts.length}`}
-                </span>
+                {c}
               </button>
             ))}
           </div>
+        </>
+      )}
 
-          {/* 이 케이스로 무엇을 보는지 — 백엔드가 엑셀에 적어 준 문장 그대로 */}
-          {group.hint && <p className="mt-2 text-[11px] text-fg-muted">{group.hint}</p>}
+      {/* 이름을 아는 사람에게는 검색이 제일 빠르다 — 반을 몰라도 찾아진다 */}
+      <div className="mt-2 flex items-center gap-1.5 rounded border border-border bg-surface px-2 py-1.5">
+        <SearchIcon aria-hidden="true" className="size-3.5 shrink-0 text-fg-subtle" />
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder={role === '교육생' ? '이름으로 찾기 (반 전체에서)' : '이름으로 찾기'}
+          aria-label="계정 이름 검색"
+          className="min-w-0 flex-1 bg-transparent text-xs outline-none placeholder:text-fg-subtle"
+        />
+        {query && (
+          <button
+            type="button"
+            onClick={() => setQuery('')}
+            className="shrink-0 text-[11px] text-fg-subtle hover:text-fg"
+          >
+            지우기
+          </button>
+        )}
+      </div>
 
-          {/* 목록이 길어도 화면을 밀지 않게 스스로 스크롤한다 */}
-          <ul className="mt-1 max-h-[196px] overflow-y-auto">
-            {shown.map((a) => (
-              <li key={a.email}>
-                <AccountRow account={a} disabled={disabled} onPick={onPick} />
-              </li>
-            ))}
-          </ul>
-          {/* 「비어 있다」와 「고장났다」는 다르다 — 왜 없는지 말한다 */}
-          {shown.length === 0 && (
-            <p className="mt-2 text-[11px] text-fg-subtle">
-              {owner}님 몫으로 배정된 {group.label} 계정이 없어요.
-            </p>
-          )}
-        </div>
+      {/*
+        이름 격자 — 목록(1열)이 아니라 격자다. 25명이 1열이면 스크롤이 길어져
+        자기 이름이 화면 밖에 있고, 그러면 맨 위 것을 그냥 누른다(= 다시 몰린다).
+      */}
+      <ul className="mt-1.5 grid max-h-[188px] grid-cols-2 gap-1 overflow-y-auto sm:grid-cols-3">
+        {rows.map((r) => (
+          <li key={r.email}>
+            <button
+              type="button"
+              disabled={disabled}
+              onClick={() => onPick(r.email, r.password)}
+              className="w-full rounded border border-border bg-surface px-2 py-1.5 text-left transition-colors hover:border-primary-border hover:bg-primary-soft disabled:opacity-50"
+            >
+              <span className="block truncate text-xs font-medium text-fg">{r.name}</span>
+              {/* 두 반을 겸하는 매니저는 `A반 · F반`으로 한 줄에 나온다(위 dedupe) */}
+              <span className="block truncate text-[11px] text-fg-subtle">
+                {[r.groups.join(' · '), r.teamName].filter(Boolean).join(' · ') ||
+                  r.note ||
+                  r.email}
+              </span>
+            </button>
+          </li>
+        ))}
+      </ul>
+
+      {/* 「비어 있다」와 「고장났다」는 다르다 — 왜 없는지 말한다 */}
+      {rows.length === 0 && (
+        <p className="mt-2 text-[11px] text-fg-subtle">
+          {query ? `「${query}」와 맞는 계정이 없어요.` : `${role} 계정이 없어요.`}
+        </p>
       )}
     </div>
-  )
-}
-
-function AccountRow({
-  account,
-  disabled,
-  onPick,
-}: {
-  account: CaseAccount
-  disabled?: boolean
-  onPick: (email: string, password: string) => void
-}) {
-  const { email, password, name, className: klass, teamName, note } = account
-  const where = [klass, teamName].filter(Boolean).join(' ')
-
-  return (
-    <button
-      type="button"
-      disabled={disabled}
-      onClick={() => onPick(email, password)}
-      className="w-full rounded px-2 py-1.5 text-left text-[11px] transition-colors hover:bg-surface-2 disabled:opacity-50"
-    >
-      <span className="flex items-baseline gap-2">
-        <span className="w-[92px] shrink-0 text-fg">
-          {where && <span className="text-fg-subtle">{where} </span>}
-          {name}
-        </span>
-        {/* 이메일이 길어 줄바꿈되면 행 높이가 흔들린다 — 한 줄로 잘라 둔다 */}
-        <span className="min-w-0 flex-1 truncate text-fg-subtle">{email}</span>
-      </span>
-      {/*
-        이 계정만 다른 점은 **아랫줄로 내린다.** 상태 코드 세 개(`WAIT_FOR_REPORT ·
-        INTERRUPTED · 도달 2단`)가 이름·이메일과 한 줄에 들어가면 목록이 가로로 넘쳐
-        이메일이 잘려 사라진다 — 실제로 그렇게 됐다.
-      */}
-      {note && <span className="mt-0.5 block truncate text-fg-muted">{note}</span>}
-    </button>
   )
 }

--- a/src/features/auth/quickLoginAccounts.ts
+++ b/src/features/auth/quickLoginAccounts.ts
@@ -30,6 +30,18 @@
 export type QuickLoginAccount = { label: string; email: string; password: string }
 
 /**
+ * 역할 넷 — **이 순서가 화면 순서다.**
+ *
+ * 로그인 화면의 역할 버튼과 계정 고르개의 탭이 같은 배열을 읽는다. 둘이 각자 순서를
+ * 들고 있으면 한쪽만 고쳤을 때 나란히 놓인 두 줄이 다른 순서로 보인다.
+ *
+ * 컴포넌트 파일이 아니라 여기 두는 이유는 Fast Refresh다 — 컴포넌트 파일이 상수를
+ * 함께 export하면 그 파일의 상태 보존 핫리로드가 꺼진다(react/only-export-components).
+ */
+export const ROLES = ['매니저', '오퍼레이터', '교육생', '슈퍼 어드민'] as const
+export type Role = (typeof ROLES)[number]
+
+/**
  * 케이스 계정 하나. 교육생은 어느 반·팀 누구인지까지 보여줘야 고를 수 있고,
  * 매니저·오퍼레이터처럼 반·팀이 없는 역할은 `className`·`teamName`을 빈 문자열로 둔다
  * (표시부는 빈 값을 알아서 건너뛴다).
@@ -68,12 +80,26 @@ export type CaseGroup = {
   accounts: CaseAccount[]
 }
 
+/*
+  **배열도 받고 `{ groups: [{ accounts: [...] }] }`도 받는다.**
+
+  🔴 Vercel이 자격 증명처럼 보이는 값을 `VITE_`(브라우저 노출) 변수로 저장하지 못하게
+  막는다 — **저장 버튼이 아예 안 먹었다**(실측). 값을 넣을 수 없으면 배포본에서 기능이
+  통째로 사라지므로, 이미 통과한 적이 있는 모양(`dev-team-accounts.env`의 봉투)을
+  그대로 쓴다.
+
+  값을 가리는 것이 아니다 — 어차피 번들에 들어가고 그것이 의도다(위 주석). 노출 범위는
+  여전히 **어디에 넣느냐**로 정한다(운영 환경에는 넣지 않는다).
+*/
 function parseAccounts(raw: string | undefined): QuickLoginAccount[] {
   if (!raw) return []
   try {
-    const parsed: unknown = JSON.parse(raw)
-    if (!Array.isArray(parsed)) throw new Error('배열이 아닙니다')
-    return parsed.filter(
+    const parsed = JSON.parse(raw) as unknown[] | { groups?: { accounts?: unknown[] }[] }
+    const list = Array.isArray(parsed)
+      ? parsed
+      : (parsed.groups ?? []).flatMap((g) => g?.accounts ?? [])
+    if (!Array.isArray(list)) throw new Error('배열이 아닙니다')
+    return (list as Partial<QuickLoginAccount>[]).filter(
       (a): a is QuickLoginAccount =>
         typeof a?.label === 'string' &&
         typeof a?.email === 'string' &&
@@ -181,5 +207,20 @@ export const CASE_ACCOUNT_OWNERS = [
   ...new Set([...(caseData.owners ?? []), ...(teamData.owners ?? [])]),
 ]
 
-/** 고른 계정 총수 — 토글 라벨이 "N개"를 말하려면 필요하다 */
-export const CASE_ACCOUNT_TOTAL = CASE_ACCOUNT_GROUPS.reduce((n, g) => n + g.accounts.length, 0)
+/*
+  헤더 역할 전환 전용 목록 — **로그인 화면의 역할 버튼과 다른 값이다.**
+
+  로그인 화면은 아직 아무도 아닌 상태라 «역할»을 고르지만, 헤더는 이미 누군가로 들어와
+  있는 상태에서 **다른 사람으로 갈아타는** 자리다. 시연에서 그 갈아타기는 대개
+  «같은 반의 매니저 ↔ 그 반 학생»이라, 역할 이름보다 **누구인지**가 필요하다.
+
+  그래서 목록을 따로 둔다. 값이 없으면 `QUICK_LOGIN_ACCOUNTS`로 물러서므로(호출부)
+  env를 안 넣은 환경도 종전과 똑같이 동작한다.
+
+  ⚠️ **넷을 넘기지 않는다.** 드롭다운은 훑는 자리가 아니라 집는 자리다 — 한 반을
+  통째로 올렸다가 26줄이 되어 도로 뺐다. 많은 계정이 필요하면 로그인 화면의 고르개를
+  쓴다(`CaseAccountPicker`).
+
+  ⚠️ 값이 번들에 들어간다 — 운영 환경에는 넣지 않는다(위 `VITE_DEV_ACCOUNTS`와 같다).
+*/
+export const HEADER_ACCOUNTS = parseAccounts(import.meta.env.VITE_HEADER_ACCOUNTS)

--- a/src/features/manager/interviews/InterviewListScreen.tsx
+++ b/src/features/manager/interviews/InterviewListScreen.tsx
@@ -24,7 +24,7 @@ import {
   useReincludeInterviewCase,
   VOID_REVIEW_OPEN,
 } from './_/api/api'
-import type { InterviewCase } from './_/api/types'
+import type { InterviewCase, RoundOption } from './_/api/types'
 import {
   ALL,
   getSessionFilters,
@@ -80,6 +80,24 @@ const traineePath = (traineeId: string, cohortId: string | undefined) =>
 /** `2026-07-24T…` → `07.24` */
 const shortDate = (iso: string | null) => (iso ? `${iso.slice(5, 7)}.${iso.slice(8, 10)}` : '')
 
+/**
+ * 아직 판정이 없는 회차 — 면담 케이스가 **하나도 생길 수 없는** 상태다.
+ *
+ * `OPEN`은 이해도 확인이 진행 중이고(`RoundOption.status` 주석), `PLANNED`는 시작도
+ * 안 했다. 위험 판정은 결과가 나와야 켜지므로 둘 다 목록이 비어 있다.
+ */
+const NO_VERDICT_YET = ['OPEN', 'PLANNED']
+
+/**
+ * 첫 진입에 열 회차 — **판정이 나온 가장 최근 회차.**
+ *
+ * 목록은 프로젝트 순서로 오므로 뒤에서부터 찾으면 가장 최근이다. 전부 진행 중이면
+ * (막 시작한 기수) `undefined`를 돌려 서버 기본값에 맡긴다 — 그때는 어느 회차를
+ * 열어도 비어 있고, 화면이 굳이 다른 판정을 내밀 이유가 없다.
+ */
+const defaultRound = (list: RoundOption[] | undefined) =>
+  list?.filter((r) => !NO_VERDICT_YET.includes(r.status)).at(-1)?.assessmentRoundId
+
 export default function InterviewListScreen() {
   const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()
@@ -134,14 +152,32 @@ export default function InterviewListScreen() {
   */
   const roundList = rounds.data
   /*
-    🟢 **회차를 안 골라도 목록을 부른다**(32차 R2). 한때 회차 목록을 먼저 받아야
-    했고 그래서 첫 진입이 **직렬 두 왕복**(2.5~3.1초)이었다 — 이제 서버가 「이번
-    회차」를 고르고, 회차 드롭다운은 그와 **나란히** 채워진다.
+    🔴 **첫 진입에 「판정이 나온 가장 최근 회차」를 연다.**
 
-    사용자가 고른 값이 있으면 그것을 보내고, 없으면 **아무것도 안 보낸다** —
-    직전 회차를 화면이 추측하지 않는다(명부와 같은 판정을 서버가 갖고 있다).
+    종전에는 회차를 안 보내고 **서버가 「이번 회차」를 고르게** 했다(32차 R2). 그런데
+    이번 회차는 **아직 진행 중**이라 위험 판정 자체가 없다 — 면담 케이스는 이해도
+    확인이 끝나고 결과가 나와야 생긴다. 그래서 첫 진입이 언제나 **빈 목록**이었다
+    (7기 실측: 미프 4차 `OPEN` → 0건, 미프 3차 `CLOSED` → 20건. 전 매니저 동일).
+
+    빈 목록은 "담당 학생 중 면담 대상이 없다"로 읽힌다. 실제로는 "아직 안 나왔다"이고,
+    바로 옆 회차에는 20건이 있다. 회차를 손으로 바꿔야만 그것을 볼 수 있었다.
+
+    ⚠️ 이 판정을 화면이 갖는 것은 **빚이다.** 서버가 「이번 회차」를 고르는 규칙은
+    명부·대시보드와 같은 축이라 그쪽과 어긋나면 안 되는데, 지금은 이 화면만 다른
+    회차를 연다. 서버가 「판정이 나온 마지막 회차」를 알려주게 되면 이 함수는 지운다.
+
+    비용은 **첫 진입 +200ms**다(회차 목록을 기다린다). 사용자가 고른 회차가 있으면
+    기다리지 않는다. 실측: `rounds` 191~209ms · `interviews` 228~351ms.
   */
-  const round = filters.round
+  const round = filters.round || defaultRound(roundList) || ''
+  /*
+    회차 조회가 끝나기 전에는 목록을 안 부른다 — 안 그러면 서버가 고른 진행 중 회차로
+    한 번 그리고 곧바로 다른 회차로 갈아쳐, 빈 목록이 한 번 스친다.
+
+    **`isPending`으로 본다.** `roundList`가 왔는지로 보면 회차 조회가 실패했을 때
+    목록이 영영 안 뜬다 — 그때는 서버 기본값으로라도 그려야 한다.
+  */
+  const roundReady = !!filters.round || !rounds.isPending
 
   const search = useDebounced(filters.search).trim()
   /*
@@ -150,7 +186,7 @@ export default function InterviewListScreen() {
     조회를 끈다 — 빈 값으로 부르면 400이다.
   */
   const list = useInterviewList(
-    cohortId
+    cohortId && roundReady
       ? {
           cohort: cohortId,
           assessmentRoundId: round || undefined,

--- a/src/features/trainee/demo/DemoReportScreen.tsx
+++ b/src/features/trainee/demo/DemoReportScreen.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router'
+import { Link, useNavigate } from 'react-router'
 import PageHeader from '@/components/common/PageHeader'
 import StatusMessageCard from '@/components/common/StatusMessageCard'
 import { Button } from '@/components/ui/Button'
@@ -9,6 +9,7 @@ import ConceptCard from '../report/components/ConceptCard'
 import RoundRail from '../report/components/RoundRail'
 import { askedConcepts } from '../report/_/api/types'
 import { buildConcepts } from './buildReport.ts'
+import { PROBLEMS } from './data/fixture.ts'
 import DemoShell from './components/DemoShell'
 import { useDemoSession } from './useDemoSession.ts'
 
@@ -22,8 +23,18 @@ import { useDemoSession } from './useDemoSession.ts'
   회차 레일은 한 칸뿐이다. 실제 화면은 과거 회차가 쌓여 있지만 시연에서는 지금 회차
   하나만 보면 되고, 없는 과거를 지어내면 그것부터 설명해야 한다.
 */
+/** 개념 이름 → 문제 번호. 리포트 카드는 이름만 들고 있다 */
+const problemNoOf = (name: string) => PROBLEMS.find((p) => p.title === name)?.problemNo ?? 1
+
 export default function DemoReportScreen() {
-  const { state } = useDemoSession()
+  const { state, send } = useDemoSession()
+  const navigate = useNavigate()
+
+  /** 그 개념 하나로 세션을 다시 열고 세션 화면으로 보낸다 */
+  const startReview = (problemNo: number) => {
+    send({ type: 'START_REVIEW', problemNo })
+    navigate('/demo/session')
+  }
 
   if (state.phase !== 'ENDED') {
     return (
@@ -49,11 +60,16 @@ export default function DemoReportScreen() {
 
   const concepts = buildConcepts(state)
   const asked = askedConcepts(concepts)
-  const retryCount = asked.filter((c) => c.isRetryTarget).length
+  /*
+    **다시 보기는 개념마다 한 번씩이다.** 대상이 셋이면 셋 다 볼 수 있고, 본 개념만
+    빠진다 — 좌측 레일이 말하는 것도 «아직 남은 개수»다.
+  */
+  const pendingRetry = asked.filter((c) => c.isRetryTarget && !c.comparedReach).length
+  const reviewedCount = asked.filter((c) => c.comparedReach).length
 
   return (
     <DemoShell>
-      <PageHeader title="내 리포트" breadcrumb="미니프로젝트 3차" />
+      <PageHeader title="내 리포트" />
 
       <div className="flex flex-col gap-4 md:flex-row md:gap-8">
         <RoundRail
@@ -61,8 +77,17 @@ export default function DemoReportScreen() {
             {
               id: 'demo',
               label: '미니프로젝트 3차',
-              note: retryCount > 0 ? `다시 볼 개념 ${retryCount}개` : '전부 통과',
-              hasDot: retryCount > 0,
+              /*
+                실제 레일은 회차마다 상태를 한 줄로 말한다(`시작 전`·`중단`·
+                `다시 보기 1개 완료`). 데모는 회차가 하나라 그 한 줄에 지금 상태를 쓴다.
+              */
+              note:
+                pendingRetry > 0
+                  ? `다시 볼 개념 ${pendingRetry}개`
+                  : reviewedCount > 0
+                    ? `다시 보기 ${reviewedCount}개 완료`
+                    : '전부 통과',
+              hasDot: pendingRetry > 0,
             },
           ]}
           selectedId="demo"
@@ -71,21 +96,56 @@ export default function DemoReportScreen() {
 
         <div className="min-w-0 flex-1">
           <Card className="p-6">
-            <div className="mb-5">
-              <p className="text-sm text-fg-muted">
-                검증 개념 {asked.length}개 중{' '}
-                <b className="text-fg">{asked.length - retryCount}개</b>를 통과했어요.
-                {retryCount > 0 && ` ${retryCount}개는 다시 보기 대상이에요.`}
-              </p>
-              <p className="mt-1 text-xs text-fg-subtle">
-                교안 spring_backend_v1.pdf · 2026-08-25 발행
+            {/*
+              헤더 — **실제 리포트와 같은 모양**이다(`MyReportScreen`의 `PublishedBody`):
+              회차 이름을 `h2`로, 그 아래 발행일·교안을 한 줄로. 다시 보기를 마쳤으면
+              그 날짜도 같은 줄에 붙는다.
+            */}
+            <div className="mb-4">
+              <h2 className="text-xl font-bold text-fg">미니프로젝트 3차</h2>
+              <p className="text-sm text-fg-subtle">
+                발행 08-25
+                {reviewedCount > 0 && ` · 다시 보기 ${reviewedCount}개`} · 교안
+                spring_backend_v1.pdf
               </p>
             </div>
 
+            {/*
+              배너를 두지 않는다. 「다시 볼 수 있는 문제 N개」·「다시 보기를 마쳤어요」를
+              맨 위에 뒀었는데, 정작 할 일은 **개념 카드 안의 버튼**이라 배너는 같은 말을
+              한 번 더 하면서 위쪽 공간만 먹었다(실사용 피드백). 남은 개수는 좌측 회차
+              레일의 한 줄이 이미 말한다.
+            */}
             <ReachLadder />
 
             {concepts.map((c, i) => (
-              <ConceptCard key={c.name} concept={c} isLast={i === concepts.length - 1} />
+              <ConceptCard
+                key={c.name}
+                concept={c}
+                isLast={i === concepts.length - 1}
+                /*
+                  🔴 **카드 안에 넣는다.** 밖에서 형제로 그렸더니 좌측 타임라인 선·핀과
+                  어긋나 버튼이 카드 밖으로 튀어나왔다(실측 — 레이아웃이 깨졌다).
+                  카드가 자기 `pl-5` 안에 품어야 선이 그 아래로 이어진다.
+
+                  다시 볼 수 있는 개념(2단 미만)이면서 **아직 안 본 것**에만 붙는다.
+                */
+                footer={
+                  c.asked && c.isRetryTarget && !c.comparedReach ? (
+                    <div className="mt-3">
+                      {/*
+                        색은 「리포트 보기」와 같은 primary — 둘 다 앞으로 나아가는 주 액션.
+
+                        옆에 설명을 붙이지 않는다 — 바로 위 잠금 안내가 이미 「마치면
+                        열린다」를 말한다. 같은 말이 두 줄에 걸치면 버튼이 그만큼 밀린다.
+                      */}
+                      <Button size="sm" onClick={() => startReview(problemNoOf(c.name))}>
+                        이 개념 다시 보기
+                      </Button>
+                    </div>
+                  ) : null
+                }
+              />
             ))}
           </Card>
         </div>
@@ -104,10 +164,12 @@ export default function DemoReportScreen() {
   **배지를 길게 만드는 대신 사다리를 위에 한 번만 그린다.** 배지마다 `4단 ·`을 붙이면
   카드 셋이 전부 길어지고, 정작 중요한 개념 이름이 밀린다.
 
-  0단은 뺐다. 사다리는 "어디까지 올라가는가"를 보여주는 자리이고 0단은 그 사다리에
-  발을 못 붙인 상태라, 칸으로 그리면 "0단도 한 단계"로 읽힌다.
+  **0단도 넣는다.** 처음엔 뺐는데, 리포트에 `코드 설명까지 가지 못했어요` 배지가 뜨는데
+  사다리에는 그 칸이 없어 **그게 몇 단인지 알 수 없었다.** 0단은 "사다리에 발을 못
+  붙인 상태"라는 뜻이고, 그것도 다섯 칸 중 하나로 보여야 위치가 잡힌다.
 */
 const LADDER = [
+  { step: 0, label: '설명까지 못 감' },
   { step: 1, label: '무엇을 하는지' },
   { step: 2, label: '왜 그렇게 했는지' },
   { step: 3, label: '가능한 다른 방법' },
@@ -116,7 +178,7 @@ const LADDER = [
 
 function ReachLadder() {
   return (
-    <div className="mb-6 rounded-md bg-canvas px-4 py-3">
+    <div className="mb-4 rounded-md bg-canvas px-3 py-2">
       <p className="mb-2 text-[11px] font-medium text-fg-muted">
         도달 단계 — 질문은 아래 순서로 깊어지고, 답한 만큼 올라갑니다
       </p>
@@ -143,6 +205,7 @@ function ReachLadder() {
 }
 
 const REACH_PIN: Record<number, string> = {
+  0: 'bg-reach-0',
   1: 'bg-reach-1',
   2: 'bg-reach-2',
   3: 'bg-reach-3',

--- a/src/features/trainee/demo/DemoSessionScreen.tsx
+++ b/src/features/trainee/demo/DemoSessionScreen.tsx
@@ -4,6 +4,8 @@ import CodePane from '../session/components/CodePane'
 import IntroScreen from '../session/components/IntroScreen'
 import QuestionThread from '../session/components/QuestionThread'
 import TransitionScreen from '../session/components/TransitionScreen'
+import { AwayToast } from '../session/components/AwayToast'
+import { useAwayToast } from '../session/useSessionEffects'
 import DemoEndScreen from './components/DemoEndScreen'
 import DemoTopBar from './components/DemoTopBar'
 import ScoreBar from './components/ScoreBar'
@@ -36,6 +38,9 @@ import { useDemoSession } from './useDemoSession.ts'
 /** 문제당 20분 — 실제 값(`session.problem-time-limit-minutes`)과 같다 */
 const PROBLEM_LIMIT_MS = 20 * 60_000
 
+/** 관찰 신호를 보낼 서버가 없다 — 토스트만 띄우면 되므로 콜백은 비운다 */
+const noop = () => {}
+
 export default function DemoSessionScreen() {
   const { state, send } = useDemoSession()
   const [callersExpanded, setCallersExpanded] = useState(true)
@@ -49,6 +54,12 @@ export default function DemoSessionScreen() {
     problemStartedAt.current = Date.now()
   }, [state.problemIdx])
 
+  /*
+    창 이탈 감지 — 실제 화면의 훅을 그대로 쓴다. 데모는 기록을 서버로 보내지 않으므로
+    콜백은 비어 있고, 토스트만 뜬다.
+  */
+  const awayToast = useAwayToast(noop, state.phase !== 'ENDED')
+
   const elapsedMs = useTicker(state.phase === 'IN_PROBLEM')
   const problemRemainingMs =
     state.phase === 'IN_PROBLEM'
@@ -61,7 +72,7 @@ export default function DemoSessionScreen() {
     return (
       <div className="h-svh">
         <IntroScreen
-          mode="FIRST"
+          mode={state.mode}
           problemTotal={PROBLEM_TOTAL}
           onStart={() => send({ type: 'START' })}
           starting={false}
@@ -74,6 +85,7 @@ export default function DemoSessionScreen() {
     return (
       <div className="flex h-svh flex-col">
         <DemoTopBar
+          mode={state.mode}
           problemNo={problem.problemNo}
           problemTotal={PROBLEM_TOTAL}
           elapsedMs={elapsedMs}
@@ -91,6 +103,7 @@ export default function DemoSessionScreen() {
     return (
       <div className="flex h-svh flex-col">
         <DemoTopBar
+          mode={state.mode}
           problemNo={problem.problemNo}
           problemTotal={PROBLEM_TOTAL}
           elapsedMs={elapsedMs}
@@ -99,7 +112,7 @@ export default function DemoSessionScreen() {
         <div className="flex-1">
           <TransitionScreen
             reason={state.transitionReason ?? 'NEXT'}
-            mode="FIRST"
+            mode={state.mode}
             nextTitle={problem.title}
             nextPath={problem.code.path}
             isNextLast={problem.problemNo === PROBLEM_TOTAL}
@@ -118,6 +131,7 @@ export default function DemoSessionScreen() {
   return (
     <div className="relative flex h-svh flex-col">
       <DemoTopBar
+        mode={state.mode}
         problemNo={problem.problemNo}
         problemTotal={PROBLEM_TOTAL}
         title={problem.title}
@@ -144,7 +158,7 @@ export default function DemoSessionScreen() {
         <ResizableHandle withHandle />
         <ResizablePanel minSize={320} className="flex flex-col">
           <QuestionThread
-            mode="FIRST"
+            mode={state.mode}
             turns={problem.turns}
             current={problem.current}
             pendingAnswer={null}
@@ -156,9 +170,19 @@ export default function DemoSessionScreen() {
             hintsLeft={problem.current?.hintsLeft ?? 0}
             onScore={(score: Score) => send({ type: 'ANSWER', score })}
             onTimeOut={() => send({ type: 'TIME_OUT' })}
+            onRequestHint={() => send({ type: 'OPEN_HINT' })}
           />
         </ResizablePanel>
       </ResizablePanelGroup>
+
+      {/*
+        창을 벗어났다 돌아오면 뜨는 토스트 — 실제 화면 것을 그대로 쓴다.
+
+        데모는 기록을 서버로 보내지 않지만 **토스트는 보여준다.** 시연에서 설명해야 하는
+        것이 "다른 창을 열면 남는다"는 사실 자체이고, 그것을 말로만 하면 안 믿는다.
+        다른 탭으로 갔다 돌아오면 그 자리에서 뜬다.
+      */}
+      {awayToast && <AwayToast seconds={awayToast.data.seconds} leaving={awayToast.leaving} />}
     </div>
   )
 }

--- a/src/features/trainee/demo/buildReport.ts
+++ b/src/features/trainee/demo/buildReport.ts
@@ -2,23 +2,33 @@ import type { ConceptReport, QaEntry } from '../report/_/api/types'
 import { answerFor } from './data/answers.ts'
 import { PROBLEMS, TEACHES } from './data/fixture.ts'
 import { AXIS_NAME, RUBRIC, type AxisCode, type Score } from './data/rubric.ts'
-import {
-  axisResults,
-  reachedLevel,
-  type AxisResult,
-  type CloseReason,
-  type DemoState,
-} from './engine.ts'
+import { axisResults, reachedLevel, type AxisResult, type DemoState } from './engine.ts'
 
 /*
   시연자가 누른 점수 → 리포트.
 
   **고정된 리포트를 보여주지 않는 이유.** 세션에서 마음대로 눌러 놓고 리포트가 항상
-  같으면, 보는 사람이 가장 먼저 "그럼 아까 누른 건 뭐였죠"를 묻는다. 누른 것이 결과로
-  이어져야 이 제품이 무엇을 하는지가 한 흐름으로 보인다.
+  같으면, 보는 사람이 가장 먼저 "그럼 아까 누른 건 뭐였죠"를 묻는다.
 
-  실제 서버가 만드는 모양(`ConceptReport`)을 그대로 만든다 — 그래야 `ConceptCard`를
-  한 줄도 안 고치고 쓴다.
+  ## 실제 응답을 보고 맞췄다
+
+  처음엔 짐작으로 만들었다가 실제 교육생 계정(`GET /reports`)을 받아 대조하니 셋이
+  달랐다. 지금은 실측 모양을 따른다.
+
+  | | 처음 만든 것 | 실제 |
+  |---|---|---|
+  | `said` | `네 질문을 모두 통과했어요` 한 줄 | **88~360자 진단문** |
+  | 해설 필드 | `explanation` | **`explain`** — 막힌 지점 + 학생 이해 재구성 2요소 |
+  | `qa` | 전 축의 문답 | **막힌 축 하나만** (`L3 질문`·`L3 힌트 1`·`L3 힌트 2`) |
+
+  실측 예(노유진 · 미프 4차):
+
+  > 학생은 JPA 엔티티에서 nullable 컬럼이 (…) L1, 그리고 (…) L2에 대해서는 힌트 없이
+  > 정확히 설명했다. 그러나 L3 단계에서 (…) 힌트 2개를 받은 뒤에도 답을 하지 못했다.
+  > 결과적으로 (…) 기본 개념은 이해하지만, (…) 응용 능력은 부족한 상태다.
+
+  세 부분이다 — **어디까지 했나 · 어디서 막혔나 · 그래서 무슨 상태인가.** 아래
+  `saidOf`가 그 세 문장을 진행 결과로 조립한다.
 */
 
 /** 도달 2단 미만이면 다시 볼 대상이다 — L1·L2가 필수 구간이라 그렇다 */
@@ -26,89 +36,250 @@ const RETRY_BELOW = 2
 
 const AXES: readonly AxisCode[] = ['L1', 'L2', 'L3', 'L4']
 
+/** 그 축이 무엇을 묻는지 — 진단문이 "무엇을" 설명했는지 말하려면 필요하다 */
+const AXIS_ASK: Record<AxisCode, string> = {
+  L1: '코드가 무엇을 하고 어떻게 이어지는지',
+  L2: '왜 그렇게 했는지',
+  L3: '다른 방법과 무엇이 다른지',
+  L4: '언제 문제가 되는지',
+}
+
+/** 그 축을 못 넘겼을 때 무엇이 부족한 것인가 — 진단의 마지막 문장에 쓴다 */
+const AXIS_GAP: Record<AxisCode, string> = {
+  L1: '코드를 읽고 흐름을 설명하는 능력',
+  L2: '선택의 이유를 제약과 연결해 설명하는 능력',
+  L3: '대안을 떠올려 지금 방식과 비교하는 응용 능력',
+  L4: '한계 조건을 특정해 방어하는 능력',
+}
+
 export function buildConcepts(state: DemoState): ConceptReport[] {
+  /*
+    다시 보기를 실제로 **답한** 개념만 추린다. 버튼만 누르고 한 문제도 안 답했으면
+    비교할 것이 없다 — `0단 → 0단`을 그리면 다시 본 것처럼 보인다.
+  */
+  const reviewed = new Set(
+    state.reviewResults.filter((r) => r.scores.length > 0).map((r) => r.problemNo),
+  )
+
   return PROBLEMS.map((p, i) => {
     const results = axisResults(state.results, p.problemNo)
     const level = reachedLevel(state.results, p.problemNo)
     const teach = TEACHES[i]
+    const isRetryTarget = level < RETRY_BELOW
+    const timedOut = state.closeReasons[i] === 'PROBLEM_TIME_LIMIT'
 
     /*
-      **한 번도 답하지 못한 개념도 `asked: true`다.** 「문항 없음」은 그 학생 코드에
-      근거가 없어 문제가 **아예 안 만들어진** 것이고, 여기는 만들어졌는데 도달을 못 한
-      것이다 — 0단으로 남겨야 그 둘이 갈린다.
+      🔴 **잠금은 다시 보기를 마치면 풀린다.**
+
+      도달 2단 미만이면 서버가 `explain`·`qa`를 가려서 보낸다(`ConceptCard`가 그때
+      자물쇠 안내를 그린다). 다시 보기를 마친 개념은 열린다 — 실측으로 확인했다
+      (미프 1차 `retryState: DONE`의 재시험 대상 개념에 `explain`이 들어 있었다).
     */
+    const didReview = reviewed.has(p.problemNo)
+
+    /*
+      🔴 **다시 보기는 개념마다 한 번씩이다.** 대상이 셋이면 셋 다 다시 볼 수 있고,
+      각 개념은 한 번 보면 그 개념의 기회가 끝난다.
+
+      잠금도 개념별이다 — 다시 본 개념만 해설·문답이 열리고, 아직 안 본 개념은 잠긴
+      채로 남아 그 자리에 버튼이 계속 있다.
+    */
+    const locked = isRetryTarget && !didReview
+
     return {
       asked: true,
       name: p.title,
+      /*
+        **판정은 언제나 1차다.** 배지도 진단문도 해설도 1차 응시를 말한다 — 다시 본
+        결과는 성적에 반영되지 않기 때문이다(실제 규칙). 다시 보기가 바꾸는 것은
+        **잠금이 풀린다**는 것 하나뿐이고, 그 사실은 카드 배지 옆 표시로 말한다.
+      */
       reachedLevel: level,
-      said: saidOf(level, results, state.closeReasons[i]),
-      isRetryTarget: level < RETRY_BELOW,
+      said: saidOf(p.problemNo, p.title, results, timedOut),
+      isRetryTarget,
       curriculumRef: { chapter: teach.unitId, pages: teach.source, title: teach.label },
-      explanation: explanationOf(results),
-      qa: qaOf(i, results),
-      comparedReach: null,
+      explanation: locked ? null : explainOf(results, timedOut),
+      qa: locked
+        ? null
+        : qaOf(i, results, didReview ? axisResults(state.reviewResults, p.problemNo) : null),
+      /*
+        다시 봤다는 **사실만** 남긴다. 올라간 단계를 문장으로 쓰지 않는다 — 판정이
+        안 바뀌는데 `다시 봤을 때 …까지`라고 적으면 그게 새 성적처럼 읽힌다
+        (실사용 피드백). 카드는 이 값이 있으면 「다시 봄」 표시만 그린다.
+      */
+      comparedReach: didReview
+        ? { before: level, after: reachedLevel(state.reviewResults, p.problemNo) }
+        : null,
     }
   })
 }
 
-/** 카드 본문 한 문단 — 어디까지 갔고 왜 멈췄나 */
-function saidOf(level: number, results: AxisResult[], closeReason: CloseReason): string {
-  const passed = results.filter((r) => r.status === 'PASSED').length
+/**
+ * 카드 본문 한 줄 — **요약이지 해설이 아니다.**
+ *
+ * 🔴 실측에서 `said`는 **한 문장 정형문**이었다.
+ *
+ * ```
+ * 문제 1 [Supervisor 패턴의 HITL 실행 흐름] — 코드 이해와 설계 논리(L1~L2)는
+ * 통과했지만, 같은 요구사항을 구현할 다른 방법과 장단점 비교(L3)가 부족했습니다.
+ * ```
+ *
+ * 한때 여기에 세 문장짜리 진단을 넣었다가 *"이 멘트 자체가 해설 아니냐"* 는 지적을
+ * 받았다 — 맞다. 어디까지 했고 왜 그랬는지를 풀어 쓰는 것은 아래 `explainOf`의
+ * 몫이고, 이 자리는 **한눈에 보는 한 줄**이다. 카드가 접혀 있어도 이 줄만 읽으면
+ * 무슨 일이 있었는지 알아야 한다.
+ */
+function saidOf(
+  problemNo: number,
+  title: string,
+  results: AxisResult[],
+  timedOut: boolean,
+): string {
+  const passed = results.filter((r) => r.status === 'PASSED')
   const stuck = results.find((r) => r.status === 'NOT_PASSED')
+  const head = `문제 ${problemNo} [${title}] — `
 
-  if (closeReason === 'PROBLEM_TIME_LIMIT') {
-    return `질문 ${passed}개까지 답하고 시간이 다 됐어요. 남은 질문은 묻지 못했으니 못한 것으로 기록하지 않아요.`
-  }
+  const range = (list: AxisResult[]) =>
+    list.length === 1
+      ? `${AXIS_NAME[list[0].axisCode]}(${list[0].axisCode})`
+      : `${AXIS_NAME[list[0].axisCode]}과 ${AXIS_NAME[list[list.length - 1].axisCode]}(${list[0].axisCode}~${list[list.length - 1].axisCode})`
+
   if (stuck) {
-    const rubric = RUBRIC[stuck.axisCode][(stuck.finalScore ?? 0) as Score]
-    return `${AXIS_NAME[stuck.axisCode]}에서 멈췄어요. 다시 설명을 두 번 드렸는데도 「${rubric}」 수준에 머물렀어요.`
+    return passed.length > 0
+      ? `${head}${range(passed)}는 통과했지만, ${AXIS_ASK[stuck.axisCode]}에 해당하는 ${AXIS_NAME[stuck.axisCode]}(${stuck.axisCode})를 통과하지 못했습니다.`
+      : `${head}${AXIS_ASK[stuck.axisCode]}에 해당하는 ${AXIS_NAME[stuck.axisCode]}(${stuck.axisCode})부터 통과하지 못했습니다.`
   }
-  if (level === AXES.length) {
-    return '네 질문을 모두 통과했어요. 코드가 무엇을 하는지부터 언제 문제가 되는지까지 설명했어요.'
+  if (timedOut) {
+    return passed.length > 0
+      ? `${head}${range(passed)}는 통과했지만, 남은 단계는 문제 시간이 다 되어 묻지 못했습니다.`
+      : `${head}답하기 전에 문제 시간이 다 되어 묻지 못했습니다.`
   }
-  return '답한 만큼 기록했어요.'
+  if (passed.length === AXES.length) {
+    return `${head}네 단계를 모두 통과했습니다.`
+  }
+  return `${head}${range(passed)}까지 통과했습니다.`
 }
 
 /*
-  「무엇이 부족했나」 — **막힌 축만** 적는다.
+  「어디서 막혔나」 — **여기가 해설이다.**
 
-  통과한 축까지 줄줄이 쓰면 정작 봐야 할 한 줄이 묻힌다(정의서 §9 "피드백은 막힌
-  만큼 두꺼워진다"). 채점 근거는 녹화된 자리에서 점수까지 맞을 때만 진짜가 있고,
-  없으면 루브릭 문장으로 대신한다 — **지어내지 않는다.**
+  실측 구조는 두 요소다.
+
+  ```
+  ["문제 1 [Service와 셀렉터] — 코드가 무엇을 하는지(L1)는 설명했지만, 왜 이 구조를
+    선택했는지에 해당하는 설계 논리(L2)를 통과하지 못했습니다.",
+   "제가 이해한 흐름은, (…) 다만 이 구조를 선택한 이유와 책임 경계까지는 설명하기
+    어렵습니다."]
+  ```
+
+  ① **판정** — `said`와 같은 문장이다(실측에서 실제로 같았다). 카드를 접었다 펴도
+  기준이 흔들리지 않게 같은 말로 시작한다. ② **학생이 이해한 것을 학생 말로 재구성** —
+  자기가 한 말을 되돌려 받아야 무엇이 빠졌는지 스스로 보인다.
+
+  여기에 **어디까지 했고 왜 거기서 막혔는지**를 풀어 쓴다 — 한 줄 요약(`said`)이 못
+  담는 것이 그것이고, 잠금이 풀렸을 때 학생이 실제로 얻는 것도 이 설명이다.
+
+  ⚠️ 도달 2단 미만이면 서버가 가리고, 다시 보기를 마치면 열린다(`buildConcepts`의 `locked`).
 */
-function explanationOf(results: AxisResult[]): string[] | null {
-  const lines = results
-    .filter((r) => r.status === 'NOT_PASSED')
-    .map(
-      (r) =>
-        `${AXIS_NAME[r.axisCode]} — ${r.evidence ?? RUBRIC[r.axisCode][(r.finalScore ?? 0) as Score]}`,
+function explainOf(results: AxisResult[], timedOut: boolean): string[] | null {
+  const stuck = results.find((r) => r.status === 'NOT_PASSED')
+  const passed = results.filter((r) => r.status === 'PASSED')
+  if (!stuck && !timedOut) return null
+
+  /*
+    🔴 **`said`를 다시 적지 않는다.**
+
+    실측 응답은 `explain[0]`이 `said`와 같은 문장이었는데, 화면에서는 그 두 줄이 위아래로
+    붙어 **같은 말이 두 번** 나온다(실사용 피드백). 실제로도 그렇게 보이는 것이 맞다고
+    할 수는 없으니 여기서는 겹치는 첫 줄을 빼고 **풀어 쓰는 부분부터** 시작한다.
+  */
+  const lines: string[] = []
+
+  // ② 어디까지 했나 — 힌트를 안 쓰고 넘긴 축과 쓰고 넘긴 축을 갈라 말한다
+  if (passed.length > 0) {
+    const solo = passed.filter((r) => r.scores.length === 1)
+    const helped = passed.filter((r) => r.scores.length > 1)
+    const label = (list: AxisResult[]) =>
+      list.map((r) => `${AXIS_ASK[r.axisCode]}(${r.axisCode})`).join(', ')
+    const done =
+      solo.length > 0 && helped.length > 0
+        ? `${label(solo)}는 힌트 없이 설명했고, ${label(helped)}는 다시 설명을 듣고 답했습니다.`
+        : helped.length > 0
+          ? `${label(helped)}를 다시 설명을 듣고 답했습니다.`
+          : `${label(solo)}를 힌트 없이 설명했습니다.`
+    lines.push(done)
+  }
+
+  // ③ 왜 거기서 막혔나 — 채점 근거가 있으면 그것이 제일 정확하다
+  if (stuck) {
+    const tries = stuck.scores.length
+    const how = tries > 1 ? `다시 설명을 ${tries - 1}번 듣고도` : '한 번의 시도에서'
+    lines.push(
+      stuck.evidence
+        ? `${AXIS_NAME[stuck.axisCode]}에서는 ${how} 막혔습니다 — ${stuck.evidence}`
+        : `${AXIS_NAME[stuck.axisCode]}에서는 ${how} 「${RUBRIC[stuck.axisCode][(stuck.finalScore ?? 0) as Score]}」 수준에 머물렀습니다.`,
     )
-  return lines.length > 0 ? lines : null
+    lines.push(`${AXIS_GAP[stuck.axisCode]}부터 다시 보면 좋겠습니다.`)
+  }
+
+  // ④ 학생이 이해한 것을 학생 말로 되돌려 준다 — **없으면 지어내지 않는다**
+  const evidence = passed.find((r) => r.evidence)?.evidence
+  if (evidence) lines.push(`제가 이해한 흐름은, ${evidence}`)
+
+  /*
+    시간 초과처럼 **풀어 쓸 것이 없는 경우**가 있다 — 답을 아예 못 한 문제가 그렇다.
+    그때는 요약(`said`)이 이미 사실을 말했으므로 빈 박스를 그리지 않는다.
+  */
+  if (lines.length === 0) {
+    return timedOut
+      ? [
+          `답을 시작하기 전에 시간이 다 됐습니다. 못한 것이 아니라 도달하지 못한 것이라, 이 개념은 다시 볼 대상이 됩니다.`,
+        ]
+      : null
+  }
+
+  return lines
 }
 
-/*
-  문답 원문 — 질문·힌트·답변을 오간 순서대로.
+/** 다시 본 문답은 라벨에 접두어가 붙는다 — `QaList`가 그것으로 묶음을 가른다 */
+const REVIEW_PREFIX = '다시 보기 · '
 
-  ⚠️ **`state.turns`를 쓰지 않는다.** 그 배열은 문제가 닫힐 때 비워진다(다음 문제의
-  대화창이라 그래야 한다). 대신 남아 있는 점수 이력(`scores`)으로 세션이 썼던 것과
-  **같은 규칙**(`answerFor`)을 다시 돌린다 — 그래서 리포트의 답변이 세션에서 본
-  문장과 어긋나지 않는다.
-*/
-function qaOf(problemIdx: number, results: AxisResult[]): QaEntry[] | null {
+function qaOf(
+  problemIdx: number,
+  results: AxisResult[],
+  /** 다시 본 결과. 있으면 1차 문답 **아래에 이어 붙인다** — 갈아치우지 않는다 */
+  reviewResults: AxisResult[] | null,
+): QaEntry[] | null {
+  const first = turnsOf(problemIdx, results, '')
+  if (!reviewResults) return first
+  const again = turnsOf(problemIdx, reviewResults, REVIEW_PREFIX)
+  const all = [...(first ?? []), ...(again ?? [])]
+  return all.length > 0 ? all : null
+}
+
+/**
+ * 한 벌의 결과에서 **답한 것 전부**를 문답으로 편다.
+ *
+ * 🔴 한때 막힌 축 하나만 뽑았다 — 실제 API가 그렇게 주기 때문이다(실측: `level 2`인
+ * 개념의 `qa`가 전부 L3의 것이었다). 그런데 **시연에서는 학생이 무엇을 답했는지가
+ * 전부 남아야 한다**(사용자 지시) — 통과한 축의 답변도 그 학생이 실제로 쓴 것이고,
+ * 그것까지 봐야 "어디까지는 했다"가 눈으로 확인된다.
+ *
+ * 축 순서대로, 축 안에서는 시도 순서대로 편다. 힌트를 받고 다시 답한 것은 `L3 힌트 1`
+ * 처럼 그 사실이 라벨에 남는다.
+ */
+function turnsOf(problemIdx: number, results: AxisResult[], labelPrefix: string): QaEntry[] | null {
   const stages = PROBLEMS[problemIdx].stages
   const problemNo = PROBLEMS[problemIdx].problemNo
-  const entries: QaEntry[] = []
 
-  results.forEach((r, axisIdx) => {
-    r.scores.forEach((score, attempt) => {
-      entries.push({
-        // 힌트 뒤의 답변은 **다른 질문이 아니다** — 같은 질문을 다시 설명한 것이다
-        questionLabel:
-          attempt === 0 ? `질문 ${axisIdx + 1}` : `질문 ${axisIdx + 1} · 다시 설명 ${attempt}`,
-        question: attempt === 0 ? stages[axisIdx].questionText : stages[axisIdx].hints[attempt - 1],
-        answer: answerFor(problemNo, AXES[axisIdx], attempt, score),
-      })
-    })
+  const entries = results.flatMap((r) => {
+    const axisIdx = AXES.indexOf(r.axisCode)
+    return r.scores.map((score, attempt) => ({
+      questionLabel:
+        labelPrefix + (attempt === 0 ? `${r.axisCode} 질문` : `${r.axisCode} 힌트 ${attempt}`),
+      question: attempt === 0 ? stages[axisIdx].questionText : stages[axisIdx].hints[attempt - 1],
+      answer: answerFor(problemNo, r.axisCode, attempt, score),
+    }))
   })
 
   return entries.length > 0 ? entries : null

--- a/src/features/trainee/demo/components/DemoTopBar.tsx
+++ b/src/features/trainee/demo/components/DemoTopBar.tsx
@@ -1,6 +1,8 @@
 import { formatClock } from '@/lib/format'
 
 type Props = {
+  /** `REVIEW`면 「기록에만 남아요」 배지가 붙는다 — 실제 화면과 같다 */
+  mode?: 'FIRST' | 'REVIEW'
   problemNo: number
   problemTotal: number
   title?: string
@@ -21,6 +23,7 @@ type Props = {
   괜찮은 이유는 이 폴더가 **시연이 끝나면 지울 것**이기 때문이다.
 */
 export default function DemoTopBar({
+  mode = 'FIRST',
   problemNo,
   problemTotal,
   title,
@@ -52,6 +55,11 @@ export default function DemoTopBar({
             />
           ))}
         </span>
+        {mode === 'REVIEW' && (
+          <span className="rounded-full bg-info-soft px-2 py-0.5 text-xs font-medium text-info">
+            기록에만 남아요
+          </span>
+        )}
       </div>
       <span className="flex items-baseline gap-3 text-sm text-fg-subtle">
         {ended ? (

--- a/src/features/trainee/demo/components/ScoreBar.tsx
+++ b/src/features/trainee/demo/components/ScoreBar.tsx
@@ -1,3 +1,4 @@
+import { LightbulbIcon } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
 import { cn } from '@/lib/utils/cn'
 import { AXIS_NAME, PASS_SCORE, RUBRIC, SCORES, type AxisCode, type Score } from '../data/rubric.ts'
@@ -7,6 +8,8 @@ type Props = {
   hintsLeft: number
   onScore: (score: Score) => void
   onTimeOut: () => void
+  /** 학생이 직접 여는 힌트 — 실제 화면의 「다시 설명해 주세요」 */
+  onRequestHint: () => void
 }
 
 /*
@@ -29,7 +32,13 @@ type Props = {
   실제로는 문제당 20분이 지나면 서버가 그 문제를 접는다. 시계로 재현하면 시연 도중
   예상 못 한 순간에 화면이 넘어가므로 **시연자가 원할 때** 누른다.
 */
-export default function ScoreBar({ axisCode, hintsLeft, onScore, onTimeOut }: Props) {
+export default function ScoreBar({
+  axisCode,
+  hintsLeft,
+  onScore,
+  onTimeOut,
+  onRequestHint,
+}: Props) {
   const rubric = RUBRIC[axisCode]
 
   return (
@@ -40,11 +49,9 @@ export default function ScoreBar({ axisCode, hintsLeft, onScore, onTimeOut }: Pr
           <span className="text-fg-muted">{AXIS_NAME[axisCode]}</span> · 채점 결과를 고르면 그대로
           진행됩니다
         </p>
-        {hintsLeft > 0 ? (
-          <span className="text-xs text-fg-subtle">설명 {hintsLeft}번 남음</span>
-        ) : (
+        {hintsLeft === 0 && (
           <span className="text-xs font-medium text-warning">
-            설명을 다 썼어요 · 여기서 또 미달이면 이 문제가 끝납니다
+            더 이상 설명해 드릴 수 없어요 · 여기서 또 미달이면 이 문제가 끝납니다
           </span>
         )}
       </div>
@@ -81,13 +88,32 @@ export default function ScoreBar({ axisCode, hintsLeft, onScore, onTimeOut }: Pr
         })}
       </div>
 
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <p className="text-[11px] text-fg-subtle">
-          {PASS_SCORE}점 이상이면 다음 질문으로 · 미만이면 같은 질문을 다시 설명해 줍니다
-        </p>
-        <Button type="button" variant="ghost" size="sm" onClick={onTimeOut}>
-          시간 초과시키기
-        </Button>
+      {/*
+        아래 줄은 **실제 세션의 `ComposeBar`와 같은 구성**이다 — 왼쪽에 힌트, 오른쪽에
+        진행 조작. 종전에는 힌트 버튼이 맨 위 우측 구석에 작게 있어 시연 중에 눈에
+        안 띄었다(실사용 피드백). 학생이 스스로 힌트를 여는 길이 제품에 있다는 것이
+        시연에서 설명해야 할 대목이라, 실제 화면과 같은 자리로 내렸다.
+      */}
+      <div className="flex flex-wrap items-center justify-between gap-2 border-t border-border pt-3">
+        <div className="flex flex-wrap items-center gap-2">
+          {hintsLeft > 0 ? (
+            <>
+              <Button type="button" variant="ghost" size="sm" onClick={onRequestHint}>
+                <LightbulbIcon className="size-3.5" />
+                다시 설명해 주세요
+              </Button>
+              <span className="text-xs text-fg-subtle">{hintsLeft}번 남음</span>
+            </>
+          ) : (
+            <p className="text-xs text-fg-subtle">더 이상 설명해 드릴 수 없어요</p>
+          )}
+        </div>
+        <div className="flex items-center gap-3">
+          <p className="text-[11px] text-fg-subtle">{PASS_SCORE}점 이상이면 다음 질문으로</p>
+          <Button type="button" variant="ghost" size="sm" onClick={onTimeOut}>
+            시간 초과시키기
+          </Button>
+        </div>
       </div>
     </div>
   )

--- a/src/features/trainee/demo/engine.ts
+++ b/src/features/trainee/demo/engine.ts
@@ -5,6 +5,7 @@
   이미 켜져 있고 Vite도 그대로 푼다.
 */
 import type { CurrentQuestion, ProblemView, Turn } from '../session/_/api/types'
+import type { SessionMode } from '../session/types'
 import { PROBLEMS } from './data/fixture.ts'
 import { answerFor, evidenceFor } from './data/answers.ts'
 import { PASS_SCORE, type AxisCode, type Score } from './data/rubric.ts'
@@ -54,6 +55,16 @@ export type CloseReason = 'ALL_AXES' | 'HINTS_EXHAUSTED' | 'PROBLEM_TIME_LIMIT' 
 
 export type DemoState = {
   phase: Phase
+  /*
+    `FIRST` 1차 응시 · `REVIEW` 다시 보기.
+
+    **다시 보기는 한 문제만 다시 연다.** 리포트에서 2단 미만인 개념에만 버튼이 붙고,
+    그 문제 하나로 세션이 구성된다 — 통과한 개념까지 다시 물으면 「다시 보기」가 아니라
+    재응시가 된다.
+  */
+  mode: SessionMode
+  /** `REVIEW`가 보고 있는 문제 번호. `FIRST`면 `null` */
+  reviewProblemNo: number | null
   /** 0-based. 화면에 그릴 때는 `+1` */
   problemIdx: number
   /** 0-based (L1=0 … L4=3) */
@@ -63,6 +74,14 @@ export type DemoState = {
   turns: Turn[]
   /** 12칸 누적. 문제 순 → 축 순 */
   results: AxisResult[]
+  /*
+    다시 보기 결과 — **`results`를 덮지 않는다.**
+
+    도달 단계의 정본은 1차 응시다(`ConceptCard`가 배지를 그 값으로 그린다). 다시 봐서
+    올라간 것은 그 아래 한 줄로만 말한다(`comparedReach`). 덮어쓰면 "원래 몇 단이었나"가
+    사라져 성장이 안 보인다.
+  */
+  reviewResults: AxisResult[]
   closeReasons: CloseReason[]
   transitionReason: 'NEXT' | 'STOP' | null
   endReason: 'COMPLETED' | 'TIMEOUT' | null
@@ -79,23 +98,29 @@ export const PROBLEM_TOTAL = PROBLEMS.length
 */
 const ANSWERED_AT = '2026-08-25T10:00:00+09:00'
 
+const blankResults = (): AxisResult[] =>
+  PROBLEMS.flatMap((p) =>
+    AXES.map((axisCode) => ({
+      problemNo: p.problemNo,
+      axisCode,
+      status: 'NOT_REACHED' as AxisStatus,
+      scores: [],
+      finalScore: null,
+      evidence: null,
+    })),
+  )
+
 export function initialState(): DemoState {
   return {
     phase: 'INTRO',
+    mode: 'FIRST',
+    reviewProblemNo: null,
     problemIdx: 0,
     axisIdx: 0,
     hintsUsed: 0,
     turns: [],
-    results: PROBLEMS.flatMap((p) =>
-      AXES.map((axisCode) => ({
-        problemNo: p.problemNo,
-        axisCode,
-        status: 'NOT_REACHED' as AxisStatus,
-        scores: [],
-        finalScore: null,
-        evidence: null,
-      })),
-    ),
+    results: blankResults(),
+    reviewResults: blankResults(),
     closeReasons: PROBLEMS.map(() => null),
     transitionReason: null,
     endReason: null,
@@ -108,8 +133,12 @@ export type DemoAction =
   | { type: 'ANSWER'; score: Score }
   /** 시연자가 「시간 초과」를 눌렀다 */
   | { type: 'TIME_OUT' }
+  /** 학생이 「다시 설명해 주세요」를 눌렀다 — 점수와 무관하게 직접 여는 힌트 */
+  | { type: 'OPEN_HINT' }
   /** 전환 화면의 「계속하기」 */
   | { type: 'CONTINUE' }
+  /** 리포트에서 「다시 보기」를 눌렀다 — 그 개념 하나만 다시 연다 */
+  | { type: 'START_REVIEW'; problemNo: number }
   | { type: 'RESET' }
 
 export function reduce(s: DemoState, a: DemoAction): DemoState {
@@ -120,6 +149,31 @@ export function reduce(s: DemoState, a: DemoAction): DemoState {
     case 'RESET':
       return initialState()
 
+    /*
+      다시 보기 — **그 문제 하나로 세션을 다시 연다.**
+
+      1차 결과(`results`·`closeReasons`)는 그대로 두고 `reviewResults`만 비운다. 도달
+      단계의 정본은 1차이고, 다시 봐서 올라간 것은 리포트가 `comparedReach`로 곁들여
+      말한다(실제 제품과 같은 규칙 — `ConceptCard` 주석).
+    */
+    case 'START_REVIEW': {
+      const idx = PROBLEMS.findIndex((p) => p.problemNo === a.problemNo)
+      if (idx < 0) return s
+      return {
+        ...s,
+        phase: 'IN_PROBLEM',
+        mode: 'REVIEW',
+        reviewProblemNo: a.problemNo,
+        problemIdx: idx,
+        axisIdx: 0,
+        hintsUsed: 0,
+        turns: [],
+        reviewResults: blankResults(),
+        transitionReason: null,
+        endReason: null,
+      }
+    }
+
     case 'CONTINUE':
       // 전환 화면에서만 유효하다. 다음 문제는 이미 `problemIdx`가 가리키고 있다
       return s.phase === 'TRANSITION' ? { ...s, phase: 'IN_PROBLEM', transitionReason: null } : s
@@ -129,6 +183,20 @@ export function reduce(s: DemoState, a: DemoAction): DemoState {
 
     case 'TIME_OUT':
       return s.phase === 'IN_PROBLEM' ? closeProblem(s, 'PROBLEM_TIME_LIMIT') : s
+
+    /*
+      학생이 직접 여는 힌트 — **점수를 매기지 않고 힌트만 하나 연다.**
+
+      미달로 자동으로 열리는 것과 같은 자원을 쓴다(축당 2개). 실제 서버도 요청분과
+      지급분을 합쳐 세므로(`hintsLeft` 주석) 여기서도 한 칸으로 둔다.
+
+      다 썼으면 아무 일도 안 한다 — 실제 화면은 그때 버튼을 문구로 바꾸므로 누를 수
+      없지만, 상태 쪽에서도 막아 두어야 규칙이 한 곳에 있다.
+    */
+    case 'OPEN_HINT':
+      return s.phase === 'IN_PROBLEM' && s.hintsUsed < MAX_HINTS
+        ? { ...s, hintsUsed: s.hintsUsed + 1 }
+        : s
   }
 }
 
@@ -152,18 +220,22 @@ function answer(s: DemoState, score: Score): DemoState {
     highlight: highlightOf(s.problemIdx, s.axisIdx),
   }
 
-  const results = s.results.map((r) =>
-    r.problemNo === problem.problemNo && r.axisCode === axisCode
-      ? {
-          ...r,
-          scores: [...r.scores, score],
-          finalScore: score,
-          evidence: evidenceFor(problem.problemNo, axisCode, s.hintsUsed, score) ?? r.evidence,
-        }
-      : r,
-  )
+  const record = (list: AxisResult[]) =>
+    list.map((r) =>
+      r.problemNo === problem.problemNo && r.axisCode === axisCode
+        ? {
+            ...r,
+            scores: [...r.scores, score],
+            finalScore: score,
+            evidence: evidenceFor(problem.problemNo, axisCode, s.hintsUsed, score) ?? r.evidence,
+          }
+        : r,
+    )
 
-  const next = { ...s, turns: [...s.turns, turn], results }
+  const next: DemoState =
+    s.mode === 'REVIEW'
+      ? { ...s, turns: [...s.turns, turn], reviewResults: record(s.reviewResults) }
+      : { ...s, turns: [...s.turns, turn], results: record(s.results) }
 
   // 통과 — 다음 축으로. L4였으면 이 문제는 물어볼 것이 없다
   if (score >= PASS_SCORE) {
@@ -189,6 +261,14 @@ function answer(s: DemoState, score: Score): DemoState {
  * 못한 것"이 갈려 있어야** 리포트에서 도달 단계를 셀 수 있다.
  */
 function closeProblem(s: DemoState, reason: NonNullable<CloseReason>): DemoState {
+  /*
+    **다시 보기는 한 문제뿐이라 그 문제가 닫히면 곧 끝이다.** 1차의 종료 사유
+    (`closeReasons`)도 건드리지 않는다 — 그건 1차가 왜 끝났는지의 기록이다.
+  */
+  if (s.mode === 'REVIEW') {
+    return { ...s, phase: 'ENDED', endReason: 'COMPLETED', transitionReason: null }
+  }
+
   const closeReasons = s.closeReasons.map((r, i) => (i === s.problemIdx ? reason : r))
   const isLast = s.problemIdx === PROBLEMS.length - 1
 
@@ -214,12 +294,13 @@ const setStatus = (
   problemNo: number,
   axisCode: AxisCode,
   status: AxisStatus,
-): DemoState => ({
-  ...s,
-  results: s.results.map((r) =>
-    r.problemNo === problemNo && r.axisCode === axisCode ? { ...r, status } : r,
-  ),
-})
+): DemoState => {
+  const mark = (list: AxisResult[]) =>
+    list.map((r) => (r.problemNo === problemNo && r.axisCode === axisCode ? { ...r, status } : r))
+  return s.mode === 'REVIEW'
+    ? { ...s, reviewResults: mark(s.reviewResults) }
+    : { ...s, results: mark(s.results) }
+}
 
 /*
   질문이 가리키는 코드 구간. 분석 결과가 축마다 `QUESTION_HIGHLIGHT`를 하나씩 준다 —
@@ -248,9 +329,16 @@ function highlightOf(problemIdx: number, axisIdx: number) {
  */
 export function currentProblem(s: DemoState): ProblemView {
   const p = PROBLEMS[s.problemIdx]
+  /*
+    **다시 보기는 문제가 하나뿐이라 `1 / 1`이다.**
+
+    전체 번호를 그대로 쓰면 상단이 `2 / 3`으로 나와 나머지 둘도 다시 푸는 것처럼
+    읽힌다 — 다시 보기는 그 개념 하나만 여는 자리다(실사용 피드백).
+  */
+  const review = s.mode === 'REVIEW'
   return {
-    problemNo: p.problemNo,
-    problemTotal: PROBLEM_TOTAL,
+    problemNo: review ? 1 : p.problemNo,
+    problemTotal: review ? 1 : PROBLEM_TOTAL,
     title: p.title,
     timeLimitAt: null,
     code: {

--- a/src/features/trainee/report/components/ConceptCard.tsx
+++ b/src/features/trainee/report/components/ConceptCard.tsx
@@ -1,7 +1,6 @@
 import { BookOpenIcon, CircleSlashIcon, LockIcon, LockOpenIcon } from 'lucide-react'
 import { cn } from '@/lib/utils/cn'
 import { REACH_LABEL, UNASKED_BODY, UNASKED_TITLE } from '../labels'
-import { clampLevel } from '../_/api/types'
 import type { ConceptReport, ReachedLevel } from '../_/api/types'
 import QaList from './QaList'
 
@@ -33,6 +32,16 @@ type Props = {
   concept: ConceptReport
   /** 마지막 카드는 선이 다음 카드로 안 이어지니 꼬리를 남기지 않는다 */
   isLast: boolean
+  /**
+   * 카드 맨 아래에 덧붙일 것 — **카드 안에 있어야 하는 것만** 넣는다.
+   *
+   * 밖에서 형제로 그리면 좌측 타임라인 선·핀과 어긋나 레이아웃이 깨진다(실측).
+   * 카드가 자기 `pl-5`·`pb-8` 안에 품어야 선이 그 아래로 이어진다.
+   *
+   * 실제 리포트는 다시 보기를 **리포트 단위 버튼 하나**로 열기 때문에(`PublishedBody`)
+   * 이 자리를 안 쓴다 — 값을 안 넘기면 아무것도 안 그린다.
+   */
+  footer?: React.ReactNode
 }
 
 /*
@@ -45,7 +54,7 @@ type Props = {
   — flex gap은 형제 사이 공간이라 어느 카드도 그 구간의 선을 못 그린다. 마지막
   카드는 다음 핀이 없어 padding도 짧고(pb-3) 선도 그 안에서 멈춘다.
 */
-export default function ConceptCard({ concept, isLast }: Props) {
+export default function ConceptCard({ concept, isLast, footer }: Props) {
   return (
     <div className={cn('relative pl-5', isLast ? 'pb-3' : 'pb-8')}>
       {/* top-[11px] = 핀(top-1.5=6px, size-2.5=10px)의 세로 중심 — 선이 핀 가운데서 뻗어나온다 */}
@@ -67,6 +76,7 @@ export default function ConceptCard({ concept, isLast }: Props) {
       )}
 
       {concept.asked ? <AskedBody concept={concept} /> : <UnaskedBody name={concept.name} />}
+      {footer}
     </div>
   )
 }
@@ -105,7 +115,19 @@ function AskedBody({ concept }: { concept: Extract<ConceptReport, { asked: true 
   return (
     <>
       <div className="mb-2 flex items-baseline justify-between gap-3">
-        <span className="text-lg font-bold text-fg">{concept.name}</span>
+        <span className="flex items-baseline gap-2">
+          <span className="text-lg font-bold text-fg">{concept.name}</span>
+          {/*
+            🔴 **제목 옆에 붙인다.** 배지 아래 별도 줄로 뒀더니 한 줄을 통째로 쓰면서
+            정작 말하는 것은 "다시 봤다" 한 마디였다(실사용 피드백). 개념 이름 옆이
+            그 사실이 붙을 자리다 — 이 개념에 일어난 일이므로.
+          */}
+          {concept.comparedReach && (
+            <span className="shrink-0 rounded-full bg-info-soft px-2 py-0.5 text-2xs font-medium text-info">
+              다시 봄
+            </span>
+          )}
+        </span>
         <div className="flex shrink-0 flex-col items-end gap-1">
           <span
             className={cn(
@@ -115,18 +137,6 @@ function AskedBody({ concept }: { concept: Extract<ConceptReport, { asked: true 
           >
             {REACH_LABEL[concept.reachedLevel]}
           </span>
-          {/*
-            다시 봐서 올라간 단계는 **배지를 덮어쓰지 않는다** — 배지는 정본(첫 응시)이고
-            성적에 반영되는 값이다. 올라간 것은 그 아래 한 줄로만 말한다.
-
-            서버는 문답을 두 벌로 주지 않고 전후 단계(`comparedReach`)만 준다 — 올라간
-            경우에만 말하면 되므로 그것으로 충분하다.
-          */}
-          {concept.comparedReach && concept.comparedReach.after > concept.reachedLevel && (
-            <span className="text-2xs text-fg-subtle">
-              다시 봤을 때 {REACH_LABEL[clampLevel(concept.comparedReach.after)]}
-            </span>
-          )}
         </div>
       </div>
 
@@ -154,7 +164,17 @@ function AskedBody({ concept }: { concept: Extract<ConceptReport, { asked: true 
         </div>
       ) : (
         concept.isRetryTarget && (
-          <div className="mt-3 flex items-center gap-2 rounded-md border border-border bg-surface-2 px-3 py-2.5 text-sm text-fg-muted">
+          /*
+            🔴 **잠금 안내는 눈에 띄어야 한다.**
+
+            연한 회색(`surface-2` + `fg-muted`)으로 뒀더니 카드 안에서 **가장 안 보이는
+            줄**이 됐다(실사용 피드백). 그런데 이 줄은 "여기 볼 것이 더 있고, 다시 보면
+            열린다"는 **행동을 부르는 안내**다 — 안 보이면 학생이 다시 보기를 안 한다.
+
+            바로 아래 「다시 보기」 버튼과 같은 warning 톤으로 묶는다. 열렸을 때의
+            primary(파랑)와도 색으로 갈려서, 잠김/열림이 한눈에 구분된다.
+          */
+          <div className="mt-3 flex items-center gap-2 rounded-md border border-warning-border bg-warning-soft px-3 py-2.5 text-sm font-medium text-warning">
             <LockIcon className="size-4 shrink-0" />
             다시 보기를 마치면 자세한 해설과 문답을 볼 수 있어요
           </div>

--- a/src/features/trainee/report/components/QaList.tsx
+++ b/src/features/trainee/report/components/QaList.tsx
@@ -17,11 +17,42 @@ import type { QaEntry } from '../_/api/types'
   전후 도달 단계(`comparedReach`)로 오고 카드 배지 옆에서 말한다. 질문과 힌트가 같은
   배열에 섞여 오고 `questionLabel`이 어느 쪽인지 알려준다(`L3 질문` · `L3 힌트 1`).
 */
+/** 다시 본 문답은 라벨에 접두어가 붙어 온다 — `다시 보기 · L1 질문` */
+const REVIEW_PREFIX = '다시 보기 · '
+
 export default function QaList({ entries }: { entries: QaEntry[] }) {
+  /*
+    🔴 **1차와 다시 보기를 한 목록에 쌓지 않는다.**
+
+    한때 다시 본 문답을 뒤에 이어 붙이고 라벨 접두어로만 갈랐는데, 펼치면 같은 축의
+    질문이 두 번씩 나오면서 **어디까지가 1차인지 경계가 안 보였다**(실사용 피드백).
+    응시 자체가 두 번이므로 목록도 둘이어야 한다 — 각자 접고 펼친다.
+  */
+  const first = entries.filter((e) => !e.questionLabel.startsWith(REVIEW_PREFIX))
+  const again = entries.filter((e) => e.questionLabel.startsWith(REVIEW_PREFIX))
+
+  return (
+    <div className="mt-3 flex flex-col gap-2 border-t border-border pt-2">
+      {first.length > 0 && <QaGroup label="내 답변" entries={first} />}
+      {again.length > 0 && <QaGroup label="다시 보기 답변" entries={again} tone="info" />}
+    </div>
+  )
+}
+
+function QaGroup({
+  label,
+  entries,
+  tone = 'default',
+}: {
+  label: string
+  entries: QaEntry[]
+  /** 다시 보기 묶음은 파란 테두리로 갈라 둔다 — 같은 회색이면 형제로 보인다 */
+  tone?: 'default' | 'info'
+}) {
   const [open, setOpen] = useState(false)
 
   return (
-    <div className="mt-3 border-t border-border pt-2">
+    <div>
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
@@ -30,26 +61,39 @@ export default function QaList({ entries }: { entries: QaEntry[] }) {
           **누르는 것**이라 흰 면 + 테두리로 둔다. 위의 교안 알약(info 톤)과 색으로도
           형태로도 갈린다 — 예전엔 둘 다 회색 면이라 형제처럼 보였다(실사용 피드백).
         */
-        className="flex w-full items-center gap-2 rounded-md border border-border bg-surface px-3 py-2 text-sm text-fg-muted transition-colors hover:border-border-strong hover:bg-surface-2 hover:text-fg"
+        className={cn(
+          'flex w-full items-center gap-2 rounded-md border bg-surface px-3 py-2 text-sm transition-colors hover:bg-surface-2 hover:text-fg',
+          tone === 'info'
+            ? 'border-info-border text-info hover:border-info'
+            : 'border-border text-fg-muted hover:border-border-strong',
+        )}
       >
         <ChevronRightIcon
           aria-hidden="true"
           className={cn('size-3.5 shrink-0 transition-transform', open && 'rotate-90')}
         />
         <span className="flex-1 text-left">
-          내 답변 <span className="text-fg-subtle">{entries.length}개</span>
+          {label} <span className="text-fg-subtle">{entries.length}개</span>
         </span>
         <span className="text-xs">{open ? '접기' : '펼치기'}</span>
       </button>
       {open && (
-        <div className="mt-2 flex flex-col gap-3">
+        <div className="mt-2 flex flex-col gap-2">
           {entries.map((row, i) => (
-            <div key={i} className="flex flex-col gap-2 rounded-md bg-surface-2 p-3">
-              <p className="text-xs text-fg-subtle">
-                <span className="font-medium">{row.questionLabel}</span> {row.question}
-              </p>
-              <div>
-                <div className="mb-0.5 text-xs font-semibold text-fg-subtle">내 답변</div>
+            <div key={i} className="overflow-hidden rounded-md border border-border">
+              <div className="bg-surface px-3 py-2.5">
+                <div className="mb-1 text-xs font-bold text-primary">
+                  {row.questionLabel.replace(REVIEW_PREFIX, '')}
+                </div>
+                <p className="text-sm leading-relaxed text-fg-muted">{row.question}</p>
+              </div>
+              {/*
+                답변은 **회색 면**이다. 한때 `primary-soft`(파랑)로 뒀는데 카드 위쪽
+                「어디서 막혔나」 해설 박스가 이미 그 색이라 둘이 형제로 보였다
+                (실사용 피드백: *"배경색 같아서 헷갈린다"*). 질문(흰 면)과는 명도로 갈린다.
+              */}
+              <div className="border-t border-border bg-surface-2 px-3 py-2.5">
+                <div className="mb-1 text-xs font-medium text-fg-subtle">내 답변</div>
                 <p className="text-sm leading-relaxed text-fg">{row.answer}</p>
               </div>
             </div>

--- a/src/shells/Header.tsx
+++ b/src/shells/Header.tsx
@@ -21,25 +21,46 @@ import {
 } from '@/components/ui/Select'
 import Wordmark from '@/components/common/Wordmark'
 import { initialScreenFor } from '@/features/auth/authStore'
+import { useQueryClient } from '@tanstack/react-query'
 import { useSignIn, useSignOut } from '@/features/auth/useSession'
 import { login } from '@/api/auth/authApi'
-import { QUICK_LOGIN_ACCOUNTS } from '@/features/auth/quickLoginAccounts'
+import { HEADER_ACCOUNTS, QUICK_LOGIN_ACCOUNTS } from '@/features/auth/quickLoginAccounts'
 
 // dev 전용 역할 전환(헤더) — import.meta.env.DEV는 프로덕션 빌드(vite build)에서
 // 항상 false라 develop Vercel 프리뷰 배포도 걸러진다. __GIT_BRANCH__(vite.config.ts
 // define, sidebarConfig.ts와 같은 패턴)로 "로컬이거나 develop 배포"일 때만 보이고
 // main 배포에서는 숨긴다.
+/*
+  헤더는 **누구로 갈아탈지**를 고르는 자리라 목록이 로그인 화면과 다르다
+  (`HEADER_ACCOUNTS` 주석). 전용 값이 없으면 종전처럼 역할 계정으로 물러선다.
+*/
+const SWITCHER_ACCOUNTS = HEADER_ACCOUNTS.length > 0 ? HEADER_ACCOUNTS : QUICK_LOGIN_ACCOUNTS
+
 // 계정이 없으면(.env.local 미설정) 드롭다운을 열어도 항목이 없다 — 아예 안 그린다
 const SHOW_DEV_ROLE_SWITCHER =
-  (import.meta.env.DEV || __GIT_BRANCH__ === 'develop') && QUICK_LOGIN_ACCOUNTS.length > 0
+  (import.meta.env.DEV || __GIT_BRANCH__ === 'develop') && SWITCHER_ACCOUNTS.length > 0
 
 function DevRoleSwitcher() {
   const navigate = useNavigate()
   const signIn = useSignIn()
+  const queryClient = useQueryClient()
 
   async function handleQuickLogin(email: string, password: string) {
     try {
       const res = await login({ body: { email, password } })
+      /*
+        🔴 **앞사람 캐시를 버린다.**
+
+        토큰은 `signIn`이 덮어쓰므로 꼬이지 않는다. 문제는 react-query 캐시다 —
+        `signIn`은 `memberKeys.all`만 무효화하고, 대시보드·명부·히트맵·리포트는
+        그대로 남는다. 그러면 **다음 사람이 앞사람의 데이터를 잠깐 본다**
+        (`useSignOut`이 `clear()`를 부르는 것과 같은 이유이고, 그 주석이 이미
+        같은 말을 하고 있다).
+
+        로그아웃을 먼저 부르지 않는 이유는 그 사이에 쿠키가 사라져 **무인증 구간**이
+        생기기 때문이다. 새 토큰을 받은 뒤 캐시만 비우면 그 구간이 없다.
+      */
+      queryClient.clear()
       await signIn(res)
       navigate(initialScreenFor(res.role))
     } catch (err) {
@@ -57,10 +78,14 @@ function DevRoleSwitcher() {
           </Button>
         }
       />
-      <DropdownMenuContent align="end">
+      {/*
+        라벨이 `매니저 · 이도윤 (D반)`처럼 길어져 기본 폭에서 줄바꿈됐다 — 항목 하나가
+        두 줄이 되면 훑는 눈이 멈춘다. 한 줄에 들어갈 만큼만 넓힌다.
+      */}
+      <DropdownMenuContent align="end" className="min-w-52">
         <DropdownMenuGroup>
           <DropdownMenuLabel>역할 전환 (dev)</DropdownMenuLabel>
-          {QUICK_LOGIN_ACCOUNTS.map(({ label, email, password }) => (
+          {SWITCHER_ACCOUNTS.map(({ label, email, password }) => (
             <DropdownMenuItem
               key={email}
               className="cursor-pointer"


### PR DESCRIPTION
## 작업 내용

[#352](https://github.com/Team-IZ/Frontend/pull/352) 이후 시연 준비에서 나온 수정 묶음이다. 데모 플로우 자체는 그 PR에 있고, 여기는 **실제로 돌려 보며 드러난 것들**이다.

### 데모 밖 — 실제 제품 동작이 바뀐다

| 커밋 | 무엇 |
|---|---|
| `fix: open interviews at the last graded round` | 면담 목록이 언제나 빈 목록이던 것 |
| `fix: clear query cache when switching role` | 역할 전환에 앞사람 캐시가 남던 것 |
| `refactor: rework dev account picker for demo day` | dev 계정 고르개 — 수백 명이 동시에 여는 자리가 됐다 |
| `style: improve report qa list readability` | 리포트 문답 목록 |
| `docs: state operator as IZ in privacy policy` | 운영 주체 표기 |

### 데모 — 다시 보기와 힌트

- **다시 보기**(REVIEW): 도달 2단 미만 개념에만 버튼이 붙고 그 개념 하나만 다시 열린다(`1 / 1`). 1차 판정은 그대로 두고 **잠겨 있던 해설·문답이 열린다**. 개념마다 한 번씩이다
- 학생이 직접 여는 **힌트 버튼**(실제 `ComposeBar`와 같은 자리), 창 이탈 **토스트**
- 리포트 진단문을 실제 응답 형식에 맞춰 다시 썼다

## 리뷰 포인트

**① 면담이 언제나 빈 목록이었다.** 종전에는 회차를 안 보내고 서버가 「이번 회차」를 고르게 했는데(32차 R2), 이번 회차는 **아직 진행 중이라 위험 판정 자체가 없다** — 면담 케이스는 결과가 나와야 생긴다. 7기 실측: 미프 4차(`OPEN`) 0건 · 미프 3차(`CLOSED`) 20건, 전 매니저 동일. 그래서 **판정이 나온 가장 최근 회차**를 연다.

비용은 첫 진입 +200ms(회차 목록을 기다린다). 사용자가 고른 회차가 있으면 안 기다린다. 이 판정을 화면이 갖는 것은 빚이고, 서버가 알려주게 되면 지운다 — 주석에 적어 뒀다.

**② 역할 전환에 앞사람 캐시가 남았다.** 토큰은 `signIn`이 덮어써 안 꼬이는데, `signIn`은 `memberKeys.all`만 무효화하고 대시보드·명부·히트맵은 그대로 남는다. `useSignOut`이 `clear()`를 부르는 이유와 같은 문제라(그 주석이 이미 같은 말을 한다) 새 토큰을 받은 뒤 캐시만 비운다. 로그아웃을 먼저 부르지 않는 것은 그 사이에 **무인증 구간**이 생기기 때문이다.

**③ 고르개에서 카드가 쌓이는 버그가 있었다.** 매니저 셋이 두 반을 겸해(박지현 A·F · 이도윤 B·D · 강민서 E·G) 같은 이메일이 두 그룹에 온다 — 270행인데 사람은 267명. `key`가 겹쳐 React가 경고를 던지고 탭을 오갈 때마다 카드가 **세 개씩 쌓였다**(실측: 10 → 28 → 31 → 34). 이메일로 합치고 담당 반을 배열로 모았다.

**④ 로그인 화면의 역할 버튼 넷을 뺐다.** 역할당 계정이 하나뿐이라 수백 명이 동시에 여는 자리에서 **전원이 같은 계정으로 들어간다.** 대신 역할 탭 → 이름 격자로 자기 계정을 고른다. 매니저는 대시보드·히트맵에 실제로 데이터가 차는 순서로 세운다(두 API 응답을 재서 넣었다 — 응시 인원 순으로 세웠다가 히트맵이 빈 매니저가 1등이 되어 고쳤다).

**⑤ 리포트를 실제 응답에 맞췄다.** 실제 교육생 계정(`GET /reports`)을 받아 대조하니 `said`는 **한 문장 정형문**이고, 상세 진단은 `explain`의 몫이었다. `qa`는 막힌 축만 온다. 데모는 시연 특성상 답한 것을 전부 남기되 형식(`L3 질문`·`L3 힌트 1`)은 실제를 따른다.

**⑥ `.ts` 확장자를 붙인 import가 있다**(`demo/engine.ts`·`demo/data/*`). 이 파일들은 브라우저 밖에서도 실행된다(`node --test scripts/check-demo-engine.mts`) — node ESM은 확장자가 없으면 못 찾는다. `allowImportingTsExtensions`가 이미 켜져 있다.

**⑦ 데모 라우트에 `RequireRole`을 안 둘렀다.** 이 화면이 존재하는 이유가 "서버가 죽었을 때"라 로그인 API에 기대면 대역이 되지 않는다.

## 확인

- [x] 로컬에서 동작 확인
- [x] 하나의 PR = 하나의 기능

서버를 끈 채 `/demo` → `/demo/session` → `/demo/report`를 끝까지 돌렸고, 세 가지 종료 경로(전부 통과 · 힌트 소진 · 시간 초과)와 다시 보기 전후를 브라우저로 확인했다. 면담 3차 20건·역할 전환 캐시 정리·고르개 탭 6바퀴 무누적도 실측했다.

`node --experimental-strip-types --test scripts/check-demo-engine.mts` — 35/35 통과. `npm run typecheck` · `npm run lint` · `npm run build` 통과.

참고 #351 · 앞 PR #352
