### PR TITLE
[Feat] Add Answer Input to Demo Session

### DIFF
--- a/scripts/check-demo-engine.mts
+++ b/scripts/check-demo-engine.mts
@@ -518,3 +518,15 @@ test('다시 보기 버튼이 붙는 개념 = 2단 미만 (0단·1단 둘 다)',
     [true, true, false],
   )
 })
+
+test('직접 친 답이 있으면 그것이 말풍선에 들어간다', () => {
+  const typed = '제가 쓴 답입니다. setUp이 mock을 만들고 grader에 넘깁니다.'
+  const s = run([{ type: 'ANSWER', score: 2, answerText: typed }], started())
+  assert.equal(s.turns[0].answerText, typed)
+})
+
+test('입력이 비어 있으면 그 자리의 준비된 답변을 쓴다', () => {
+  // 시연자가 매번 타이핑할 수는 없다 — 비워 두면 은행/녹화본이 대신한다
+  const s = run([{ type: 'ANSWER', score: 5, answerText: '   ' }], started())
+  assert.match(s.turns[0].answerText, /@BeforeEach/)
+})

--- a/src/features/trainee/demo/DemoSessionScreen.tsx
+++ b/src/features/trainee/demo/DemoSessionScreen.tsx
@@ -168,7 +168,9 @@ export default function DemoSessionScreen() {
           <ScoreBar
             axisCode={axisCode}
             hintsLeft={problem.current?.hintsLeft ?? 0}
-            onScore={(score: Score) => send({ type: 'ANSWER', score })}
+            onScore={(score: Score, answerText: string) =>
+              send({ type: 'ANSWER', score, answerText })
+            }
             onTimeOut={() => send({ type: 'TIME_OUT' })}
             onRequestHint={() => send({ type: 'OPEN_HINT' })}
           />

--- a/src/features/trainee/demo/components/ScoreBar.tsx
+++ b/src/features/trainee/demo/components/ScoreBar.tsx
@@ -1,12 +1,15 @@
 import { LightbulbIcon } from 'lucide-react'
+import { useState } from 'react'
 import { Button } from '@/components/ui/Button'
+import { Textarea } from '@/components/ui/Textarea'
 import { cn } from '@/lib/utils/cn'
 import { AXIS_NAME, PASS_SCORE, RUBRIC, SCORES, type AxisCode, type Score } from '../data/rubric.ts'
 
 type Props = {
   axisCode: AxisCode
   hintsLeft: number
-  onScore: (score: Score) => void
+  /** 점수와 함께 **직접 친 답**을 넘긴다 — 비어 있으면 그 자리의 준비된 답변이 쓰인다 */
+  onScore: (score: Score, answerText: string) => void
   onTimeOut: () => void
   /** 학생이 직접 여는 힌트 — 실제 화면의 「다시 설명해 주세요」 */
   onRequestHint: () => void
@@ -15,10 +18,24 @@ type Props = {
 /*
   시연자가 채점 결과를 정하는 자리 — 실제 화면의 `ComposeBar`가 있던 곳이다.
 
-  ## 왜 텍스트 입력이 아닌가
+  ## 입력칸이 있고, 점수 버튼이 곧 제출이다
 
-  실제로는 학생이 답을 쓰고 AI가 0~5점을 매긴다. AI가 죽었을 때 대신할 것은
-  **타이핑이 아니라 그 점수**다. 시연자가 답변을 지어내 봐야 채점할 것이 없다.
+  실제로는 학생이 답을 쓰고 AI가 0~5점을 매긴다. AI가 죽었을 때 대신할 것은 **그
+  점수**라, 여기서는 시연자가 고른다. 그래도 **입력칸은 둔다** — 학생이 실제로 답을
+  쓰는 자리라, 없으면 이 화면이 실제와 제일 달라 보인다.
+
+  실제 `ComposeBar`를 그대로 쓰지 못하는 이유는 그 안에 「답변 제출」 버튼이 있어서다.
+  데모에서는 **점수 버튼이 곧 제출**이라 버튼이 둘일 수 없다. 그래서 좋은 부분만
+  가져왔다 — 붙여넣기 막힘 · 글자 수 · 짧은 답변 경고.
+
+  ## 🔴 길이로 점수를 추천하는 것은 **목업 편의다**
+
+  **실제 제품은 길이로 채점하지 않는다.** 오히려 반대다 — `12-scoring-rules.md`가
+  *"장황함 편향은 길이 페널티"* 라고 못박고, 실측에서도 3~5문장이면 판정에 충분했다.
+
+  그런데 시연에서 타이핑을 하는데 아무 일도 안 일어나면 입력칸이 장식이 된다. 그래서
+  **길이에 따라 점수 한 칸을 「추천」으로 표시**한다 — 누르는 것은 여전히 시연자다.
+  화면에도 목업이라고 적어 둔다(아래 안내 줄).
 
   ## 왜 숫자만 두지 않는가
 
@@ -32,6 +49,30 @@ type Props = {
   실제로는 문제당 20분이 지나면 서버가 그 문제를 접는다. 시계로 재현하면 시연 도중
   예상 못 한 순간에 화면이 넘어가므로 **시연자가 원할 때** 누른다.
 */
+/** 실제 `ComposeBar`와 같은 값 — 이보다 짧으면 「지금은 짧아요」가 뜬다 */
+const SHORT_ANSWER_THRESHOLD = 15
+
+/*
+  글자 수 → 추천 점수. **목업 전용 규칙이다**(위 주석).
+
+  경계는 실제 답변 길이에서 가져왔다 — 녹화된 20턴의 통과 답변이 대개 150~400자,
+  미달 답변이 20~80자였다. 그 사이를 여섯 칸으로 나눈다.
+*/
+const SCORE_BY_LENGTH: [number, Score][] = [
+  [0, 0],
+  [15, 1],
+  [45, 2],
+  [90, 3],
+  [160, 4],
+  [260, 5],
+]
+const suggestScore = (len: number): Score | null => {
+  if (len === 0) return null
+  let picked: Score = 0
+  for (const [min, score] of SCORE_BY_LENGTH) if (len >= min) picked = score
+  return picked
+}
+
 export default function ScoreBar({
   axisCode,
   hintsLeft,
@@ -40,9 +81,37 @@ export default function ScoreBar({
   onRequestHint,
 }: Props) {
   const rubric = RUBRIC[axisCode]
+  const [answer, setAnswer] = useState('')
+  const suggested = suggestScore(answer.trim().length)
+  const isShort = answer.length > 0 && answer.length < SHORT_ANSWER_THRESHOLD
+
+  const submit = (score: Score) => {
+    onScore(score, answer)
+    setAnswer('')
+  }
 
   return (
     <div className="flex flex-col gap-3 border-t border-border p-4">
+      {/*
+        실제 화면의 답변칸과 같은 규칙 — 붙여넣기를 막고(직접 쓰게 한다) 글자 수를 센다.
+        비워 두면 그 자리의 준비된 답변이 대신 들어가므로 시연자가 매번 칠 필요는 없다.
+      */}
+      <div>
+        <Textarea
+          value={answer}
+          onChange={(e) => setAnswer(e.target.value)}
+          onPaste={(e) => e.preventDefault()}
+          placeholder="답을 입력해 주세요 (비워 두면 준비된 답변이 들어갑니다)"
+          rows={3}
+        />
+        <div className="mt-1 flex items-center justify-between text-xs text-fg-subtle">
+          <span>{answer.length}자</span>
+          {isShort && (
+            <span className="font-medium text-warning">조금 더 써 볼까요? 지금은 짧아요</span>
+          )}
+        </div>
+      </div>
+
       <div className="flex flex-wrap items-baseline justify-between gap-2">
         <p className="text-xs text-fg-subtle">
           지금 묻는 축 <span className="font-bold text-fg">{axisCode}</span>{' '}
@@ -67,7 +136,7 @@ export default function ScoreBar({
             <button
               key={score}
               type="button"
-              onClick={() => onScore(score)}
+              onClick={() => submit(score)}
               className={cn(
                 'flex flex-col gap-1 rounded-md border p-2.5 text-left transition-colors',
                 'hover:bg-canvas focus-visible:bg-canvas',
@@ -79,8 +148,18 @@ export default function ScoreBar({
                 만드는 것이라 맞는 점수라는 게 없고, 표가 붙으면 그 점수를 눌러야 하는
                 것처럼 읽힌다.
               */}
-              <span className={cn('text-sm font-bold', passes ? 'text-primary' : 'text-fg-muted')}>
-                {score}점
+              <span className="flex items-center gap-1.5">
+                <span
+                  className={cn('text-sm font-bold', passes ? 'text-primary' : 'text-fg-muted')}
+                >
+                  {score}점
+                </span>
+                {/* 길이로 고른 칸 — **목업 편의다**(머리 주석). 누르는 것은 시연자다 */}
+                {suggested === score && (
+                  <span className="rounded-sm bg-info-soft px-1 text-[11px] font-medium text-info">
+                    추천
+                  </span>
+                )}
               </span>
               <span className="text-[11px] leading-snug text-fg-subtle">{rubric[score]}</span>
             </button>
@@ -109,7 +188,12 @@ export default function ScoreBar({
           )}
         </div>
         <div className="flex items-center gap-3">
-          <p className="text-[11px] text-fg-subtle">{PASS_SCORE}점 이상이면 다음 질문으로</p>
+          <p className="text-[11px] text-fg-subtle">
+            {PASS_SCORE}점 이상이면 다음 질문으로 ·{' '}
+            <span className="text-warning">
+              「추천」은 목업이라 글자 수로 고른 것 — 실제 채점은 길이를 보지 않습니다
+            </span>
+          </p>
           <Button type="button" variant="ghost" size="sm" onClick={onTimeOut}>
             시간 초과시키기
           </Button>

--- a/src/features/trainee/demo/engine.ts
+++ b/src/features/trainee/demo/engine.ts
@@ -129,8 +129,14 @@ export function initialState(): DemoState {
 
 export type DemoAction =
   | { type: 'START' }
-  /** 시연자가 점수를 눌렀다 — 이것이 답변 제출이자 채점 결과다 */
-  | { type: 'ANSWER'; score: Score }
+  /**
+   * 시연자가 점수를 눌렀다 — 이것이 답변 제출이자 채점 결과다.
+   *
+   * `answerText`는 **학생이 직접 친 답**이다. 비어 있으면 그 자리의 준비된 답변을
+   * 쓴다(`answers.ts`) — 시연자가 타이핑까지 하고 있을 수는 없으므로 기본은 그쪽이고,
+   * 쳤을 때만 그것이 말풍선에 들어간다.
+   */
+  | { type: 'ANSWER'; score: Score; answerText?: string }
   /** 시연자가 「시간 초과」를 눌렀다 */
   | { type: 'TIME_OUT' }
   /** 학생이 「다시 설명해 주세요」를 눌렀다 — 점수와 무관하게 직접 여는 힌트 */
@@ -179,7 +185,7 @@ export function reduce(s: DemoState, a: DemoAction): DemoState {
       return s.phase === 'TRANSITION' ? { ...s, phase: 'IN_PROBLEM', transitionReason: null } : s
 
     case 'ANSWER':
-      return answer(s, a.score)
+      return answer(s, a.score, a.answerText)
 
     case 'TIME_OUT':
       return s.phase === 'IN_PROBLEM' ? closeProblem(s, 'PROBLEM_TIME_LIMIT') : s
@@ -200,7 +206,7 @@ export function reduce(s: DemoState, a: DemoAction): DemoState {
   }
 }
 
-function answer(s: DemoState, score: Score): DemoState {
+function answer(s: DemoState, score: Score, typed?: string): DemoState {
   if (s.phase !== 'IN_PROBLEM') return s
 
   const problem = PROBLEMS[s.problemIdx]
@@ -215,7 +221,8 @@ function answer(s: DemoState, score: Score): DemoState {
     sequenceNo: s.axisIdx + 1,
     questionText: stage.questionText,
     hintText: s.hintsUsed > 0 ? stage.hints[s.hintsUsed - 1] : null,
-    answerText: answerFor(problem.problemNo, axisCode, s.hintsUsed, score),
+    // 직접 친 답이 있으면 그것이 이긴다 — 없으면 그 자리의 준비된 답변
+    answerText: typed?.trim() || answerFor(problem.problemNo, axisCode, s.hintsUsed, score),
     answeredAt: ANSWERED_AT,
     highlight: highlightOf(s.problemIdx, s.axisIdx),
   }


### PR DESCRIPTION
## 작업 내용

데모 세션에 **답변 입력칸**을 넣었다. 지금까지는 `ScoreBar`가 `ComposeBar` 자리를 통째로 차지해 학생이 답을 쓰는 자리가 아예 없었고, 시연에서 이 화면이 실제와 가장 달라 보이는 대목이었다.

- 실제 화면과 같은 규칙 — 붙여넣기 막힘 · 글자 수 · 짧은 답변 경고(15자)
- 친 답이 그대로 말풍선에 들어간다. **비워 두면 그 자리의 준비된 답변**이 쓰인다 — 시연자가 매번 타이핑할 수는 없으므로 기본은 그쪽이다
- 제출 버튼은 두지 않는다. 데모에서는 **점수 버튼이 곧 제출**이라 버튼이 둘일 수 없다

## 리뷰 포인트

**🔴 길이로 점수를 「추천」하는 것은 목업 편의다.**

실제 제품은 길이로 채점하지 않는다 — `12-scoring-rules.md`가 *"장황함 편향은 길이 페널티"* 라고 못박고, 실측에서도 3~5문장이면 판정에 충분했다. 그런데 타이핑을 했는데 아무 일도 안 일어나면 입력칸이 장식이 되므로, 길이에 따라 점수 한 칸을 **추천으로 표시만** 한다. 누르는 것은 여전히 시연자다.

그 사실을 **화면에도 적었다** — *"「추천」은 목업이라 글자 수로 고른 것 — 실제 채점은 길이를 보지 않습니다"*. 시연에 개발자가 오므로 화면이 스스로 밝히지 않으면 오해가 남는다. 코드 주석에도 같은 경고를 남겼다.

**실제 `ComposeBar`를 재사용하지 않은 이유**는 그 안에 「답변 제출」 버튼이 있어서다. 좋은 부분(붙여넣기 막힘·글자 수·짧은 답변 경고)만 가져왔다.

## 확인

- [x] 로컬에서 동작 확인
- [x] 하나의 PR = 하나의 기능

브라우저로 확인했다 — 0자/3자/64자/258자에서 추천이 없음/0점/2점/4점으로 오르고, 친 답이 말풍선에 그대로 들어가며, 제출 후 입력칸이 비워진다. 데모 엔진 검사 37/37(2개 추가). `npm run typecheck` · `npm run lint` · `npm run build` 통과.

closes #351
