### PR TITLE
[Style] Surface Unbriefed Interview Cases First

### DIFF
--- a/src/features/manager/interviews/InterviewListScreen.tsx
+++ b/src/features/manager/interviews/InterviewListScreen.tsx
@@ -88,6 +88,26 @@ const shortDate = (iso: string | null) => (iso ? `${iso.slice(5, 7)}.${iso.slice
  */
 const NO_VERDICT_YET = ['OPEN', 'PLANNED']
 
+/** 브리프를 아직 안 만든 케이스 — 이 목록에서 할 일이 남은 쪽이다 */
+const needsBriefCase = (c: InterviewCase) => c.briefState === 'NONE' || c.briefState === 'FAILED'
+
+/**
+ * **할 일이 남은 케이스를 위로 올린다.**
+ *
+ * 🔴 정렬은 원래 서버 것이다(스펙: *"정렬은 서버가 정하며 클라이언트가 바꿀 수 없다"*).
+ * 그런데 서버 순서는 **반 → 이름**이라 브리프를 만든 것과 안 만든 것이 뒤섞여 나오고,
+ * 매니저가 이 목록에서 하는 일이 「만들 것 찾기」인데 스무 줄을 훑어야 했다(사용자 지시).
+ *
+ * 서버 순서를 **버리지 않는다** — 안정 정렬이라 같은 묶음 안에서는 반·이름 순이 그대로
+ * 유지된다. 위아래로 가르기만 한다.
+ *
+ * ⚠️ 서버가 이 축을 정렬에 넣어 주면 이 함수는 지운다.
+ */
+const briefFirst = (items: InterviewCase[]) => [
+  ...items.filter(needsBriefCase),
+  ...items.filter((c) => !needsBriefCase(c)),
+]
+
 /**
  * 첫 진입에 열 회차 — **판정이 나온 가장 최근 회차.**
  *
@@ -459,7 +479,7 @@ export default function InterviewListScreen() {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {data.items.map((c) => (
+              {briefFirst(data.items).map((c) => (
                 <TableRow
                   key={c.caseId}
                   className={c.status === 'EXCLUDED' ? 'opacity-45' : undefined}
@@ -576,6 +596,8 @@ function RowActions({
   }
 
   // PLANNED
+  const needsBrief = needsBriefCase(c)
+
   return (
     <div className="flex justify-end gap-1.5">
       {c.voidReviewPending && !VOID_REVIEW_OPEN ? (
@@ -586,8 +608,23 @@ function RowActions({
         */
         <span className="text-fg-subtle self-center text-2xs">무효 확인 준비 중</span>
       ) : (
-        <Button variant="primary" size="sm" disabled={pending} onClick={onOpenBrief}>
-          {c.briefState === 'NONE' || c.briefState === 'FAILED' ? '브리프 생성' : '브리프 열기'}
+        /*
+          **생성과 열기는 다른 일이라 다르게 보인다.**
+
+          둘 다 `primary`였는데, 목록을 훑을 때 **아직 안 만든 것과 이미 만든 것이
+          구분되지 않았다**(실사용 피드백). 매니저가 이 목록에서 하는 일은 "만들 것을
+          찾는 것"이라, 만드는 쪽이 눈에 먼저 들어와야 한다.
+
+          생성은 채운 버튼(primary), 열기는 테두리 버튼(ghost) — 색이 아니라 **형태**로
+          갈린다(`Wordmark`·교안 알약에서 쓴 것과 같은 규칙).
+        */
+        <Button
+          variant={needsBrief ? 'primary' : 'ghost'}
+          size="sm"
+          disabled={pending}
+          onClick={onOpenBrief}
+        >
+          {needsBrief ? '브리프 생성' : '브리프 열기'}
         </Button>
       )}
       <Button variant="ghost" size="sm" disabled={pending} onClick={onExclude}>


### PR DESCRIPTION
## 작업 내용

면담 목록에서 **할 일이 남은 케이스가 눈에 안 들어오던 것**을 고쳤다.

**① 브리프 생성과 열기를 다르게 그린다.** 둘 다 `primary`라 목록을 훑을 때 아직 안 만든 것과 이미 만든 것이 구분되지 않았다. 생성은 채운 버튼(primary), 열기는 테두리 버튼(ghost) — 색이 아니라 **형태**로 가른다.

**② 브리프 없는 케이스를 위로 올린다.** 서버 정렬은 반 → 이름이라 브리프 유무가 뒤섞여 나온다(실측: 20건 중 생성 8 · 열기 12가 교차). 매니저가 이 목록에서 하는 일은 「만들 것 찾기」인데 스무 줄을 훑어야 했다.

## 리뷰 포인트

**정렬은 원래 서버 것이다** — 스펙이 *"정렬은 서버가 정하며 클라이언트가 바꿀 수 없다"* 고 못박고 있다. 그래서 **서버 순서를 버리지 않았다**: 안정 정렬이라 같은 묶음(생성 / 열기) 안에서는 반·이름 순이 그대로 유지되고, 위아래로 가르기만 한다. 서버가 이 축을 정렬에 넣어 주면 지울 함수라고 주석에 적어 뒀다.

## 확인

- [x] 로컬에서 동작 확인
- [x] 하나의 PR = 하나의 기능

박지현(A·F반) 계정 · 미프 3차 20건으로 확인했다 — 생성 8건이 위(파랑), 열기 12건이 아래(흰 면), 각 묶음 안에서 반→이름 순 유지. `npm run typecheck` · `npm run lint` · `npm run build` 통과.

---

⚠️ **같이 발견한 서버 버그는 이 PR에 안 들어 있다.** 반 필터에 같은 반이 3번씩 오고(`classId`가 전부 다름), 회차를 바꿔도 목록이 안 갈린다. 프론트에서 합칠 수 없는 건이라 이슈에 실측을 남겼다 — #351 코멘트 참고.

closes #351
