### PR TITLE
[Fix] Raise Session Toast Above the Resize Handle

### DIFF
--- a/src/features/trainee/session/components/AwayToast.tsx
+++ b/src/features/trainee/session/components/AwayToast.tsx
@@ -14,8 +14,18 @@ import StatusMessageCard from '@/components/common/StatusMessageCard'
   한다. 사라질 때도 즉시 언마운트하면 뚝 끊겨 보여, leaving 동안 opacity를 0으로
   트랜지션한 뒤(useSessionEffects.ts의 TOAST_FADE_MS만큼 더 붙어 있다가) 사라진다.
 */
+/*
+  🔴 **`z-50`이 없으면 리사이즈 손잡이에 가린다.**
+
+  코드 패널과 대화 패널 사이 손잡이의 thumb이 `z-10`이다(`ui/Resizable.tsx`). 토스트는
+  화면 한가운데 뜨는데 그 손잡이가 세로로 가로지르므로 정확히 겹치고, 쌓임 순서가
+  없으면 **나중에 그려진 손잡이가 위로 온다**(실사용 피드백으로 발견).
+
+  **언제나 최상단이다.** 이 화면에서 토스트보다 위에 와야 하는 것은 없으므로 다른 층과
+  경쟁하지 않게 넉넉히 올려 둔다 — 나중에 무엇이 추가돼도 이 판단이 안 흔들린다.
+*/
 const TOAST_POSITION =
-  'pointer-events-none absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-[45%]'
+  'pointer-events-none absolute top-1/2 left-1/2 z-[1000] -translate-x-1/2 -translate-y-[45%]'
 const TOAST_BODY =
   'rounded-full bg-code px-4 py-2.5 text-sm text-code-fg shadow-card transition-opacity duration-300'
 
@@ -43,7 +53,8 @@ export function TimeWarningToast({ leaving }: { leaving: boolean }) {
 /** 네트워크 끊김 — 뒤 화면은 그대로 두고 오버레이만(H+ "오버레이는 진행이 막혔을 때") */
 export function OfflineOverlay({ onDismiss }: { onDismiss: () => void }) {
   return (
-    <div className="absolute inset-0 flex items-center justify-center bg-fg/55 p-6">
+    // 손잡이(z-10)보다 위 — 진행을 막는 오버레이가 그 아래 깔리면 안 된다
+    <div className="absolute inset-0 z-[1000] flex items-center justify-center bg-fg/55 p-6">
       {/* 오버레이는 목업에서 border-color:transparent만 다르고 나머지 카드 모양은 같다 */}
       <Card className="mx-auto w-full max-w-[460px] gap-0 border-transparent p-6 shadow-card">
         <StatusMessageCard


### PR DESCRIPTION
## 작업 내용

세션 화면에서 **창 이탈 토스트가 리사이즈 손잡이에 가리던 것**을 고쳤다.

코드 패널과 대화 패널 사이 손잡이의 thumb이 `z-10`인데(`ui/Resizable.tsx`), 토스트는 화면 한가운데 뜨고 그 손잡이가 세로로 정확히 가로지른다. 토스트에 쌓임 순서가 없어서 **나중에 그려진 손잡이가 위로 왔다**(실사용 피드백).

토스트(`AwayToast`·`TimeWarningToast`)와 오프라인 오버레이(`OfflineOverlay`)를 `z-[1000]`으로 올렸다.

## 리뷰 포인트

**`z-50`이 아니라 `z-[1000]`인 이유** — 이 화면에서 토스트보다 위에 와야 하는 것은 없다. 값 자체에 의미가 있는 것이 아니라 **"다른 층과 경쟁하지 않는다"는 뜻**이라, 나중에 무엇이 추가돼도 이 판단이 안 흔들리게 넉넉히 올렸다. 주석에 그렇게 적어 뒀다.

**손잡이의 `z-10`은 안 건드렸다** — 그 값은 패널 경계에서 자기 몫이 있고, 낮추면 리사이즈를 쓰는 다른 화면이 영향을 받는다. 위로 올려야 하는 쪽은 토스트다.

## 확인

- [x] 로컬에서 동작 확인
- [x] 하나의 PR = 하나의 기능

`npm run typecheck` · `npm run lint` · `npm run build` 통과. 데모 엔진 검사 35/35.

closes #351
